### PR TITLE
Pseudo-elements: selection, placeholder, backdrop

### DIFF
--- a/org/w3c/css/selectors/PseudoFactory.java
+++ b/org/w3c/css/selectors/PseudoFactory.java
@@ -51,7 +51,8 @@ public class PseudoFactory {
 	};
 
 	private static final String[] PSEUDOELEMENT_CONSTANTSCSS3 = {
-			"first-line", "first-letter", "before", "after", "marker"
+			"first-line", "first-letter", "before", "after", "marker",
+			"selection", "placeholder", "backdrop"
 	};
 
 	private static final String[] PSEUDOELEMENT_CONSTANTSCSS2 = {


### PR DESCRIPTION
This change allows the `selection`, `placeholder` & `backdrop` pseudo-elements.

`selection` & `placeholder` are defined in CSS Pseudo-Elements Level 4:

https://www.w3.org/TR/2016/WD-css-pseudo-4-20160607/#selectordef-selection
https://www.w3.org/TR/2016/WD-css-pseudo-4-20160607/#selectordef-placeholder

`backdrop` is defined in the Fullscreen spec:

https://fullscreen.spec.whatwg.org/#::backdrop-pseudo-element