### PR TITLE
Add CORS headers for scripted cross-origin access

### DIFF
--- a/org/w3c/css/servlet/CssValidator.java
+++ b/org/w3c/css/servlet/CssValidator.java
@@ -851,6 +851,10 @@ public final class CssValidator extends HttpServlet {
 			res.setHeader("charset", Utf8Properties.ENCODING);
 		}
 		res.setHeader("Vary", "Accept-Language");
+		res.setHeader("Access-Control-Allow-Origin", "*");
+		res.setHeader("Access-Control-Allow-Headers", "content-type,accept-charset");
+		res.setHeader("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS");
+		res.setHeader("Access-Control-Max-Age", "600");
 	}
 
 	private void handleError(HttpServletResponse res, ApplContext ac,


### PR DESCRIPTION
To enable scripted access to the CSS validator from frontend JavaScript code
running in a browser, this change makes the CSS validator send back the
necessary Access-Control-Allow-Origin, Access-Control-Allow-Headers,
Access-Control-Allow-Methods, and Access-Control-Max-Age response headers.

See https://stackoverflow.com/q/46855633/441757