### PR TITLE
Allow 'pointer-events: auto'

### DIFF
--- a/org/w3c/css/properties/svg/CssPointerEvents.java
+++ b/org/w3c/css/properties/svg/CssPointerEvents.java
@@ -19,6 +19,8 @@ public class CssPointerEvents extends org.w3c.css.properties.css.CssPointerEvent
 
 	public static final CssIdent[] allowed_values;
 
+	public static final CssIdent auto = CssIdent.getIdent("auto");
+
 	static {
 		String[] _allowed_values = {"visiblePainted", "visibleFill", "visibleStroke",
 				"visible", "painted", "fill", "stroke", "all", "none"};
@@ -69,6 +71,10 @@ public class CssPointerEvents extends org.w3c.css.properties.css.CssPointerEvent
 			CssIdent ident = (CssIdent) val;
 			if (inherit.equals(ident)) {
 				value = inherit;
+			} else if (auto.equals(ident)) {
+				value = auto;
+				ac.getFrame().addWarning("value-unofficial", //
+					new String[]{"auto","pointer-events"});
 			} else {
 				value = getAllowedValue(ident);
 				if (value == null) {

--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -197,6 +197,9 @@ error.few-value: too few values for the property \u201C%s\u201D
 # You can't write something like this : For the color, blue is an incorrect value
 error.value: \u201C%s\u201D is not a \u201C%s\u201D value
 
+# used by org.w3c.css.properties.svg.CssPointerEvents
+warning.value-unofficial: \u201C%s\u201D is not defined by any specification as an allowed value for \u201C%s\u201D, but is supported in multiple browsers
+
 #used by org.w3c.css.properties3.CssToggleGroup
 error.groupname: \u201C%s\u201D is not a correct groupname. Use a valid identifier
 

--- a/org/w3c/css/util/Messages.properties.fr
+++ b/org/w3c/css/util/Messages.properties.fr
@@ -215,6 +215,9 @@ error.value: \u201C%s\u201D n'est pas une valeur de \u201C%s\u201D
 # used by org.w3c.css.properties3.CssToggleGroup
 error.groupname: \u201C%s\u201D n'est pas un nom de groupe correct. Utilisez un bon identifiant
 
+# used by org.w3c.css.properties.svg.CssPointerEvents
+warning.value-unofficial: \u201C%s\u201D n'est définie dans aucune spécification comme étant une valeur autorisée pour \u201C%s\u201D, mais elle est implémentée dans plusieurs navigateurs
+
 #used by org.w3c.css.properties3.CssGroupReset
 error.nogroup: \u201C%s\u201D n'a pas été initialisé par toggle-group
 


### PR DESCRIPTION
This change allows the `auto` value for the `pointer-events` property.

The `auto` value for `pointer-events` is used commonly in the wild — even though
it’s not defined as valid in any CSS specs — because support for it has been
implemented in browsers for more than 10 years now.

Details are in comments in https://bugzilla.mozilla.org/show_bug.cgi?id=380573
and https://webkit.org/specs/PointerEventsProperty.html is the spec which the
browsers implemented from.