### PR TITLE
Handle all CssVersion cases in AtRuleMedia

### DIFF
--- a/org/w3c/css/media/AtRuleMedia.java
+++ b/org/w3c/css/media/AtRuleMedia.java
@@ -96,9 +96,14 @@ public abstract class AtRuleMedia extends AtRule {
             case CSS21:
                 return new org.w3c.css.media.css21.AtRuleMedia();
             case CSS3:
+            case CSS:
+            case CSS_2015:
                 return new org.w3c.css.media.css3.AtRuleMedia();
+            default:
+                throw new IllegalArgumentException(
+                    "AtRuleMedia.getInstance called with unhandled"
+                        + " CssVersion \"" + version.toString() + "\".");
         }
-        return null;
     }
 }
 


### PR DESCRIPTION
This change makes `org.w3c.css.media.AtRuleMedia.getInstance` handle all current
`CssVersion` cases, and to throw for unrecognized cases.

Previously, calling `org.w3c.css.media.AtRuleMedia.getInstance` with an unhandled
`CssVersion` value caused it to return `null` instead of an expected `AtRuleMedia`
instance — which in turn caused a `NullPointerException` to get thrown in
`org.w3c.css.parser.analyzer.CssParser.mediaquery`, which tries to call
`org.w3c.css.media.AtRuleMedia.addMedia` on the expected `AtRuleMedia` instance.