### PR TITLE
Allow pseduo-classes defined in HTML & Fullscreen

### DIFF
--- a/org/w3c/css/selectors/PseudoFactory.java
+++ b/org/w3c/css/selectors/PseudoFactory.java
@@ -27,6 +27,9 @@ public class PseudoFactory {
 			"checked", "indeterminate", "root", "last-child",
 			"first-of-type", "last-of-type", "only-of-type",
 			"only-child", "empty",
+			"fullscreen", "default", "valid", "invalid", "in-range",
+			"out-of-range", "required", "optional", "read-only",
+			"read-write", "defined", "placeholder-shown"
 	};
 
 	private static final String[] PSEUDOCLASS_CONSTANTSCSS2 = {


### PR DESCRIPTION
This change allows the pseudo-classes defined in the HTML spec at
https://html.spec.whatwg.org/multipage/semantics-other.html#pseudo-classes
and as defined in https://fullscreen.spec.whatwg.org/#:fullscreen-pseudo-class,
the `fullscreen` pseudo-class.

Addresses https://github.com/validator/validator/issues/588 Thanks @zimorodokan