### PR TITLE
Emit params to stderr, not stdout, when using CLI

### DIFF
--- a/org/w3c/css/css/CssValidator.java
+++ b/org/w3c/css/css/CssValidator.java
@@ -92,7 +92,7 @@ public class CssValidator {
         try {
             style.getParams(args);
             style.ac = new ApplContext((String) style.params.get("lang"));
-            System.out.println(style.params);
+            System.err.println(style.params);
         } catch (Exception e) {
             System.out.println("Usage: java org.w3c.css.css.CssValidator " +
                     " [OPTIONS] | [URL]*");


### PR DESCRIPTION
This change causes the parameter info for the ApplContext instance when using
the command-line interface to get dumped to stderr instead of stdout — so if you
redirect stdout to a file/pipe, you get just the actual error/warning report.

That ensures the resulting report output is syntactically-correct HTML (for
output=html), valid JSON (for output=json), etc. — without a prolog like:

```
{output=json, profile=css3, vextwarning=false, warning=2, medium=all, lang=en}
```