### PR TITLE
Make css-validator.jar include all dependencies

### DIFF
--- a/DOWNLOAD.html.en
+++ b/DOWNLOAD.html.en
@@ -102,7 +102,6 @@ http://localhost:8001/css-validator/validator.html</li>
 Download the css-validator.jar jar archive (or build it with <kbd>ant jar</kbd>) and run it as :<br />
 <kbd>java -jar css-validator.jar http://www.w3.org/</kbd>.
 </p>
-<p>Note : the css-validator.jar file must be located at the exact same level as the lib/ folder to work properly.</p>
 </div>
    <ul class="navbar"  id="menu">
 	<li><strong><a href="./" title="Home page for the W3C CSS Validation Service">Home</a></strong> <span class="hideme">|</span></li>

--- a/build.xml
+++ b/build.xml
@@ -118,6 +118,7 @@
   <target name="jar" depends="build" description="Creates the lib archive">
     <delete file="${jar.file}"/>
     <jar jarfile="${jar.file}" basedir="build" excludes="org/**/*.java">
+      <zipgroupfileset dir="lib" includes="*.jar"/>
       <include name="org/**"/>
       <manifest>
         <attribute name="Main-Class" value="org.w3c.css.css.CssValidator"/>


### PR DESCRIPTION
This change makes the built css-validator.jar file also include all dependency
jars from the lib/ subdirectory. That makes it possible to actually run the jar
file with just `java -jar css-validator.jar ...`, without any other jars needing
to be present in the local environment.

Fixes https://github.com/w3c/css-validator/issues/45