### PR TITLE
Make parser handle “star property hack” gracefully

### DIFF
--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -6064,7 +6064,14 @@ n.image = Util.strip(n.image);
 	 }
 	 token = oldToken;
 	 jj_kind = kind;
-	 throw generateParseException();
+	 if (kind == LBRACE) {
+	   if (ac.getTreatCssHacksAsWarnings()) {
+		ac.getFrame().addWarning("css-hack", skipStatement());
+	   } else {
+		addError(generateParseException(), skipStatement());
+	   }
+	 }
+	 return token;
   }
 
   @SuppressWarnings("serial")

--- a/org/w3c/css/parser/analyzer/Makefile
+++ b/org/w3c/css/parser/analyzer/Makefile
@@ -4,4 +4,5 @@ CssParser.java: CssParser.jj .FORCE
 	cat CssParser.java \
 	  | sed 's/^}/  }/g; $$d' > C && mv -f C CssParser.java && \
 	  echo '}' >> CssParser.java
+	patch < patch.star-property-hack
 .FORCE:

--- a/org/w3c/css/parser/analyzer/patch.star-property-hack
+++ b/org/w3c/css/parser/analyzer/patch.star-property-hack
@@ -1,0 +1,18 @@
+--- CssParser.java
++++ CssParser.java
+@@ -6064,7 +6064,14 @@ n.image = Util.strip(n.image);
+ 	 }
+ 	 token = oldToken;
+ 	 jj_kind = kind;
+-	 throw generateParseException();
++	 if (kind == LBRACE) {
++	   if (ac.getTreatCssHacksAsWarnings()) {
++		ac.getFrame().addWarning("css-hack", skipStatement());
++	   } else {
++		addError(generateParseException(), skipStatement());
++	   }
++	 }
++	 return token;
+   }
+ 
+   @SuppressWarnings("serial")


### PR DESCRIPTION
This change makes the parser gracefully handle cases like `*zoom: 1` where a CSS
identifier is prefixed with an asterisk (the so-called “star property hack”).
Without this change, the parser “derails” into a state where it ends up
incorrectly emitting spurious errors about later valid CSS constructs.

If the option to treat vendor extensions as warnings is set, a vendor-
extension warning message is reported; otherwise, a parse error is reported.

This change is itself a hack in that it achieves its effect by patching the
generated CssParser.java code after it’s been built by running javacc on the
CssParser.jj source.