### PR TITLE
Fix documentation for Util.isWhiteSpace

### DIFF
--- a/org/w3c/css/util/Util.java
+++ b/org/w3c/css/util/Util.java
@@ -260,7 +260,7 @@ public final class Util {
 	}
 
 	/**
-	 * Returns <code>true</code> if the character is not a white space
+	 * Returns <code>true</code> if the character is a whitespace character
 	 *
 	 * @param c the character
 	 */


### PR DESCRIPTION
`Util.isWhiteSpace` returns `true` if the character **is** whitespace. The current documentation of `Util.isWhiteSpace` doesn't match its implementation.