### PR TITLE
Align clip-path checking more closely with spec

### DIFF
--- a/org/w3c/css/properties/css3/CssBorderRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderRadius.java
@@ -177,7 +177,7 @@ public class CssBorderRadius extends org.w3c.css.properties.css.CssBorderRadius 
 	 * Check the border-*-radius and returns a value.
 	 * It makes sense to do it only once for all the corners, so by having the code here.
 	 */
-	protected static CssValue checkBorderCornerRadius(ApplContext ac, CssProperty caller,
+	public static CssValue checkBorderCornerRadius(ApplContext ac, CssProperty caller,
 													  CssExpression expression, boolean check)
 			throws InvalidParamException {
 

--- a/org/w3c/css/properties/svg/CssClipPath.java
+++ b/org/w3c/css/properties/svg/CssClipPath.java
@@ -6,12 +6,18 @@
 package org.w3c.css.properties.svg;
 
 import org.w3c.css.properties.css.CssProperty;
+import org.w3c.css.properties.css3.CssBackgroundClip;
+import org.w3c.css.properties.css3.CssBorderRadius;
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssExpression;
 import org.w3c.css.values.CssFunction;
+import org.w3c.css.values.CssIdent;
 import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
 
 import static org.w3c.css.values.CssOperator.SPACE;
 
@@ -20,94 +26,175 @@ import static org.w3c.css.values.CssOperator.SPACE;
  */
 public class CssClipPath extends org.w3c.css.properties.css.CssClipPath {
 
-	/**
-	 * Create a new CssClipPath
-	 */
-	public CssClipPath() {
-		value = initial;
-	}
+    public static final CssIdent[] geometry_box_allowed_values;
+    public static final CssIdent inset_round;
 
-	/**
-	 * Creates a new CssClipPath
-	 *
-	 * @param expression The expression for this property
-	 * @throws org.w3c.css.util.InvalidParamException
-	 *          Expressions are incorrect
-	 */
-	public CssClipPath(ApplContext ac, CssExpression expression, boolean check)
-			throws InvalidParamException {
-		if (check && expression.getCount() > 1) {
-			throw new InvalidParamException("unrecognize", ac);
-		}
-		setByUser();
+    static {
+        String[] _allowed_values = {"margin-box", "fill-box", "stroke-box", "view-box"};
 
-		CssValue val;
+        geometry_box_allowed_values = new CssIdent[_allowed_values.length];
+        for (int i = 0; i < geometry_box_allowed_values.length; i++) {
+            geometry_box_allowed_values[i] = CssIdent.getIdent(_allowed_values[i]);
+        }
+        inset_round = CssIdent.getIdent("round");
+    }
 
-		val = expression.getValue();
+    public static final CssIdent getGeometryBoxAllowedValue(CssIdent ident) {
+        // <geometry-box> = <shape-box> | fill-box | stroke-box | view-box
+        // <shape-box> = <box> | margin-box
+        CssIdent idt = CssBackgroundClip.getMatchingIdent(ident);
+        if (idt != null) {
+            return idt;
+        }
+        for (CssIdent id : geometry_box_allowed_values) {
+            if (id.equals(ident)) {
+                return id;
+            }
+        }
+        return null;
+    }
 
-		switch (val.getType()) {
-			case CssTypes.CSS_FUNCTION:
-				CssFunction func = (CssFunction) val;
-				String funcname = func.getName().toLowerCase();
-				if (funcname.equals("inset")) {
-					checkInset(ac, func.getParameters(), this);
-				} else {
-					throw new InvalidParamException("value", val,
-							getPropertyName(), ac);
-				}
-				value = val;
-				break;
-			case CssTypes.CSS_URL:
-				value = val;
-				break;
-			case CssTypes.CSS_IDENT:
-				if (inherit.equals(val)) {
-					value = inherit;
-					break;
-				}
-				if (none.equals(val)) {
-					value = none;
-					break;
-				}
-			default:
-				throw new InvalidParamException("value",
-						val.toString(),
-						getPropertyName(), ac);
-		}
-		expression.next();
-	}
+    /**
+     * Create a new CssClipPath
+     */
+    public CssClipPath() {
+        value = initial;
+    }
 
-	public CssClipPath(ApplContext ac, CssExpression expression)
-			throws InvalidParamException {
-		this(ac, expression, false);
-	}
+    /**
+     * Creates a new CssClipPath
+     *
+     * @param expression The expression for this property
+     * @throws org.w3c.css.util.InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssClipPath(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
 
-	static void checkInset(ApplContext ac, CssExpression expression,
-						   CssProperty caller) throws InvalidParamException {
-		if (expression.getCount() > 4) {
-			throw new InvalidParamException("unrecognize", ac);
-		}
-		CssValue val;
-		char op;
-		for (int i = 0; i < 4; i++) {
-			val = expression.getValue();
-			op = expression.getOperator();
-			if (op != SPACE) {
-				throw new InvalidParamException("inset-separator",
-						((new Character(op)).toString()), ac);
-			}
-			switch (val.getType()) {
-				case CssTypes.CSS_LENGTH:
-					break;
-				case CssTypes.CSS_PERCENTAGE:
-					break;
-				default:
-					throw new InvalidParamException("value",
-							val.toString(),
-							caller.getPropertyName(), ac);
-			}
-			expression.next();
-		}
-	}
+        ArrayList<CssValue> values = new ArrayList<CssValue>();
+        boolean gotGeometryBox = false;
+        boolean gotBasicShape = false;
+        while (!expression.end()) {
+            CssValue val;
+            char op = expression.getOperator();
+            val = expression.getValue();
+
+            switch (val.getType()) {
+                case CssTypes.CSS_FUNCTION:
+                    if (!gotBasicShape) {
+                        CssFunction func = (CssFunction) val;
+                        String funcname = func.getName().toLowerCase();
+                        switch (funcname) {
+                            case "inset":
+                                checkInset(ac, func.getParameters(), this);
+                                break;
+                            case "circle":
+                            case "ellipse":
+                            case "polygon":
+                                // not yet implemented
+                            default:
+                                throw new InvalidParamException("value", val,
+                                        getPropertyName(), ac);
+                        }
+                        gotBasicShape = true;
+                        values.add(val);
+                        break;
+                    }
+                    throw new InvalidParamException("value", val,
+                            getPropertyName(), ac);
+                case CssTypes.CSS_URL:
+                    value = val;
+                    break;
+                case CssTypes.CSS_IDENT:
+                    if (inherit.equals(val)) {
+                        value = inherit;
+                        break;
+                    }
+                    if (none.equals(val)) {
+                        value = none;
+                        break;
+                    }
+                    if (!gotGeometryBox) {
+                        CssIdent ident = getGeometryBoxAllowedValue((CssIdent) val);
+                        if (ident != null) {
+                            gotGeometryBox = true;
+                            values.add(ident);
+                            break;
+                        }
+                    }
+
+                default:
+                    throw new InvalidParamException("value",
+                            val.toString(),
+                            getPropertyName(), ac);
+            }
+            expression.next();
+            if (op != SPACE) {
+                throw new InvalidParamException("operator",
+                        ((new Character(op)).toString()), ac);
+            }
+        }
+        if (gotBasicShape || gotGeometryBox) {
+            value = (values.size() == 1) ? values.get(0) : new CssValueList(values);
+        }
+    }
+
+    public CssClipPath(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    static void checkInset(ApplContext ac, CssExpression expression,
+                           CssProperty caller) throws InvalidParamException {
+        CssValue val;
+        char op;
+        int nb_shape_arg = 0;
+
+        while (!expression.end()) {
+            val = expression.getValue();
+            op = expression.getOperator();
+
+            switch (val.getType()) {
+                case CssTypes.CSS_NUMBER:
+                    val.getCheckableValue().checkEqualsZero(ac, caller);
+                case CssTypes.CSS_LENGTH:
+                case CssTypes.CSS_PERCENTAGE:
+                    nb_shape_arg++;
+                    if (nb_shape_arg > 4) {
+                        throw new InvalidParamException("unrecognize", ac);
+                    }
+                    break;
+                case CssTypes.CSS_IDENT:
+                     if (inset_round.equals((CssIdent)val)) {
+                         // the remainder must be a border-radius
+                         CssExpression nex = new CssExpression();
+                         expression.next();
+                         while (!expression.end()) {
+                             nex.addValue(expression.getValue());
+                             nex.setOperator(expression.getOperator());
+                             expression.next();
+                         }
+                         if (nex.getCount() == 0) {
+                             throw new InvalidParamException("unrecognize", ac);
+                         }
+                         CssBorderRadius.checkBorderCornerRadius(ac, caller, nex, true);
+                         break;
+                     }
+                default:
+                    throw new InvalidParamException("value",
+                            val.toString(),
+                            caller.getPropertyName(), ac);
+            }
+            if (op != SPACE) {
+                throw new InvalidParamException("inset-separator",
+                        ((new Character(op)).toString()), ac);
+            }
+            expression.next();
+        }
+    }
 }
 

--- a/org/w3c/css/properties/svg/CssClipPath.java
+++ b/org/w3c/css/properties/svg/CssClipPath.java
@@ -90,7 +90,7 @@ public class CssClipPath extends org.w3c.css.properties.css.CssClipPath {
                         String funcname = func.getName().toLowerCase();
                         switch (funcname) {
                             case "inset":
-                                checkInset(ac, func.getParameters(), this);
+                                checkInsetFunction(ac, func.getParameters(), this);
                                 break;
                             case "circle":
                             case "ellipse":
@@ -148,8 +148,8 @@ public class CssClipPath extends org.w3c.css.properties.css.CssClipPath {
         this(ac, expression, false);
     }
 
-    static void checkInset(ApplContext ac, CssExpression expression,
-                           CssProperty caller) throws InvalidParamException {
+    static void checkInsetFunction(ApplContext ac, CssExpression expression,
+                                   CssProperty caller) throws InvalidParamException {
         CssValue val;
         char op;
         int nb_shape_arg = 0;

--- a/org/w3c/css/properties/svg/CssClipPath.java
+++ b/org/w3c/css/properties/svg/CssClipPath.java
@@ -219,7 +219,7 @@ public class CssClipPath extends org.w3c.css.properties.css.CssClipPath {
                             caller.getPropertyName(), ac);
             }
             if (op != SPACE) {
-                throw new InvalidParamException("inset-separator",
+                throw new InvalidParamException("operator",
                         ((new Character(op)).toString()), ac);
             }
             expression.next();

--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -232,6 +232,9 @@ error.shape: Invalid shape definition rect(<top>,<right>,<bottom>,<left>)
 error.shape-separator: Invalid separator in shape definition. It must be a comma.
 warning.shape-separator: Invalid separator in shape definition. It must be a comma.
 
+# used by org.w3c.svg.properties.CssClipPath
+error.inset-separator: Invalid separator \u201C%s\u201D in \u201Cinset\u201D definition (must be a space)
+
 # used by org.w3c.css.properties.CssContent
 error.attr: Invalid attr definition attr(X)
 error.function: Invalid function definition 

--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -232,9 +232,6 @@ error.shape: Invalid shape definition rect(<top>,<right>,<bottom>,<left>)
 error.shape-separator: Invalid separator in shape definition. It must be a comma.
 warning.shape-separator: Invalid separator in shape definition. It must be a comma.
 
-# used by org.w3c.svg.properties.CssClipPath
-error.inset-separator: Invalid separator \u201C%s\u201D in \u201Cinset\u201D definition (must be a space)
-
 # used by org.w3c.css.properties.CssContent
 error.attr: Invalid attr definition attr(X)
 error.function: Invalid function definition 


### PR DESCRIPTION
This change brings `clip-path` checking a bit closer into alignment with the
requirements in https://drafts.fxtf.org/css-masking-1/#the-clip-path.

Even with this change, the checker still doesn’t recognize circle(), ellipse()
or polygon() values for clip-path, but it does now recognize inset() values —
with the limitation of not yet recognizing the `round <‘border-radius’>`
optional argument.