### PR TITLE
Drop warning about missing style[type] attribute

### DIFF
--- a/org/w3c/css/css/HTMLParserStyleSheetHandler.java
+++ b/org/w3c/css/css/HTMLParserStyleSheetHandler.java
@@ -348,16 +348,6 @@ public class HTMLParserStyleSheetHandler implements ContentHandler, LexicalHandl
 
                 if (type == null) {
                     // By default we consider that it is CSS for HTML content
-                    // and raise a warning about the missing type attribute.
-                    // (per HTML5 spec)
-                    if (!isHTML5) {
-                        int line = (locator != null ? locator.getLineNumber() : -1);
-                        Warning w = new Warning(baseURI.toString(), line,
-                                "style-type", 0, ac);
-                        Warnings warnings = new Warnings(ac.getWarningLevel());
-                        warnings.addWarning(w);
-                        styleSheetParser.notifyWarnings(warnings);
-                    }
                     text.setLength(0);
                     inStyle = true;
                 } else {

--- a/org/w3c/css/css/TagSoupStyleSheetHandler.java
+++ b/org/w3c/css/css/TagSoupStyleSheetHandler.java
@@ -330,15 +330,6 @@ public class TagSoupStyleSheetHandler implements ContentHandler, LexicalHandler,
 
                 if (type == null) {
                     // By default we consider that it is CSS for HTML content
-                    // and raise a warning about the missing type attribute.
-                    // (per HTML5 spec)
-                    int line = (locator != null ? locator.getLineNumber() : -1);
-                    Warning w = new Warning(baseURI.toString(), line,
-                            "style-type", 0, ac);
-                    Warnings warnings = new Warnings(ac.getWarningLevel());
-                    warnings.addWarning(w);
-                    styleSheetParser.notifyWarnings(warnings);
-
                     text.setLength(0);
                     inStyle = true;
                 } else {

--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -137,7 +137,6 @@ warning.redefinition: Redefinition of %s
 
 # used by xml parser 
 warning.style-inside-comment: Do not put style rules inside HTML comments as they may be removed by user agent
-warning.style-type: You should add a 'type' attribute with a value of 'text/css' to the 'style' element
 warning.link-type: You should add a 'type' attribute with a value of 'text/css' to the 'link' element
 
 # used by org.w3c.css.properties.Css1Style


### PR DESCRIPTION
Per [current requirements in the HTML spec](https://goo.gl/rpW3h2):

> Authors should not specify a `type` attribute on a `style` element.

Addresses https://github.com/validator/validator/issues/584