### PR TITLE
Make css-validator.jar CLI runnable anywhere

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -116,14 +116,13 @@
       windowtitle="W3C CSS Validator API"/>
   </target>
 
-  <target name="jar" depends="build" description="Creates the lib archive">
+  <target name="jar" depends="build" description="Creates the lib archive with all dependency jars included">
     <delete file="${jar.file}"/>
     <jar jarfile="${jar.file}" basedir="build" excludes="org/**/*.java">
       <zipgroupfileset dir="lib" includes="*.jar"/>
       <include name="org/**"/>
       <manifest>
         <attribute name="Main-Class" value="org.w3c.css.css.CssValidator"/>
-        <attribute name="Class-path" value=". lib/commons-beanutils-1.9.2.jar lib/commons-collections-3.2.1.jar lib/commons-digester-1.8.1.jar lib/commons-text-1.1.jar lib/commons-logging-1.1.1.jar lib/jigsaw-2.2.6.jar lib/tagsoup-1.2.1.jar lib/velocity-1.7.jar lib/velocity-tools-generic-2.0.jar lib/xercesImpl-2.11.0.jar lib/xml-apis-1.4.01.jar lib/htmlparser-1.4.1.jar"/>
       </manifest>
     </jar>
   </target>

--- a/org/w3c/css/css/StyleSheetGenerator.java
+++ b/org/w3c/css/css/StyleSheetGenerator.java
@@ -5,6 +5,8 @@ import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.Velocity;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import org.apache.velocity.tools.ToolManager;
 import org.w3c.css.error.ErrorReportHTML;
 import org.w3c.css.parser.CssError;
@@ -83,17 +85,10 @@ public class StyleSheetGenerator extends StyleReport {
 		}
 
 		try {
-			Velocity.setProperty(Velocity.RESOURCE_LOADER, "file");
-			Velocity.addProperty(Velocity.RESOURCE_LOADER, "jar");
-			Velocity.setProperty("jar." + Velocity.RESOURCE_LOADER + ".class",
-					"org.apache.velocity.runtime.resource.loader.JarResourceLoader");
-			URL path = StyleSheetGenerator.class.getResource("/");
-			if (path != null) {
-				Velocity.addProperty("file." + Velocity.RESOURCE_LOADER +
-						".path", path.getFile());
-				Velocity.setProperty("jar." + Velocity.RESOURCE_LOADER + ".path",
-						"jar:" + path + "css-validator.jar");
-			}
+			Velocity.setProperty(RuntimeConstants.RESOURCE_LOADER,
+				"classpath");
+			Velocity.setProperty("classpath.resource.loader.class",
+				ClasspathResourceLoader.class.getName());
 			Velocity.init();
 			velocityToolManager = new ToolManager();
 			velocityToolManager.configure("org/w3c/css/css/velocity-tools.xml");


### PR DESCRIPTION
This change makes it possible to run the css-validator.jar CLI from anywhere.

Prior to this change, the css-validator.jar CLI could be run only from within a
working directory that had the org/w3c/css/css/*.properties Velocity templates.
That’s because the code for the CLI looked for the templates on the filesystem,
or looked for a jar on the filesystem containing the templates.

This change makes the CLI code instead just look for the templates anywhere in
the classpath. And the templates are in the css-validator.jar file, so it works
regardless of whether you invoke the CLI with `java -jar css-validator.jar` or
instead with `java -cp css-validator.jar org.w3c.css.css.CssValidator`.

This change also makes the CLI stop looking for the dependency jar files on the
filesystem in a `lib/` subdirectory. In the case where you’re using the full
css-validator.jar file that contains all the dependency jars, there’s no need to
look for them on the filesystem. And in the case where you’re using the
css-validator.jar that doesn’t have the dependency jars included, you can just
call org.w3c.css.css.CssValidator with the jars in your classpath; for example:

```
java -cp ~/css-validator/lib/* org.w3c.css.css.CssValidator https://www.w3.org
```

Note that this change replaces the code added in 6b7b237 and c6cbb04 that took
the approach of looking for the templates and lib/ dir on the filesystem.