### PR TITLE
Put literals in messages in curly quotes/monospace

### DIFF
--- a/org/w3c/css/css/StyleSheetGenerator.java
+++ b/org/w3c/css/css/StyleSheetGenerator.java
@@ -297,6 +297,7 @@ public class StyleSheetGenerator extends StyleReport {
 						produceParseException((CssParseException) ex, h);
 					} else if (ex instanceof InvalidParamException) {
 						h.put("ClassName", "invalidparam");
+						h.put("ErrorMsg", queryReplace((String) h.get("ErrorMsg")));
 					} else if (ex instanceof IOException) {
 						String stringError = ex.toString();
 						// int index = stringError.indexOf(':');
@@ -477,8 +478,10 @@ public class StyleSheetGenerator extends StyleReport {
 	 * @return the string s with html character escaped
 	 */
 	private String queryReplace(String s) {
+		if (!"xhtml.properties".equals(this.template_file)) {
+			return s;
+		}
 		if (s != null) {
-			/*
 			int len = s.length();
             StringBuilder ret = new StringBuilder(len + 16);
             char c;
@@ -500,13 +503,17 @@ public class StyleSheetGenerator extends StyleReport {
                     case '>':
                         ret.append("&gt;");
                         break;
+                    case '\u201C':
+                        ret.append("<code>");
+                        break;
+                    case '\u201D':
+                        ret.append("</code>");
+                        break;
                     default:
                         ret.append(c);
                 }
             }
             return ret.toString();
-            */
-			return s;
 		}
 		return "[empty string]";
 	}

--- a/org/w3c/css/css/xhtml.properties
+++ b/org/w3c/css/css/xhtml.properties
@@ -7,7 +7,7 @@
       <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="ROBOTS" content="NOINDEX, NOFOLLOW" />
 #if ( !$css ) #set ( $css = $cssversion ) #end
-        <title>$W3C_validator_results $esc.html($file_title) ($css)</title>
+        <title>$W3C_validator_results $file_title ($css)</title>
         <link href="http://jigsaw.w3.org/css-validator/" rel="validator" />
         <link type="text/css" rel="stylesheet" href="style/base.css" />
         <link type="text/css" rel="stylesheet" href="style/results.css" />
@@ -19,7 +19,7 @@
        <a href="./"><span>$W3C_CSS_validation_service</span></a></h1>
 
        <p id="tagline">
-         $W3C_validator_results $esc.html($file_title) ($css)
+         $W3C_validator_results $file_title ($css)
        </p>
       </div>
 
@@ -39,9 +39,9 @@
 #end
 <div id="results_container">
 #if ($file_title.trim().startsWith("http://"))
-   <h2>$W3C_validator_results <a href="$esc.html($file_title)">$esc.html($file_title)</a> ($css)</h2>
+   <h2>$W3C_validator_results <a href="$file_title">$file_title</a> ($css)</h2>
 #else
-   <h2>$W3C_validator_results $esc.html($file_title) ($css)</h2>
+   <h2>$W3C_validator_results $file_title ($css)</h2>
 #end
 #if ( !$no_errors_report )
     #if ($errors_count == 0)
@@ -149,7 +149,7 @@ http://jigsaw.w3.org/css-validator/check/referer ($no_errors_forHTML_only_msg)
                     <!--end of individual error section-->
                     </div>
                 #end
-                #set ( $sf = $esc.html($err.SourceFile) )
+                #set ( $sf = $err.SourceFile )
                 <div class="error-section">
 		#if ( $fake_input ) 
                     <h4>URI : $file_title</h4>
@@ -161,17 +161,17 @@ http://jigsaw.w3.org/css-validator/check/referer ($no_errors_forHTML_only_msg)
             #end
                         <tr class="error">
                             <td class="linenumber" title="Line $err.Line">$err.Line</td>
-                            <td class="$context_name">#if ( $context_msg ) $esc.html($context_msg) #end</td>
+                            <td class="$context_name">#if ( $context_msg ) $context_msg #end</td>
                             <td class="$class_name">
             #if ( $link_value )
                 #set ( $link_name = $error_content.get("link_name_parse_error") )
-                    $before_link : #if ( $cssversion == "css21" || $cssversion == "css2" )<a href="$esc.html($link_value)">$esc.html($link_name)</a> #else $esc.html($link_name) #end
+                    $before_link : #if ( $cssversion == "css21" || $cssversion == "css2" )<a href="$link_value">$link_name</a> #else $link_name #end
             #end
-                                $esc.html($error_msg)
+                                $error_msg
             #if ( $span_value )
                 #set ( $span_class = $error_content.get("span_class_parse_error") )
                                 <span class="$span_class">
-                                    $esc.html($span_value)
+                                    $span_value
                                 </span>
             #end
                             </td>
@@ -204,7 +204,7 @@ http://jigsaw.w3.org/css-validator/check/referer ($no_errors_forHTML_only_msg)
                     <!--end of individual warning section-->
                     </div>
             #end
-            #set ( $sf = $esc.html($warning.SourceFile) )
+            #set ( $sf = $warning.SourceFile )
                 <div class="warning-section">
 		#if ( $fake_input ) 
                     <h4>URI : $file_title</h4>
@@ -217,8 +217,8 @@ http://jigsaw.w3.org/css-validator/check/referer ($no_errors_forHTML_only_msg)
         #if ( $warning.Level <= $warning_level )
                         <tr class="warning">
                             <td class="linenumber" title="Line $warning.Line">$warning.Line</td>
-                            <td class="codeContext">#if ( $warning.Context ) $esc.html($warning.Context) #end</td>
-                            <td class="level$warning.Level" title="warning level $warning.Level">$esc.html($warning.WarningMessage)</td>
+                            <td class="codeContext">#if ( $warning.Context ) $warning.Context #end</td>
+                            <td class="level$warning.Level" title="warning level $warning.Level">$Messages.replaceCurlyQuotesWithHtmlCodeTags($warning.WarningMessage)</td>
                         </tr>
         #end
     #end
@@ -242,11 +242,11 @@ http://jigsaw.w3.org/css-validator/check/referer ($no_errors_forHTML_only_msg)
     #foreach ( $rules in $at_rules_list )
         #if ( $rules.AtRule != "" )
 	    #if ( $rules.Empty )
-                <div class="vEmptyAtRule">$esc.html($rules.AtRule)
+                <div class="vEmptyAtRule">$rules.AtRule
 	    #else   
                 <div class="atRule">
                     <span class="atSelector">
-                        $esc.html($rules.AtRule)
+                        $rules.AtRule
                     </span>
                     {
             #end
@@ -256,15 +256,15 @@ http://jigsaw.w3.org/css-validator/check/referer ($no_errors_forHTML_only_msg)
                         <div class="selector">
                             #if ( $rule.Selectors )
                             <span class="selectorValue">
-                                $esc.html($rule.Selectors)
+                                $rule.Selectors
                             </span>
                             {
                             #end
                             <div class="RuleList">
             #foreach ( $property in $rule.Properties )
                                 <div class="Rule">
-                                    <span class="Property">$esc.html($property.PropertyName)</span> :
-                                    <span class="PropertyValue">$esc.html($property)</span>#if ( $property.Important ) !important #end;
+                                    <span class="Property">$property.PropertyName</span> :
+                                    <span class="PropertyValue">$property</span>#if ( $property.Important ) !important #end;
                                 </div>
             #end
                             </div>

--- a/org/w3c/css/util/Messages.java
+++ b/org/w3c/css/util/Messages.java
@@ -188,6 +188,31 @@ public class Messages {
 		return "[empty string]";
 	}
 
+	/**
+	 * Replace curly quotes with HTML code tags
+	 */
+	static public String replaceCurlyQuotesWithHtmlCodeTags(String orig) {
+		if (orig != null) {
+			int len = orig.length();
+			StringBuilder ret = new StringBuilder(len + 16);
+			char c;
+			for (int i = 0; i < len; i++) {
+				switch (c = orig.charAt(i)) {
+					case '\u201C':
+						ret.append("<code>");
+						break;
+					case '\u201D':
+						ret.append("</code>");
+						break;
+					default:
+						ret.append(c);
+				}
+			}
+			return ret.toString();
+		}
+		return "[empty string]";
+	}
+
 	public String getString(String message, ArrayList<String> params) {
 		if ((params == null) || params.size() == 0) {
 			return getString(message);

--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -133,33 +133,33 @@ output-encoding-name: utf-8
 # You can change the level warning like this (example) :
 # warning.redefinition.level: 5
 #  level is an integer between 0 and 9 (all others values are ignored)
-warning.redefinition: Redefinition of %s
+warning.redefinition: Redefinition of \u201C%s\u201D
 
 # used by xml parser 
 warning.style-inside-comment: Do not put style rules inside HTML comments as they may be removed by user agent
-warning.link-type: You should add a 'type' attribute with a value of 'text/css' to the 'link' element
+warning.link-type: You should add a \u201Ctype\u201D attribute with a value of \u201Ctext/css\u201D to the \u201Clink\u201D element
 
 # used by org.w3c.css.properties.Css1Style
-warning.same-colors: Same color for %s and %s
+warning.same-colors: Same color for \u201C%s\u201D and \u201C%s\u201D
 warning.no-color: You have no color set (or color is set to transparent) but you have set a background-color. Make sure that cascading of colors keeps the text reasonably legible.
 warning.no-background-color: You have no background-color set (or background-color is set to transparent) but you have set a color. Make sure that cascading of colors keeps the text reasonably legible.
 #warning.color.mixed-capitalization is now obsolete
 #warning.color.mixed-capitalization: Although color names are case-insensitive, it is recommended to use the mixed capitalization, to make the names more legible: %s
-warning.no-generic-family: %s: You are encouraged to offer a generic family as a last alternative
+warning.no-generic-family: \u201C%s\u201D: You are encouraged to offer a generic family as a last alternative
 warning.with-space: Family names containing whitespace should be quoted. If quoting is omitted, any whitespace \
 characters before and after the name are ignored and any sequence of whitespace characters inside the \
 name is converted to a single space. 
 warning.no-padding: You are encouraged to have a padding area with a background color
-warning.same-colors2: Same colors for color and background-color in two contexts %s and %s
-warning.relative-absolute: You have some absolute and relative lengths in %s. This is not a robust style sheet.
+warning.same-colors2: Same colors for color and background-color in two contexts \u201C%s\u201D and \u201C%s\u201D
+warning.relative-absolute: You have some absolute and relative lengths in \u202C%s\u201D. This is not a robust style sheet.
 # used by org.w3c.css.properties.CssSelectors
-warning.unknown-html: %s is not an HTML Element
+warning.unknown-html: \u201C%s\u201D is not an HTML Element
 warning.html-inside: HTML element can't be inside another element
 warning.body-inside: BODY element can't be inside another element except HTML
-warning.pseudo-classes: Anchor pseudo-class %s have no effect on elements other than 'A'
+warning.pseudo-classes: Anchor pseudo-class \u201C%s\u201D have no effect on elements other than \u201CA'
 
 # not used by org.w3c.css.properties.CssSelectors for the moment
-warning.noinside: %s can't be inside an inline element
+warning.noinside: \u201C%s\u201D can't be inside an inline element
 warning.withblock: Be careful. Pseudo-elements can only be attached to a block-level element
 warning.block-level: This property applies to block-level elements.
 
@@ -170,57 +170,57 @@ warning.no-declaration: No declarations in the rule
 warning.unsupported-import: Imported style sheets are not checked in direct input and file upload modes
 
 # used by org.w3c.css.values.CssColor
-warning.out-of-range: %s is out of range
+warning.out-of-range: \u201C%s\u201D is out of range
 error.invalid-color: Invalid RGB function
 
 # used for clipping negative values
-warning.negative: negative value %s will be interpreted as 0
-warning.lowerequal: value %s will be interpreted as %s
-warning.greaterequal: value %s will be interpreted as %s
-warning.noexproperty: Property %s does not exist
+warning.negative: negative value \u201C%s\u201D will be interpreted as \u201C0\u201D
+warning.lowerequal: value \u201C%s\u201D will be interpreted as \u201C%s\u201D
+warning.greaterequal: value \u201C%s\u201D will be interpreted as \u201C%s\u201D
+warning.noexproperty: Property \u201C%s\u201D does not exist
 
-warning.marker: The marker-offset property applies on elements with 'display: marker'
+warning.marker: The \u201Cmarker-offset\u201D property applies on elements with \u201Cdisplay: marker\u201D
 
 # used by org.w3c.css.properties.ACssStyle
-warning.relative: Using relative units gives more robust stylesheets in property %s
+warning.relative: Using relative units gives more robust stylesheets in property \u201C%s\u201D
 
 # used by org.w3c.css.css.StyleSheetParser and org.w3c.css.css.StyleSheetXMLParser
-error.at-rule: Unrecognized at-rule %s
-warning.at-rule: Unrecognized at-rule %s
+error.at-rule: Unrecognized at-rule \u201C%s\u201D
+warning.at-rule: Unrecognized at-rule \u201C%s\u201D
 
 # used by all properties and values
-error.operator: %s is an incorrect operator
-error.negative-value: %s negative values are not allowed
-error.few-value: too few values for the property %s
+error.operator: \u201C%s\u201D is an incorrect operator
+error.negative-value: \u201C%s\u201D negative values are not allowed
+error.few-value: too few values for the property \u201C%s\u201D
 
 # be careful here, values comes first
 # You can't write something like this : For the color, blue is an incorrect value
-error.value: %s is not a %s value
+error.value: \u201C%s\u201D is not a \u201C%s\u201D value
 
 #used by org.w3c.css.properties3.CssToggleGroup
-error.groupname: %s is not a correct groupname. Use a valid identifier
+error.groupname: \u201C%s\u201D is not a correct groupname. Use a valid identifier
 
 #used by org.w3c.css.properties3.CssGroupReset
-error.nogroup: %s has not been set by the toggle-group property
+error.nogroup: \u201C%s\u201D has not been set by the \u201Ctoggle-group\u201D property
 
 #used by org.w3c.css.properties3.CssGlyphOrVert
-error.anglevalue: Value must be between -360 and 360 and be divisable by 90
+error.anglevalue: Value must be between \u201C-360\u201D and \u201C360\u201D and be divisable by \u201C90\u201D
 
 #used by org.w3c.css.properties3.CssTextKashidaSpace
 error.percentage: percentage value expected
 
 #used by org.w3c.css.properties.CssTextAlign
-warning.xsl: value %s only applies to XSL
+warning.xsl: value \u201C%s\u201D only applies to XSL
 
 #used by org.w3c.css.parser.analyzer.CssParser
-warning.medialist: medialist should start with 'media :' %s
-error.nocomb: Combinator %s between selectors is not allowed in this profile or version
+warning.medialist: medialist should start with \u201Cmedia:\u201D \u201C%s\u201D
+error.nocomb: Combinator \u201C%s\u201D between selectors is not allowed in this profile or version
 
 #used by org.w3c.css.properties.CssDirection
-warning.direction: instead of using 'direction' for block-level elements use the new CSS3 'writing-mode' property
+warning.direction: instead of using \u201Cdirection\u201D for block-level elements use the new CSS3 \u201Cwriting-mode\u201D property
 
 # used by org.w3c.css.properties.CssTextDecoration
-error.same-value: %s appears twice
+error.same-value: \u201C%s\u201D appears twice
 
 error.generic-family.quote: Generic family names are keywords, and therefore must not be quoted.
 
@@ -240,16 +240,16 @@ error.format: Invalid format definition format(<string>[,<string>]*)
 error.local: Invalid format definition local(<string>|<ident>+)
 
 # used by org.w3c.css.values.CssAngle, org.w3c.css.values.CssFrequency, org.w3c.css.values.CssTime, org.w3c.css.values.CssLength
-error.unit: %s is an incorrect unit
+error.unit: \u201C%s\u201D is an incorrect unit
 
 # used by org.w3c.css.aural.ACssAzimuth
 error.degree: Position must be described in terms of degrees.
 
 # used by org.w3c.css.aural.ACssElevation
-error.elevation.range: Specifies the elevation as an angle, between '-90deg' and '90deg'.
+error.elevation.range: Specifies the elevation as an angle, between \u201C-90deg\u201D and \u201C90deg'.
 
 # used by org.w3c.css.aural.ACssPitchRange
-error.range: The value is out of range.This value must be between '0' and '100'.
+error.range: The value is out of range.This value must be between \u201C0\u201D and \u201C100'.
 
 # used by org.w3c.css.properties.CssTextShadow
 error.two-lengths: A shadow offset is specified with two <length> values (A blur radius may optionally be specified after the shadow offset.)
@@ -258,54 +258,54 @@ error.integer: This number should be an integer.
 error.comma: Missing comma separator.
 
 # used by org.w3c.css.values.CssPercentage
-error.percent: %s is an incorrect percentage
+error.percent: \u201C%s\u201D is an incorrect percentage
 
 # used by org.w3c.css.values.CssString
-error.string: %s is an incorrect string
+error.string: \u201C%s\u201D is an incorrect string
 
 # used by org.w3c.css.values.CssURL
-error.url: %s is an incorrect URL
+error.url: \u201C%s\u201D is an incorrect URL
 
 # used by org.w3c.css.values.CssColor
-error.rgb: %s is not a valid color 3 or 6 hexadecimals numbers
-error.angle: %s is not a valid angle. Value should be between 0 and 360
+error.rgb: \u201C%s\u201D is not a valid color 3 or 6 hexadecimals numbers
+error.angle: \u201C%s\u201D is not a valid angle. Value should be between \u201C0\u201D and \u201C360\u201D
 
 # used by org.w3c.css.values.CssNumber
-error.zero: only 0 can be a %s. You must put a unit after your number
-warning.zero:  only 0 can be a %s. You must put a unit after your number
+error.zero: only \u201C0\u201D can be a \u201C%s\u201D. You must put a unit after your number
+warning.zero:  only \u201C0\u201D can be a \u201C%s\u201D. You must put a unit after your number
 warning.dynamic: dynamic values cannot be checked as an unitless number. Please qualify it with an unit.
 
 #used by org.w3c.css.properties.CssColumnCount
-error.strictly-positive: %s is not valid, only values greater than 0 allowed.
+error.strictly-positive: \u201C%s\u201D is not valid, only values greater than /u201C0/u201D allowed.
 
-error.greaterequal: %s is not valid, only values greater than or equal to %s are allowed.
-error.lowerequal: %s is not valid, only values lower than or equal to %s are allowed.
-error.lower: %s is not valid, only values strictly lower than %s are allowed.
+error.greaterequal: \u201C%s\u201D is not valid, only values greater than or equal to \u201C%s\u201D are allowed.
+error.lowerequal: \u201C%s\u201D is not valid, only values lower than or equal to \u201C%s\u201D are allowed.
+error.lower: \u201C%s\u201D is not valid, only values strictly lower than \u201C%s\u201D are allowed.
 
-error.greaterequal: %s is not valid, only values greater than or equal to %s are allowed.
-error.greater: %s is not valid, only values strictly greater than %s are allowed.
+error.greaterequal: \u201C%s\u201D is not valid, only values greater than or equal to \u201C%s\u201D are allowed.
+error.greater: \u201C%s\u201D is not valid, only values strictly greater than \u201C%s\u201D are allowed.
 
 # used by org.w3c.css.parser.CssPropertyFactory
-error.noexistence-at-all: Property %s doesn't exist
-error.noexistence-media: Feature %s doesn't exist for media %s
-error.noexistence: Property %s doesn't exist in %s but exists in %s
-warning.noexistence: Property %s doesn't exist in %s but exists in %s
-warning.noexistence-media: Property %s doesn't exist for media %s
-warning.notforusermedium : Property %s doesn't exist for this usermedium
+error.noexistence-at-all: Property \u201C%s\u201D doesn't exist
+error.noexistence-media: Feature \u201C%s\u201D doesn't exist for media \u201C%s\u201D
+error.noexistence: Property \u201C%s\u201D doesn't exist in \u201C%s\u201D but exists in \u201C%s\u201D
+warning.noexistence: Property \u201C%s\u201D doesn't exist in \u201C%s\u201D but exists in \u201C%s\u201D
+warning.noexistence-media: Property \u201C%s\u201D doesn't exist for media \u201C%s\u201D
+warning.notforusermedium : Property \u201C%s\u201D doesn't exist for this usermedium
 warning.noothermedium : Properties for other media might not work for usermedium
-warning.vendor-extension : Property %s is an unknown vendor extension
-warning.vendor-ext-pseudo-class : %s is an unknown vendor extended pseudo-class
-warning.vendor-ext-pseudo-element : %s is an unknown vendor extended pseudo-element
+warning.vendor-extension : Property \u201C%s\u201D is an unknown vendor extension
+warning.vendor-ext-pseudo-class : \u201C%s\u201D is an unknown vendor extended pseudo-class
+warning.vendor-ext-pseudo-element : \u201C%s\u201D is an unknown vendor extended pseudo-element
 # used by org.w3c.css.parser.AtRule*
-error.noatruleyet: Other @rules than @import are not supported by CSS1 %s
+error.noatruleyet: Other @rules than @import are not supported by CSS1 \u201C%s\u201D
 # used by org.w3c.css.parser.analyzer.CssParser
-error.notforcss1: Value %s does not exist for CSS1
-warning.pseudo: Unknown pseudo-element or pseudo-class %s in the default profile (%s)
-warning.nocomb: Combinator %s between selectors is not allowed in this profile (%s)
+error.notforcss1: Value \u201C%s\u201D does not exist for CSS1
+warning.pseudo: Unknown pseudo-element or pseudo-class \u201C%s\u201D in the default profile (\u201C%s\u201D)
+warning.nocomb: Combinator \u201C%s\u201D between selectors is not allowed in this profile (\u201C%s\u201D)
 warning.charsetspecial: This profile has a very specific syntax for @charset: \
 @charset followed by exactly one space, followed by the name of the encoding \
 in quotes, followed immediately by a semicolon.
-warning.notversion: %s can not be used with this version of CSS : %s
+warning.notversion: \u201C%s\u201D can not be used with this version of CSS : \u201C%s\u201D
 
 # used by org.w3c.css.parser.CssFouffa
 error.unrecognize: Too many values or values are not recognized
@@ -318,21 +318,21 @@ generator.dontmixhtml: Parse Error. Style sheets should not include HTML syntax.
 error.unknown: Unknown error
 
 # used by org.w3c.css.parser.CssSelectors
-error.pseudo-element: The pseudo-element %s can't appear here in the context %s
-error.pseudo-class: The pseudo-class .%s can't appear here in the HTML context %s
-error.pseudo: Unknown pseudo-element or pseudo-class %s
+error.pseudo-element: The pseudo-element \u201C%s\u201D can't appear here in the context \u201C%s\u201D
+error.pseudo-class: The pseudo-class .\u201C%s\u201D can't appear here in the HTML context \u201C%s\u201D
+error.pseudo: Unknown pseudo-element or pseudo-class \u201C%s\u201D
 error.id: ID selector #%s is invalid ! Only one ID selector can be specified in a simple selector: %s.
-error.space: If the attribute selector ~= is used, the word in the value %s must not contain spaces.
-error.todo : Sorry the feature %s is not implemented yet.
-error.incompatible: %s and %s are incompatible
-warning.incompatible: %s and %s are incompatible
-error.notformobile: %s can not be used with mobile profile
-error.notforatsc: %s can not be used with ATSC profile
-error.notfortv: %s can not be used with TV profile
-error.notversion: %s can not be used with this version of CSS : %s
+error.space: If the attribute selector ~= is used, the word in the value \u201C%s\u201D must not contain spaces.
+error.todo : Sorry the feature \u201C%s\u201D is not implemented yet.
+error.incompatible: \u201C%s\u201D and \u201C%s\u201D are incompatible
+warning.incompatible: \u201C%s\u201D and \u201C%s\u201D are incompatible
+error.notformobile: \u201C%s\u201D can not be used with mobile profile
+error.notforatsc: \u201C%s\u201D can not be used with ATSC profile
+error.notfortv: \u201C%s\u201D can not be used with TV profile
+error.notversion: \u201C%s\u201D can not be used with this version of CSS : \u201C%s\u201D
 
-error.media: unrecognized media %s 
-error.page: unrecognized pseudo named page %s
+error.media: unrecognized media \u201C%s\u201D
+error.page: unrecognized pseudo named page \u201C%s\u201D
 
 error.unrecognized.link: Unrecognized link element or xml-stylesheet PI.
 
@@ -351,14 +351,14 @@ generator.doc:  <!-- removed this confusing message olivier 2006-12-14 -->
 
 
 # used by the parser
-parser.semi-colon: Missing a semicolon before the property name %s
+parser.semi-colon: Missing a semicolon before the property name \u201C%s\u201D
 
 parser.unknown-dimension: Unknown dimension
 
 parser.old_class: In CSS1, a class name could start with a digit (".55ft"), \
 unless it was a dimension (".55in"). In CSS2, such classes are parsed as \
 unknown dimensions (to allow for future additions of new units) \
-To make "%s" a valid class, CSS2 requires the first digit to be escaped "%s"
+To make \u201C%s\u201D a valid class, CSS2 requires the first digit to be escaped: \u201C%s\u201D
 
 parser.old_id: In CSS1, an id name could start with a digit ("#55ft"), \
 unless it was a dimension ("#55in"). In CSS2, such ids are parsed as \
@@ -389,12 +389,12 @@ unknown dimensions (to allow for future additions of new units).
 servlet.invalid-request: You have sent an invalid request.
 servlet.process: Can't process the object
 
-warning.atsc: %s might not be supported by the medium atsc-tv
-error.onlyATSC: %s this function is only for the atsc-tv medium
+warning.atsc: \u201C%s\u201D might not be supported by the medium atsc-tv
+error.onlyATSC: \u201C%s\u201D this function is only for the atsc-tv medium
 
-warning.otherprofile: property %s does not exist for this profile, but is validated conforming to another profile
-warning.deprecated: The value '%s' is deprecated
-warning.deprecatedproperty: The property '%s' is deprecated
+warning.otherprofile: property \u201C%s\u201D does not exist for this profile, but is validated conforming to another profile
+warning.deprecated: The value \u201C%s\u201D is deprecated
+warning.deprecatedproperty: The property \u201C%s\u201D is deprecated
 
 warning.float-no-width: In (x)HTML+CSS, floated elements need to have a width declared. Only elements with an intrinsic width (html, img, input, textarea, select, or object) are not affected
 
@@ -404,25 +404,25 @@ parser.attrcss1: Attribute selectors are invalid in CSS1
 parser.invalid_id_selector: Invalid ID selector
 parser.import_not_allowed: @import are not allowed after any valid statement other than @charset and @import.
 
-error.bg_order: In the CSS3 background definition, 'bg_position' must occur before / 'bg_size' if both are present
+error.bg_order: In the CSS3 background definition, \u201Cbg_position\u201D must occur before / \u201Cbg_size\u201D if both are present
 
-warning.deprecatedmedia: The media "%s" has been deprecated
+warning.deprecatedmedia: The media \u201C%s\u201D has been deprecated
 error.nomediarestrictor: Mediarestrictor not defined in this CSS level
 error.nomediafeature: Media features are not defined in this CSS level
 error.nomodifiershortmedia: No prefixes are allowed for media features with no value
-error.nomodifiermedia: The media feature %s does not support prefixes
-error.grid: Only 0 and 1 are acceptable values for grid
+error.nomodifiermedia: The media feature \u201C%s\u201D does not support prefixes
+error.grid: Only /u201C0/u201D and /u201C1/u201D are acceptable values for grid
 
-error.errortoken: Unexpected content "%s" at line %s, expecting on token of %s (skipped %s)
-error.selectorname: Invalid selector name %s
+error.errortoken: Unexpected content \u201C%s\u201D at line \u201C%s\u201D, expecting on token of \u201C%s\u201D (skipped \u201C%s\u201D)
+error.selectorname: Invalid selector name \u201C%s\u201D
 
 # calc
 
-parser.calcwhitespace: Whitespace is required on both sides of the '+' or '-' operators
+parser.calcwhitespace: Whitespace is required on both sides of the \u201C+\u201D or \u201C-\u201D operators
 error.divzero: Division by zero
 error.operandnumber: One operand must be a number
 error.divisortype: The divisor must be a number
 error.incompatibletypes: The types are incompatible
-error.invalidtype: Invalid type: %s
-error.typevaluemismatch: The value %s is incompatible with its type definition <%s>
+error.invalidtype: Invalid type: \u201C%s\u201D
+error.typevaluemismatch: The value \u201C%s\u201D is incompatible with its type definition <\u201C%s\u201D>
 

--- a/style/results.css
+++ b/style/results.css
@@ -255,3 +255,14 @@ p.backtop a:link, p.backtop a:hover, p.backtop a:visited {
         text-decoration: none;
 }
 
+.error code, .warning code,
+.unrecognized, .exp, .skippedString, .codeContext {
+        border: 1px dashed #999;
+        padding: 2px;
+        padding-left: 4px;
+        padding-right: 4px;
+}
+
+.unrecognized, .exp, .skippedString, .codeContext {
+        font-family: monospace;
+}


### PR DESCRIPTION
This change causes curly quotation marks to be added around literals in the raw
error and warning messages (before the messages get passed to Velocity for
processing with the output-format-specific *.properties templates).

For non-"xhtml" output formats, the curly quotation marks are left as-is
(unprocessed) in the messages emitted to end users. But for the "xhtml" output
format, the curly quotation marks get changed into HTML `<code>` and `</code>`
tags, which causes their contents to get rendered in a monospace font.

Note: this change moves the HTML-escaping out of the xhtml.properties template
(`$esc.html`s added in f7766d87d) and back into the StyleSheetGenerator code
(making the existing `queryReplace()` method once again do the actual escaping).

This change also makes minor additions to the stylesheet for the CSS Validator
Web-based service, to cause other parts of the HTML output to get rendered in
monospace: the .unrecognized, .exp, .skippedString, and .codeContext classes.