### PR TITLE
Treat prefixed media features as vendor extensions

### DIFF
--- a/org/w3c/css/parser/CssFouffa.java
+++ b/org/w3c/css/parser/CssFouffa.java
@@ -24,6 +24,7 @@ import org.w3c.css.util.CssVersion;
 import org.w3c.css.util.HTTPURL;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.util.Util;
+import org.w3c.css.util.WarningParamException;
 import org.w3c.css.util.Warnings;
 import org.w3c.css.values.CssExpression;
 
@@ -610,7 +611,12 @@ public final class CssFouffa extends CssParser {
         try {
             mf = properties.createMediaFeature(ac, rule, feature, expression);
         } catch (InvalidParamException e) {
-            throw e;
+            mf = null;
+            if (e instanceof WarningParamException) {
+                ac.getFrame().addWarning(e.getMessage(), feature);
+            } else {
+                ac.getFrame().addError(new CssError(e));
+            }
         } catch (Exception e) {
             e.printStackTrace();
             if (Util.onDebug) {
@@ -619,6 +625,9 @@ public final class CssFouffa extends CssParser {
             throw new InvalidParamException(e.toString(), ac);
         }
 
+        if (mf == null) {
+            return mf;
+        }
         mf.setOrigin(origin);
         // set informations for errors and warnings
         mf.setInfo(ac.getFrame().getLine(), ac.getFrame().getSourceFile());

--- a/org/w3c/css/parser/CssFouffa.java
+++ b/org/w3c/css/parser/CssFouffa.java
@@ -610,23 +610,18 @@ public final class CssFouffa extends CssParser {
 
         try {
             mf = properties.createMediaFeature(ac, rule, feature, expression);
+        } catch (WarningParamException w) {
+            ac.getFrame().addWarning(w.getMessage(), feature);
+            return null;
         } catch (InvalidParamException e) {
-            mf = null;
-            if (e instanceof WarningParamException) {
-                ac.getFrame().addWarning(e.getMessage(), feature);
-            } else {
-                ac.getFrame().addError(new CssError(e));
-            }
+            ac.getFrame().addError(new CssError(e));
+            return null;
         } catch (Exception e) {
             e.printStackTrace();
             if (Util.onDebug) {
                 e.printStackTrace();
             }
             throw new InvalidParamException(e.toString(), ac);
-        }
-
-        if (mf == null) {
-            return mf;
         }
         mf.setOrigin(origin);
         // set informations for errors and warnings
@@ -655,6 +650,7 @@ public final class CssFouffa extends CssParser {
      * @param context The current context
      * @see org.w3c.css.parser.CssFouffa#addListener
      */
+
     public void parseDeclarations(CssSelectors context) {
         // here we have an example for reusing the parser.
         try {

--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -1341,7 +1341,9 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
       jj_consume_token(S);
     }
 MediaFeature mf = handleMediaFeature(mediaRule, mediaFeatureName, val);
-        mediaRule.addMediaFeature(mf, ac);
+        if (mf != null) {
+            mediaRule.addMediaFeature(mf, ac);
+        }
   }
 
   final public void unused_production_generic_syntax() throws ParseException {CssExpression values = new CssExpression();

--- a/org/w3c/css/parser/analyzer/CssParser.jj
+++ b/org/w3c/css/parser/analyzer/CssParser.jj
@@ -1021,7 +1021,9 @@ void mediaexpression(AtRuleMedia mediaRule, boolean defaultMedia) :
     ( <S> )*
     ( <COLON> ( <S> )* val=mediaexpr() )? <LPARAN>  ( <S> )*  {
         MediaFeature mf = handleMediaFeature(mediaRule, mediaFeatureName, val);
-        mediaRule.addMediaFeature(mf, ac);
+        if (mf != null) {
+            mediaRule.addMediaFeature(mf, ac);
+        }
     }
 }
 


### PR DESCRIPTION
This change causes vendor-prefixed media features to be handled in the same way
as other vendor extensions — so if the option to treat vendor extensions as
warnings is set, messages about vendor-prefixed media features will be emitted
as warnings rather than as errors.