### PR TITLE
Make server allow empty input from POST requests

### DIFF
--- a/org/w3c/css/servlet/CssValidator.java
+++ b/org/w3c/css/servlet/CssValidator.java
@@ -614,16 +614,6 @@ public final class CssValidator extends HttpServlet {
 		if (output == null) {
 			output = texthtml;
 		}
-		if ((file == null || file.getSize() == 0) &&
-				(text == null || text.isEmpty())) {
-			// res.sendError(res.SC_BAD_REQUEST,
-			// "You have send an invalid request");
-			handleError(res, ac, output, "No file",
-					new IOException(ac.getMsg().getServletString(
-							"invalid-request")),
-					false);
-			return;
-		}
 
 		// set the warning output
 		if (warning != null) {
@@ -666,13 +656,16 @@ public final class CssValidator extends HttpServlet {
 		InputStream is = null;
 		boolean isCSS = false;
 
-		if (file != null && file.getSize() != 0) {
+		if (file != null) {
+			isCSS = file.getContentType().equals(textcss);
+			if (file.getSize() == 0) {
+				file.write("\n".getBytes(), 0, 1);
+				isCSS = true;
+			}
 			ac.setFakeFile(file);
 			fileName = file.getName();
 			Util.verbose("File : " + fileName);
-			// another way to get file type...
-			isCSS = file.getContentType().equals(textcss);
-		} else if (text != null) {
+		} else {
 			ac.setFakeText(text);
 			fileName = "TextArea";
 			Util.verbose("- " + fileName + " Data -");


### PR DESCRIPTION
This change makes the server (servlet) allow empty file-upload input and
empty text/direct-input from POST requests — including from requests
made with the HTTP POST API — and to respond with a success message.

That more closely aligns the POST handling with the existing GET
handling; e.g., https://jigsaw.w3.org/css-validator/validator?text=,
which allows the `text` query parameter to be empty, and treats such
content as conforming (because empty CSS documents are valid).

Fixes https://github.com/w3c/css-validator/issues/73. Thanks @niedzielski