### PR TITLE
Prevent NPE in org.w3c.css.media.css3.MediaWidth

### DIFF
--- a/org/w3c/css/media/css3/MediaWidth.java
+++ b/org/w3c/css/media/css3/MediaWidth.java
@@ -42,6 +42,10 @@ public class MediaWidth extends MediaFeature {
 
             CssValue val = expression.getValue();
 
+            if (val == null) {
+                return;
+            }
+
             switch (val.getType()) {
                 case CssTypes.CSS_NUMBER:
                     // a bit stupid as the only value would be 0...


### PR DESCRIPTION
This change prevents a NullPointerException that could otherwise occur in
org.w3c.css.media.css3.MediaWidth due do that code not doing a null check and
handling the result of that in a place where it should.

---

Before this change, code in org.w3c.css.media.css3.MediaWidth always called
.getType() from the result of a CssExpression instance’s .getValue() call
without first checking to see if the .getValue() call actually returned a
CssValue. But a CssExpression instance’s .getValue() method can by design return
null rather than a CssValue. So calling .getType() from the result of a
CssExpression instance’s .getValue() call could fail with an NPE.

This change causes the MediaWidth code to instead do an early return if the
.getValue() call comes back null. That appears to be the right thing to do,
since the code intentionally sends the null value in certain cases, and it
doesn’t seem to indicate any error has occurred.