### PR TITLE
Allow the touch-action property & check it

### DIFF
--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -43,6 +43,9 @@ will-change:                            org.w3c.css.properties.css3.CssWillChang
 # contain
 contain:                                org.w3c.css.properties.css3.CssContain
 
+# touch-action
+touch-action:                           org.w3c.css.properties.css3.CssTouchAction
+
 # compositing
 background-blend-mode:                  org.w3c.css.properties.css3.CssBackgroundBlendMode
 isolation:                              org.w3c.css.properties.css3.CssIsolation

--- a/org/w3c/css/properties/CSS3SVGProperties.properties
+++ b/org/w3c/css/properties/CSS3SVGProperties.properties
@@ -85,6 +85,9 @@ will-change:                            org.w3c.css.properties.css3.CssWillChang
 # contain
 contain:                                org.w3c.css.properties.css3.CssContain
 
+# touch-action
+touch-action:                           org.w3c.css.properties.css3.CssTouchAction
+
 # compositing
 background-blend-mode:                  org.w3c.css.properties.css3.CssBackgroundBlendMode
 isolation:                              org.w3c.css.properties.css3.CssIsolation

--- a/org/w3c/css/properties/Media.properties
+++ b/org/w3c/css/properties/Media.properties
@@ -368,6 +368,7 @@ marker-start:                   handheld, print, projection, screen, tty, tv
 marker-end:                     handheld, print, projection, screen, tty, tv
 marker-mid:                     handheld, print, projection, screen, tty, tv
 lighting-color:                 handheld, print, projection, screen, tty, tv
+touch-action:                   handheld, print, projection, screen, tty, tv
 
 
 # properties not yet implemented

--- a/org/w3c/css/properties/css/CssTouchAction.java
+++ b/org/w3c/css/properties/css/CssTouchAction.java
@@ -1,0 +1,117 @@
+// 
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio and Beihang, 2017.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since DOM
+ * present in  pointerevents
+ */
+public class CssTouchAction extends CssProperty {
+
+	public CssValue value;
+
+	/**
+	 * Create a new CssTouchAction
+	 */
+	public CssTouchAction() {
+	}
+
+	/**
+	 * Creates a new CssTouchAction
+	 *
+	 * @param expression The expression for this property
+	 * @throws org.w3c.css.util.InvalidParamException
+	 *          Expressions are incorrect
+	 */
+	public CssTouchAction(ApplContext ac, CssExpression expression, boolean check)
+			throws InvalidParamException {
+		throw new InvalidParamException("value",
+				expression.getValue().toString(),
+				getPropertyName(), ac);
+	}
+
+	public CssTouchAction(ApplContext ac, CssExpression expression)
+			throws InvalidParamException {
+		this(ac, expression, false);
+	}
+
+	/**
+	 * Returns the value of this property
+	 */
+	public Object get() {
+		return value;
+	}
+
+
+	/**
+	 * Returns the name of this property
+	 */
+	public final String getPropertyName() {
+		return "touch-action";
+	}
+
+	/**
+	 * Returns true if this property is "softly" inherited
+	 * e.g. his value is equals to inherit
+	 */
+	public boolean isSoftlyInherited() {
+		return value.equals(inherit);
+	}
+
+	/**
+	 * Returns a string representation of the object.
+	 */
+	public String toString() {
+		return value.toString();
+	}
+
+	/**
+	 * Add this property to the CssStyle.
+	 *
+	 * @param style The CssStyle
+	 */
+	public void addToStyle(ApplContext ac, CssStyle style) {
+		Css3Style s = (Css3Style) style;
+		if (s.cssTouchAction != null) {
+			style.addRedefinitionWarning(ac, this);
+		}
+		s.cssTouchAction = this;
+	}
+
+
+	/**
+	 * Compares two properties for equality.
+	 *
+	 * @param property The other property.
+	 */
+	public boolean equals(CssProperty property) {
+		return (property instanceof CssTouchAction &&
+				value.equals(((CssTouchAction) property).value));
+	}
+
+
+	/**
+	 * Get this property in the style.
+	 *
+	 * @param style   The style where the property is
+	 * @param resolve if true, resolve the style to find this property
+	 */
+	public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+		if (resolve) {
+			return ((Css3Style) style).getTouchAction();
+		} else {
+			return ((Css3Style) style).cssTouchAction;
+		}
+	}
+}
+

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -171,6 +171,7 @@ import org.w3c.css.properties.css.CssTextEmphasisStyle;
 import org.w3c.css.properties.css.CssTextJustify;
 import org.w3c.css.properties.css.CssTextOverflow;
 import org.w3c.css.properties.css.CssTextUnderlinePosition;
+import org.w3c.css.properties.css.CssTouchAction;
 import org.w3c.css.properties.css.CssTransform;
 import org.w3c.css.properties.css.CssTransformOrigin;
 import org.w3c.css.properties.css.CssTransformStyle;
@@ -217,6 +218,7 @@ public class Css3Style extends ATSCStyle {
 	public CssNegative counterStyleCssNegative;
 
 	public CssWritingMode cssWritingMode;
+    public CssTouchAction cssTouchAction;
 
 	public CssScrollSnapMarginBlockStart cssScrollSnapMarginBlockStart;
 	public CssScrollSnapMarginBlockEnd cssScrollSnapMarginBlockEnd;
@@ -269,7 +271,6 @@ public class Css3Style extends ATSCStyle {
 	public CssWillChange cssWillChange;
 	
 	public CssContain cssContain;
-	public CssTouchAction cssTouchAction;
 
 	public CssMixBlendMode cssMixBlendMode;
 	public CssIsolation cssIsolation;
@@ -447,6 +448,15 @@ public class Css3Style extends ATSCStyle {
 		return cssWritingMode;
 	}
 
+    public CssTouchAction getTouchAction() {
+        if (cssTouchAction == null) {
+            cssTouchAction =
+                    (CssTouchAction) style.CascadingOrder(new CssTouchAction(),
+                            style, selector);
+        }
+        return cssTouchAction;
+    }
+    
 	public org.w3c.css.properties.css.counterstyle.CssSpeakAs getCounterStyleCssSpeakAs() {
 		if (counterStyleCssSpeakAs == null) {
 			counterStyleCssSpeakAs = (org.w3c.css.properties.css.counterstyle.CssSpeakAs) style.CascadingOrder(new org.w3c.css.properties.css.counterstyle.CssSpeakAs(), style, selector);
@@ -946,14 +956,6 @@ public class Css3Style extends ATSCStyle {
 							style, selector);
 		}
 		return cssContain;
-	}
-
-	public final CssTouchAction getTouchAction() {
-		if (cssTouchAction == null) {
-			cssTouchAction = (CssTouchAction) style //
-			.CascadingOrder(new CssFloatOffset(), style, selector);
-		}
-		return cssTouchAction;
 	}
 
 	public CssMixBlendMode getMixBlendMode() {

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -269,6 +269,7 @@ public class Css3Style extends ATSCStyle {
 	public CssWillChange cssWillChange;
 	
 	public CssContain cssContain;
+	public CssTouchAction cssTouchAction;
 
 	public CssMixBlendMode cssMixBlendMode;
 	public CssIsolation cssIsolation;
@@ -945,6 +946,14 @@ public class Css3Style extends ATSCStyle {
 							style, selector);
 		}
 		return cssContain;
+	}
+
+	public final CssTouchAction getTouchAction() {
+		if (cssTouchAction == null) {
+			cssTouchAction = (CssTouchAction) style //
+			.CascadingOrder(new CssFloatOffset(), style, selector);
+		}
+		return cssTouchAction;
 	}
 
 	public CssMixBlendMode getMixBlendMode() {

--- a/org/w3c/css/properties/css3/CssTouchAction.java
+++ b/org/w3c/css/properties/css3/CssTouchAction.java
@@ -4,11 +4,6 @@
 
 package org.w3c.css.properties.css3;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import org.w3c.css.parser.CssStyle;
-import org.w3c.css.properties.css.CssProperty;
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssExpression;
@@ -17,177 +12,188 @@ import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
 import org.w3c.css.values.CssValueList;
 
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
 /**
- * <P>
- * <EM>Value:</EM> auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y |
- * pan-up | pan-down ] || pinch-zoom ] | manipulation<BR>
- * <EM>Initial:</EM> auto<BR>
- * <EM>Applies to:</EM> all elements except: non-replaced inline elements, table
- * rows, row groups, table columns, and column groups.<BR>
- * <EM>Inherited:</EM> no<BR>
- * <EM>Percentages:</EM> no<BR>
- * <EM>Media:</EM> :visual
- * <P>
- * The touch-action CSS property determines whether touch input <EM>MAY</EM>
- * trigger default behavior supplied by user agent.<BR>
- * This includes, but is not limited to, behaviors such as panning or zooming.
+ * @spec https://www.w3.org/TR/2016/WD-pointerevents2-20160719/#the-touch-action-css-property
+ * @spec https://compat.spec.whatwg.org/#touch-action
  */
 
-public class CssTouchAction extends CssProperty {
+public class CssTouchAction extends org.w3c.css.properties.css.CssTouchAction {
 
-    CssValue touchaction;
+    public static final CssIdent[] allowed_vertical_values;
+    public static final CssIdent[] allowed_horizontal_values;
+    public static final CssIdent[] allowed_values;
+    public static final CssIdent pinch_zoom;
 
-    /* See https://w3c.github.io/pointerevents/#the-touch-action-css-property
-     * and https://compat.spec.whatwg.org/#touch-action (for `pinch-zoom`). */
+    static {
+        String[] _allowed_vertical_values = {"pan-x", "pan-left", "pan-right"};
+        allowed_vertical_values = new CssIdent[_allowed_vertical_values.length];
+        int i = 0;
+        for (String s : _allowed_vertical_values) {
+            allowed_vertical_values[i++] = CssIdent.getIdent(s);
+        }
+        String[] _allowed_horizontal_values = {"pan-y", "pan-up", "pan-down"};
+        allowed_horizontal_values = new CssIdent[_allowed_horizontal_values.length];
+        i = 0;
+        for (String s : _allowed_horizontal_values) {
+            allowed_horizontal_values[i++] = CssIdent.getIdent(s);
+        }
+        String[] _allowed_values = {"auto", "none", "manipulation"};
+        allowed_values = new CssIdent[_allowed_values.length];
+        i = 0;
+        for (String s : _allowed_values) {
+            allowed_values[i++] = CssIdent.getIdent(s);
+        }
+        pinch_zoom = CssIdent.getIdent("pinch-zoom");
+    }
 
-    CssIdent auto = new CssIdent("auto");
-    CssIdent none = new CssIdent("none");
-    CssIdent panX = new CssIdent("pan-x");
-    CssIdent panLeft = new CssIdent("pan-left");
-    CssIdent panRight = new CssIdent("pan-right");
-    CssIdent panY = new CssIdent("pan-y");
-    CssIdent panUp = new CssIdent("pan-up");
-    CssIdent panDown = new CssIdent("pan-down");
-    CssIdent pinchZoom = new CssIdent("pinch-zoom");
-    CssIdent manipulation = new CssIdent("manipulation");
+    public static CssIdent getAllowedHorizontalIdent(CssIdent ident) {
+        for (CssIdent id : allowed_horizontal_values) {
+            if (id.equals(ident)) {
+                return id;
+            }
+        }
+        return null;
+    }
+
+    public static CssIdent getAllowedVerticalIdent(CssIdent ident) {
+        for (CssIdent id : allowed_vertical_values) {
+            if (id.equals(ident)) {
+                return id;
+            }
+        }
+        return null;
+    }
+
+    public static CssIdent getAllowedIdent(CssIdent ident) {
+        for (CssIdent id : allowed_values) {
+            if (id.equals(ident)) {
+                return id;
+            }
+        }
+        return null;
+    }
 
     /**
      * Create a new CssTouchAction
      */
     public CssTouchAction() {
-        touchaction = new CssValueList(
-                new ArrayList<CssValue>(Arrays.asList(auto)));
+        value = initial;
     }
 
     /**
      * Create a new CssTouchAction
      *
-     * @param expression
-     *            The expression for this property
-     * @exception InvalidParamException
-     *                Incorrect value
+     * @param expression The expression for this property
+     * @throws InvalidParamException Incorrect value
      */
     public CssTouchAction(ApplContext ac, CssExpression expression,
-            boolean check) throws InvalidParamException {
+                          boolean check) throws InvalidParamException {
+
         CssValue val;
-        ArrayList<CssValue> values = new ArrayList<CssValue>();
-        boolean gotHorizontal = false;
-        boolean gotVertical = false;
-        boolean gotPinchZoom = false;
+        char op;
+        CssIdent id, ident;
+        boolean got_vertical = false;
+        boolean got_horizontal = false;
+        boolean got_pinch_zoom = false;
 
         setByUser();
 
+        if (check && expression.getCount() > 3) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+
+        ArrayList<CssValue> values = new ArrayList<>();
+
         while (!expression.end()) {
             val = expression.getValue();
+            op = expression.getOperator();
 
-            if (val.getType() != CssTypes.CSS_IDENT) {
-                throw new InvalidParamException("value", val, getPropertyName(),
-                        ac);
-            } else if (val.equals(auto) || val.equals(none)
-                    || val.equals(manipulation)) {
-                if (expression.getCount() > 1) {
-                    throw new InvalidParamException("unrecognize", ac);
-                }
-            } else if (val.equals(panX) //
-                    || val.equals(panLeft) //
-                    || val.equals(panRight)) {
-                if (gotHorizontal) {
-                    throw new InvalidParamException("unrecognize", ac);
-                }
-                gotHorizontal = true;
-            } else if (val.equals(panY) //
-                    || val.equals(panUp) //
-                    || val.equals(panDown)) {
-                if (gotVertical) {
-                    throw new InvalidParamException("unrecognize", ac);
-                }
-                gotVertical = true;
-            } else if (val.equals(pinchZoom)) {
-                if (gotPinchZoom) {
-                    throw new InvalidParamException("unrecognize", ac);
-                }
-                gotPinchZoom = true;
-            } else {
-                throw new InvalidParamException("value", val.toString(),
+            if (op != SPACE) {
+                throw new InvalidParamException("operator", op,
                         getPropertyName(), ac);
             }
-            values.add(val);
-            expression.next();
+
+            if (val.getType() != CssTypes.CSS_IDENT) {
+                throw new InvalidParamException("value",
+                        val.toString(),
+                        getPropertyName(), ac);
+            }
+            id = (CssIdent) val;
+            if (id.equals(inherit)) {
+                if (expression.getCount() > 1) {
+                    throw new InvalidParamException("value",
+                            expression.getValue(),
+                            getPropertyName(), ac);
+                }
+                values.add(inherit);
+                expression.next();
+                continue;
+            }
+            // check for single values first.
+            ident = getAllowedIdent(id);
+            if (ident != null) {
+                if (expression.getCount() > 1) {
+                    throw new InvalidParamException("value",
+                            expression.getValue(),
+                            getPropertyName(), ac);
+                }
+                values.add(ident);
+                expression.next();
+                continue;
+            }
+            // then for the possible double values
+            ident = getAllowedHorizontalIdent(id);
+            if (ident != null) {
+                if (got_horizontal) {
+                    // we already got one
+                    throw new InvalidParamException("value",
+                            expression.getValue(),
+                            getPropertyName(), ac);
+                }
+                got_horizontal = true;
+                values.add(ident);
+                expression.next();
+                continue;
+            }
+            ident = getAllowedVerticalIdent(id);
+            if (ident != null) {
+                if (got_vertical) {
+                    // we already got one
+                    throw new InvalidParamException("value",
+                            expression.getValue(),
+                            getPropertyName(), ac);
+                }
+                got_vertical = true;
+                values.add(ident);
+                expression.next();
+                continue;
+            }
+            if (pinch_zoom.equals(id)) {
+                if (got_pinch_zoom) {
+                    // we already got one
+                    throw new InvalidParamException("value",
+                            expression.getValue(),
+                            getPropertyName(), ac);
+                }
+                got_pinch_zoom = true;
+                values.add(pinch_zoom);
+                expression.next();
+                continue;
+            }
+            throw new InvalidParamException("value", val.toString(),
+                    getPropertyName(), ac);
+
         }
-        touchaction = new CssValueList(values);
+        // no need to check for single values as it was done earlier.
+        value = (values.size() == 1) ? values.get(0) : new CssValueList(values);
     }
 
     public CssTouchAction(ApplContext ac, CssExpression expression)
             throws InvalidParamException {
         this(ac, expression, false);
     }
-
-    /**
-     * Add this property to the CssStyle
-     *
-     * @param style
-     *            The CssStyle
-     */
-    public void addToStyle(ApplContext ac, CssStyle style) {
-        if (((Css3Style) style).cssTouchAction != null)
-            style.addRedefinitionWarning(ac, this);
-        ((Css3Style) style).cssTouchAction = this;
-    }
-
-    /**
-     * Get this property in the style.
-     *
-     * @param style
-     *            The style where the property is
-     * @param resolve
-     *            if true, resolve the style to find this property
-     */
-    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
-        if (resolve) {
-            return ((Css3Style) style).getAlignmentAdjust();
-        } else {
-            return ((Css3Style) style).cssTouchAction;
-        }
-    }
-
-    /**
-     * Compares two properties for equality.
-     *
-     * @param value
-     *            The other property.
-     */
-    public boolean equals(CssProperty property) {
-        return (property instanceof CssTouchAction
-                && touchaction.equals(((CssTouchAction) property).touchaction));
-    }
-
-    /**
-     * Returns the name of this property
-     */
-    public String getPropertyName() {
-        return "touch-action";
-    }
-
-    /**
-     * Returns the value of this property
-     */
-    public Object get() {
-        return touchaction;
-    }
-
-    /**
-     * Returns a string representation of the object
-     */
-    public String toString() {
-        return touchaction.toString();
-    }
-
-    /**
-     * Is the value of this property a default value It is used by all macro for
-     * the function <code>print</code>
-     */
-    public boolean isDefault() {
-        return "auto".equals(touchaction.toString());
-    }
-
 }

--- a/org/w3c/css/properties/css3/CssTouchAction.java
+++ b/org/w3c/css/properties/css3/CssTouchAction.java
@@ -1,0 +1,193 @@
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2017.
+// Please first read the full copyright statement at:
+// https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+
+package org.w3c.css.properties.css3;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css.CssProperty;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssIdent;
+import org.w3c.css.values.CssTypes;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+/**
+ * <P>
+ * <EM>Value:</EM> auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y |
+ * pan-up | pan-down ] || pinch-zoom ] | manipulation<BR>
+ * <EM>Initial:</EM> auto<BR>
+ * <EM>Applies to:</EM> all elements except: non-replaced inline elements, table
+ * rows, row groups, table columns, and column groups.<BR>
+ * <EM>Inherited:</EM> no<BR>
+ * <EM>Percentages:</EM> no<BR>
+ * <EM>Media:</EM> :visual
+ * <P>
+ * The touch-action CSS property determines whether touch input <EM>MAY</EM>
+ * trigger default behavior supplied by user agent.<BR>
+ * This includes, but is not limited to, behaviors such as panning or zooming.
+ */
+
+public class CssTouchAction extends CssProperty {
+
+    CssValue touchaction;
+
+    /* See https://w3c.github.io/pointerevents/#the-touch-action-css-property
+     * and https://compat.spec.whatwg.org/#touch-action (for `pinch-zoom`). */
+
+    CssIdent auto = new CssIdent("auto");
+    CssIdent none = new CssIdent("none");
+    CssIdent panX = new CssIdent("pan-x");
+    CssIdent panLeft = new CssIdent("pan-left");
+    CssIdent panRight = new CssIdent("pan-right");
+    CssIdent panY = new CssIdent("pan-y");
+    CssIdent panUp = new CssIdent("pan-up");
+    CssIdent panDown = new CssIdent("pan-down");
+    CssIdent pinchZoom = new CssIdent("pinch-zoom");
+    CssIdent manipulation = new CssIdent("manipulation");
+
+    /**
+     * Create a new CssTouchAction
+     */
+    public CssTouchAction() {
+        touchaction = new CssValueList(
+                new ArrayList<CssValue>(Arrays.asList(auto)));
+    }
+
+    /**
+     * Create a new CssTouchAction
+     *
+     * @param expression
+     *            The expression for this property
+     * @exception InvalidParamException
+     *                Incorrect value
+     */
+    public CssTouchAction(ApplContext ac, CssExpression expression,
+            boolean check) throws InvalidParamException {
+        CssValue val;
+        ArrayList<CssValue> values = new ArrayList<CssValue>();
+        boolean gotHorizontal = false;
+        boolean gotVertical = false;
+        boolean gotPinchZoom = false;
+
+        setByUser();
+
+        while (!expression.end()) {
+            val = expression.getValue();
+
+            if (val.getType() != CssTypes.CSS_IDENT) {
+                throw new InvalidParamException("value", val, getPropertyName(),
+                        ac);
+            } else if (val.equals(auto) || val.equals(none)
+                    || val.equals(manipulation)) {
+                if (expression.getCount() > 1) {
+                    throw new InvalidParamException("unrecognize", ac);
+                }
+            } else if (val.equals(panX) //
+                    || val.equals(panLeft) //
+                    || val.equals(panRight)) {
+                if (gotHorizontal) {
+                    throw new InvalidParamException("unrecognize", ac);
+                }
+                gotHorizontal = true;
+            } else if (val.equals(panY) //
+                    || val.equals(panUp) //
+                    || val.equals(panDown)) {
+                if (gotVertical) {
+                    throw new InvalidParamException("unrecognize", ac);
+                }
+                gotVertical = true;
+            } else if (val.equals(pinchZoom)) {
+                if (gotPinchZoom) {
+                    throw new InvalidParamException("unrecognize", ac);
+                }
+                gotPinchZoom = true;
+            } else {
+                throw new InvalidParamException("value", val.toString(),
+                        getPropertyName(), ac);
+            }
+            values.add(val);
+            expression.next();
+        }
+        touchaction = new CssValueList(values);
+    }
+
+    public CssTouchAction(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Add this property to the CssStyle
+     *
+     * @param style
+     *            The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssTouchAction != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssTouchAction = this;
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style
+     *            The style where the property is
+     * @param resolve
+     *            if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getAlignmentAdjust();
+        } else {
+            return ((Css3Style) style).cssTouchAction;
+        }
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param value
+     *            The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssTouchAction
+                && touchaction.equals(((CssTouchAction) property).touchaction));
+    }
+
+    /**
+     * Returns the name of this property
+     */
+    public String getPropertyName() {
+        return "touch-action";
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return touchaction;
+    }
+
+    /**
+     * Returns a string representation of the object
+     */
+    public String toString() {
+        return touchaction.toString();
+    }
+
+    /**
+     * Is the value of this property a default value It is used by all macro for
+     * the function <code>print</code>
+     */
+    public boolean isDefault() {
+        return "auto".equals(touchaction.toString());
+    }
+
+}


### PR DESCRIPTION
This change makes the CSS checker recognize the `touch-action` property and
check its value.

The checking behavior conforms to the definition in the Pointer Events spec at
https://w3c.github.io/pointerevents/#the-touch-action-css-property and to the
Compatibility spec’s definition at https://compat.spec.whatwg.org/#touch-action
for the additional value `pinch-zoom`.

Tests: https://github.com/w3c/css-validator-testsuite/pull/1