### PR TITLE
Do not track Java package files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ properties.zip
 variables.test
 *.class
 *.iml
+*.jar
+*.war


### PR DESCRIPTION
For `ant war` and `ant jar`.