### PR TITLE
Allow 'word-break: break-word'

### DIFF
--- a/org/w3c/css/properties/css3/CssWordBreak.java
+++ b/org/w3c/css/properties/css3/CssWordBreak.java
@@ -20,7 +20,8 @@ public class CssWordBreak extends org.w3c.css.properties.css.CssWordBreak {
 	public static final CssIdent[] allowed_values;
 
 	static {
-		String[] _allowed_values = {"normal", "keep-all", "break-all"};
+		String[] _allowed_values = {"normal", "keep-all", "break-all",
+			"break-word"};
 		allowed_values = new CssIdent[_allowed_values.length];
 		int i = 0;
 		for (String s : _allowed_values) {

--- a/org/w3c/css/properties/css3/CssWordBreak.java
+++ b/org/w3c/css/properties/css3/CssWordBreak.java
@@ -13,7 +13,7 @@ import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2012/WD-css3-text-20120814/#word-break0
+ * @spec https://www.w3.org/TR/2017/WD-css-text-3-20170822/#word-break-property
  */
 public class CssWordBreak extends org.w3c.css.properties.css.CssWordBreak {
 


### PR DESCRIPTION
This change allows the `break-word` value for the `word-break` property,
per https://www.w3.org/TR/2017/WD-css-text-3-20170822/#word-break-property