### PR TITLE
Treat 'min-width:0\0' hack as a vendor extension

### DIFF
--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -4102,8 +4102,8 @@ setValue(new CssVolume(), exp, operator, n, SPL);
       case DIMEN:{
         n = jj_consume_token(DIMEN);
 if ("0\\0".equals(n.image) //
-                && ac.getTreatVendorExtensionsAsWarnings()) {
-                ac.getFrame().addWarning("vendor-extension", n.image);
+                && ac.getTreatCssHacksAsWarnings()) {
+                ac.getFrame().addWarning("css-hack", n.image);
             } else {
                 addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
             }
@@ -4353,8 +4353,8 @@ setValue(new CssVolume(), exp, operator, n, SPL);
       case DIMEN:{
         n = jj_consume_token(DIMEN);
 if ("0\\0".equals(n.image) //
-                && ac.getTreatVendorExtensionsAsWarnings()) {
-                ac.getFrame().addWarning("vendor-extension", n.image);
+                && ac.getTreatCssHacksAsWarnings()) {
+                ac.getFrame().addWarning("css-hack", n.image);
             } else {
                 addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
             }

--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -4101,7 +4101,12 @@ setValue(new CssVolume(), exp, operator, n, SPL);
         }
       case DIMEN:{
         n = jj_consume_token(DIMEN);
-addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+if ("0\\0".equals(n.image) //
+                && ac.getTreatVendorExtensionsAsWarnings()) {
+                ac.getFrame().addWarning("vendor-extension", n.image);
+            } else {
+                addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+            }
         break;
         }
       default:
@@ -4347,7 +4352,12 @@ setValue(new CssVolume(), exp, operator, n, SPL);
         }
       case DIMEN:{
         n = jj_consume_token(DIMEN);
-addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+if ("0\\0".equals(n.image) //
+                && ac.getTreatVendorExtensionsAsWarnings()) {
+                ac.getFrame().addWarning("vendor-extension", n.image);
+            } else {
+                addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+            }
         break;
         }
       case FUNCTION:{
@@ -5308,17 +5318,6 @@ n.image = Util.strip(n.image);
     finally { jj_save(4, xla); }
   }
 
-  private boolean jj_3R_125()
- {
-    if (jj_3R_129()) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3R_130()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
   private boolean jj_3_3()
  {
     Token xsp;
@@ -5351,6 +5350,23 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3R_125()
+ {
+    if (jj_3R_129()) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3R_130()) { jj_scanpos = xsp; break; }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_180()
+ {
+    if (jj_3R_182()) return true;
+    return false;
+  }
+
   private boolean jj_3R_176()
  {
     if (jj_scan_token(UNICODERANGE)) return true;
@@ -5363,21 +5379,15 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_180()
+  private boolean jj_3R_140()
  {
-    if (jj_3R_182()) return true;
+    if (jj_scan_token(NUMBER)) return true;
     return false;
   }
 
   private boolean jj_3R_174()
  {
     if (jj_3R_179()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_140()
- {
-    if (jj_scan_token(NUMBER)) return true;
     return false;
   }
 
@@ -5425,12 +5435,6 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_152()
- {
-    if (jj_scan_token(PLUS)) return true;
-    return false;
-  }
-
   private boolean jj_3R_149()
  {
     if (jj_scan_token(FUNCTIONCALC)) return true;
@@ -5440,6 +5444,107 @@ n.image = Util.strip(n.image);
       if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
     }
     if (jj_3R_180()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_134()
+ {
+    if (jj_3R_150()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_133()
+ {
+    if (jj_3R_149()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_132()
+ {
+    if (jj_scan_token(RPARAN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_181()
+ {
+    if (jj_scan_token(IDENT)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_173()
+ {
+    if (jj_scan_token(IDENT)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_148()
+ {
+    if (jj_scan_token(FREQ)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_172()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(47)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(46)) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_147()
+ {
+    if (jj_scan_token(TIME)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_171()
+ {
+    if (jj_scan_token(DIV)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_152()
+ {
+    if (jj_scan_token(PLUS)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_146()
+ {
+    if (jj_scan_token(ANGLE)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_170()
+ {
+    if (jj_scan_token(STRING)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_145()
+ {
+    if (jj_scan_token(FLEX)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_169()
+ {
+    if (jj_3R_178()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_144()
+ {
+    if (jj_scan_token(ABSOLUTLENGTH)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_168()
+ {
+    if (jj_3R_150()) return true;
     return false;
   }
 
@@ -5460,79 +5565,9 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_173()
+  private boolean jj_3R_143()
  {
-    if (jj_scan_token(IDENT)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_172()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(47)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(46)) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_171()
- {
-    if (jj_scan_token(DIV)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_134()
- {
-    if (jj_3R_150()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_170()
- {
-    if (jj_scan_token(STRING)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_121()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(36)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(48)) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_133()
- {
-    if (jj_3R_149()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_169()
- {
-    if (jj_3R_178()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_132()
- {
-    if (jj_scan_token(RPARAN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_181()
- {
-    if (jj_scan_token(IDENT)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_168()
- {
-    if (jj_3R_150()) return true;
+    if (jj_scan_token(RELVIEWLENGTH)) return true;
     return false;
   }
 
@@ -5542,15 +5577,21 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_148()
+  private boolean jj_3R_139()
  {
-    if (jj_scan_token(FREQ)) return true;
+    if (jj_3R_135()) return true;
     return false;
   }
 
-  private boolean jj_3R_147()
+  private boolean jj_3R_142()
  {
-    if (jj_scan_token(TIME)) return true;
+    if (jj_scan_token(RELFONTLENGTH)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_141()
+ {
+    if (jj_scan_token(PERCENTAGE)) return true;
     return false;
   }
 
@@ -5589,78 +5630,6 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_146()
- {
-    if (jj_scan_token(ANGLE)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_145()
- {
-    if (jj_scan_token(FLEX)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_166()
- {
-    if (jj_scan_token(DIMEN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_144()
- {
-    if (jj_scan_token(ABSOLUTLENGTH)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_165()
- {
-    if (jj_scan_token(SPL)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_143()
- {
-    if (jj_scan_token(RELVIEWLENGTH)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_164()
- {
-    if (jj_scan_token(ST)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_139()
- {
-    if (jj_3R_135()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_142()
- {
-    if (jj_scan_token(RELFONTLENGTH)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_163()
- {
-    if (jj_scan_token(RESOLUTION)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_141()
- {
-    if (jj_scan_token(PERCENTAGE)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_162()
- {
-    if (jj_scan_token(FREQ)) return true;
-    return false;
-  }
-
   private boolean jj_3R_131()
  {
     Token xsp;
@@ -5695,15 +5664,14 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_161()
+  private boolean jj_3R_121()
  {
-    if (jj_scan_token(TIME)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_160()
- {
-    if (jj_scan_token(ANGLE)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(36)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(48)) return true;
+    }
     return false;
   }
 
@@ -5738,6 +5706,60 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3R_123()
+ {
+    if (jj_scan_token(ANY)) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
+    }
+    if (jj_3R_127()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_166()
+ {
+    if (jj_scan_token(DIMEN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_165()
+ {
+    if (jj_scan_token(SPL)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_164()
+ {
+    if (jj_scan_token(ST)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_163()
+ {
+    if (jj_scan_token(RESOLUTION)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_162()
+ {
+    if (jj_scan_token(FREQ)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_161()
+ {
+    if (jj_scan_token(TIME)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_160()
+ {
+    if (jj_scan_token(ANGLE)) return true;
+    return false;
+  }
+
   private boolean jj_3R_159()
  {
     if (jj_scan_token(FLEX)) return true;
@@ -5765,21 +5787,15 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_123()
- {
-    if (jj_scan_token(ANY)) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
-    }
-    if (jj_3R_127()) return true;
-    return false;
-  }
-
   private boolean jj_3R_156()
  {
     if (jj_scan_token(RELFONTLENGTH)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_126()
+ {
+    if (jj_scan_token(S)) return true;
     return false;
   }
 
@@ -5798,6 +5814,17 @@ n.image = Util.strip(n.image);
   private boolean jj_3R_153()
  {
     if (jj_3R_135()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_122()
+ {
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3R_126()) { jj_scanpos = xsp; break; }
+    }
+    if (jj_scan_token(MINUS)) return true;
     return false;
   }
 
@@ -5847,6 +5874,13 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3_5()
+ {
+    if (jj_3R_125()) return true;
+    if (jj_scan_token(LPARAN)) return true;
+    return false;
+  }
+
   private boolean jj_3R_177()
  {
     if (jj_scan_token(COMMA)) return true;
@@ -5868,48 +5902,17 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3R_182()
+ {
+    if (jj_3R_127()) return true;
+    return false;
+  }
+
   private boolean jj_3R_138()
  {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_177()) jj_scanpos = xsp;
-    return false;
-  }
-
-  private boolean jj_3R_126()
- {
-    if (jj_scan_token(S)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_122()
- {
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3R_126()) { jj_scanpos = xsp; break; }
-    }
-    if (jj_scan_token(MINUS)) return true;
-    return false;
-  }
-
-  private boolean jj_3_5()
- {
-    if (jj_3R_125()) return true;
-    if (jj_scan_token(LPARAN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_130()
- {
-    if (jj_3R_138()) return true;
-    if (jj_3R_129()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_182()
- {
-    if (jj_3R_127()) return true;
     return false;
   }
 
@@ -5922,6 +5925,13 @@ n.image = Util.strip(n.image);
       if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
     }
     if (jj_scan_token(DIV)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_130()
+ {
+    if (jj_3R_138()) return true;
+    if (jj_3R_129()) return true;
     return false;
   }
 

--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -4101,11 +4101,12 @@ setValue(new CssVolume(), exp, operator, n, SPL);
         }
       case DIMEN:{
         n = jj_consume_token(DIMEN);
-if ("0\\0".equals(n.image) //
+String dimen = n.image.trim();
+            if ("0\\0".equals(dimen) //
                 && ac.getTreatCssHacksAsWarnings()) {
-                ac.getFrame().addWarning("css-hack", n.image);
+                ac.getFrame().addWarning("css-hack", dimen);
             } else {
-                addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+                addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), dimen);
             }
         break;
         }
@@ -4352,11 +4353,12 @@ setValue(new CssVolume(), exp, operator, n, SPL);
         }
       case DIMEN:{
         n = jj_consume_token(DIMEN);
-if ("0\\0".equals(n.image) //
+String dimen = n.image.trim();
+            if ("0\\0".equals(dimen) //
                 && ac.getTreatCssHacksAsWarnings()) {
-                ac.getFrame().addWarning("css-hack", n.image);
+                ac.getFrame().addWarning("css-hack", dimen);
             } else {
-                addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+                addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), dimen);
             }
         break;
         }
@@ -5373,15 +5375,15 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_175()
- {
-    if (jj_scan_token(URL)) return true;
-    return false;
-  }
-
   private boolean jj_3R_140()
  {
     if (jj_scan_token(NUMBER)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_175()
+ {
+    if (jj_scan_token(URL)) return true;
     return false;
   }
 
@@ -5471,15 +5473,21 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3R_148()
+ {
+    if (jj_scan_token(FREQ)) return true;
+    return false;
+  }
+
   private boolean jj_3R_173()
  {
     if (jj_scan_token(IDENT)) return true;
     return false;
   }
 
-  private boolean jj_3R_148()
+  private boolean jj_3R_147()
  {
-    if (jj_scan_token(FREQ)) return true;
+    if (jj_scan_token(TIME)) return true;
     return false;
   }
 
@@ -5494,9 +5502,9 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_147()
+  private boolean jj_3R_146()
  {
-    if (jj_scan_token(TIME)) return true;
+    if (jj_scan_token(ANGLE)) return true;
     return false;
   }
 
@@ -5506,15 +5514,9 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_152()
+  private boolean jj_3R_145()
  {
-    if (jj_scan_token(PLUS)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_146()
- {
-    if (jj_scan_token(ANGLE)) return true;
+    if (jj_scan_token(FLEX)) return true;
     return false;
   }
 
@@ -5524,15 +5526,9 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_145()
+  private boolean jj_3R_152()
  {
-    if (jj_scan_token(FLEX)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_169()
- {
-    if (jj_3R_178()) return true;
+    if (jj_scan_token(PLUS)) return true;
     return false;
   }
 
@@ -5542,9 +5538,39 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3R_169()
+ {
+    if (jj_3R_178()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_143()
+ {
+    if (jj_scan_token(RELVIEWLENGTH)) return true;
+    return false;
+  }
+
   private boolean jj_3R_168()
  {
     if (jj_3R_150()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_139()
+ {
+    if (jj_3R_135()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_142()
+ {
+    if (jj_scan_token(RELFONTLENGTH)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_167()
+ {
+    if (jj_3R_149()) return true;
     return false;
   }
 
@@ -5565,33 +5591,43 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_143()
- {
-    if (jj_scan_token(RELVIEWLENGTH)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_167()
- {
-    if (jj_3R_149()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_139()
- {
-    if (jj_3R_135()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_142()
- {
-    if (jj_scan_token(RELFONTLENGTH)) return true;
-    return false;
-  }
-
   private boolean jj_3R_141()
  {
     if (jj_scan_token(PERCENTAGE)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_131()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_139()) jj_scanpos = xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_140()) {
+    jj_scanpos = xsp;
+    if (jj_3R_141()) {
+    jj_scanpos = xsp;
+    if (jj_3R_142()) {
+    jj_scanpos = xsp;
+    if (jj_3R_143()) {
+    jj_scanpos = xsp;
+    if (jj_3R_144()) {
+    jj_scanpos = xsp;
+    if (jj_3R_145()) {
+    jj_scanpos = xsp;
+    if (jj_3R_146()) {
+    jj_scanpos = xsp;
+    if (jj_3R_147()) {
+    jj_scanpos = xsp;
+    if (jj_3R_148()) return true;
+    }
+    }
+    }
+    }
+    }
+    }
+    }
+    }
     return false;
   }
 
@@ -5630,51 +5666,6 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_131()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_139()) jj_scanpos = xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_140()) {
-    jj_scanpos = xsp;
-    if (jj_3R_141()) {
-    jj_scanpos = xsp;
-    if (jj_3R_142()) {
-    jj_scanpos = xsp;
-    if (jj_3R_143()) {
-    jj_scanpos = xsp;
-    if (jj_3R_144()) {
-    jj_scanpos = xsp;
-    if (jj_3R_145()) {
-    jj_scanpos = xsp;
-    if (jj_3R_146()) {
-    jj_scanpos = xsp;
-    if (jj_3R_147()) {
-    jj_scanpos = xsp;
-    if (jj_3R_148()) return true;
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_121()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(36)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(48)) return true;
-    }
-    return false;
-  }
-
   private boolean jj_3R_127()
  {
     Token xsp;
@@ -5703,6 +5694,17 @@ n.image = Util.strip(n.image);
     xsp = jj_scanpos;
     if (jj_3R_128()) jj_scanpos = xsp;
     if (jj_scan_token(NUMBER)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_121()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(36)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(48)) return true;
+    }
     return false;
   }
 
@@ -5781,6 +5783,12 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3R_126()
+ {
+    if (jj_scan_token(S)) return true;
+    return false;
+  }
+
   private boolean jj_3R_157()
  {
     if (jj_scan_token(RELVIEWLENGTH)) return true;
@@ -5790,12 +5798,6 @@ n.image = Util.strip(n.image);
   private boolean jj_3R_156()
  {
     if (jj_scan_token(RELFONTLENGTH)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_126()
- {
-    if (jj_scan_token(S)) return true;
     return false;
   }
 
@@ -5811,12 +5813,6 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_153()
- {
-    if (jj_3R_135()) return true;
-    return false;
-  }
-
   private boolean jj_3R_122()
  {
     Token xsp;
@@ -5825,6 +5821,19 @@ n.image = Util.strip(n.image);
       if (jj_3R_126()) { jj_scanpos = xsp; break; }
     }
     if (jj_scan_token(MINUS)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_153()
+ {
+    if (jj_3R_135()) return true;
+    return false;
+  }
+
+  private boolean jj_3_5()
+ {
+    if (jj_3R_125()) return true;
+    if (jj_scan_token(LPARAN)) return true;
     return false;
   }
 
@@ -5874,10 +5883,9 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3_5()
+  private boolean jj_3R_182()
  {
-    if (jj_3R_125()) return true;
-    if (jj_scan_token(LPARAN)) return true;
+    if (jj_3R_127()) return true;
     return false;
   }
 
@@ -5899,12 +5907,6 @@ n.image = Util.strip(n.image);
       xsp = jj_scanpos;
       if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
     }
-    return false;
-  }
-
-  private boolean jj_3R_182()
- {
-    if (jj_3R_127()) return true;
     return false;
   }
 

--- a/org/w3c/css/parser/analyzer/CssParser.jj
+++ b/org/w3c/css/parser/analyzer/CssParser.jj
@@ -2399,7 +2399,13 @@ void term(CssExpression exp) :
         | n=<ST> { setValue(new CssSemitone(), exp, operator, n, ST); }
         | n=<SPL> { setValue(new CssVolume(), exp, operator, n, SPL); }
         | n=<DIMEN> {
-	    addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image); }
+	    if ("0\\0".equals(n.image) //
+		&& ac.getTreatVendorExtensionsAsWarnings()) {
+		ac.getFrame().addWarning("vendor-extension", n.image);
+	    } else {
+		addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+	    }
+        }
         ) 
       )
       | ( func=mathcalc() { setValue(func, exp, operator, null, FUNCTION); }
@@ -2467,7 +2473,13 @@ void mediaterm(CssExpression exp) :
     | n=<ST> { setValue(new CssSemitone(), exp, operator, n, ST); }
     | n=<SPL> { setValue(new CssVolume(), exp, operator, n, SPL); }
     | n=<DIMEN> {
-	  addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image); }
+	    if ("0\\0".equals(n.image) //
+		&& ac.getTreatVendorExtensionsAsWarnings()) {
+		ac.getFrame().addWarning("vendor-extension", n.image);
+	    } else {
+		addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+	    }
+    }
     | func=function() { setValue(func, exp, operator, null, FUNCTION); }
       ) ( <S> )* )
    | (( n=<STRING> { setValue(new CssString(), exp, operator, n, STRING); }

--- a/org/w3c/css/parser/analyzer/CssParser.jj
+++ b/org/w3c/css/parser/analyzer/CssParser.jj
@@ -2399,11 +2399,12 @@ void term(CssExpression exp) :
         | n=<ST> { setValue(new CssSemitone(), exp, operator, n, ST); }
         | n=<SPL> { setValue(new CssVolume(), exp, operator, n, SPL); }
         | n=<DIMEN> {
-	    if ("0\\0".equals(n.image) //
+	    String dimen = n.image.trim();
+	    if ("0\\0".equals(dimen) //
 		&& ac.getTreatCssHacksAsWarnings()) {
-		ac.getFrame().addWarning("css-hack", n.image);
+		ac.getFrame().addWarning("css-hack", dimen);
 	    } else {
-		addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+		addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), dimen);
 	    }
         }
         ) 
@@ -2473,11 +2474,12 @@ void mediaterm(CssExpression exp) :
     | n=<ST> { setValue(new CssSemitone(), exp, operator, n, ST); }
     | n=<SPL> { setValue(new CssVolume(), exp, operator, n, SPL); }
     | n=<DIMEN> {
-	    if ("0\\0".equals(n.image) //
+	    String dimen = n.image.trim();
+	    if ("0\\0".equals(dimen) //
 		&& ac.getTreatCssHacksAsWarnings()) {
-		ac.getFrame().addWarning("css-hack", n.image);
+		ac.getFrame().addWarning("css-hack", dimen);
 	    } else {
-		addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
+		addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), dimen);
 	    }
     }
     | func=function() { setValue(func, exp, operator, null, FUNCTION); }

--- a/org/w3c/css/parser/analyzer/CssParser.jj
+++ b/org/w3c/css/parser/analyzer/CssParser.jj
@@ -2400,8 +2400,8 @@ void term(CssExpression exp) :
         | n=<SPL> { setValue(new CssVolume(), exp, operator, n, SPL); }
         | n=<DIMEN> {
 	    if ("0\\0".equals(n.image) //
-		&& ac.getTreatVendorExtensionsAsWarnings()) {
-		ac.getFrame().addWarning("vendor-extension", n.image);
+		&& ac.getTreatCssHacksAsWarnings()) {
+		ac.getFrame().addWarning("css-hack", n.image);
 	    } else {
 		addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
 	    }
@@ -2474,8 +2474,8 @@ void mediaterm(CssExpression exp) :
     | n=<SPL> { setValue(new CssVolume(), exp, operator, n, SPL); }
     | n=<DIMEN> {
 	    if ("0\\0".equals(n.image) //
-		&& ac.getTreatVendorExtensionsAsWarnings()) {
-		ac.getFrame().addWarning("vendor-extension", n.image);
+		&& ac.getTreatCssHacksAsWarnings()) {
+		ac.getFrame().addWarning("css-hack", n.image);
 	    } else {
 		addError(new ParseException(ac.getMsg().getString("parser.unknown-dimension")), n.image);
 	    }

--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -302,6 +302,9 @@ warning.noothermedium : Properties for other media might not work for usermedium
 warning.vendor-extension : Property \u201C%s\u201D is an unknown vendor extension
 warning.vendor-ext-pseudo-class : \u201C%s\u201D is an unknown vendor extended pseudo-class
 warning.vendor-ext-pseudo-element : \u201C%s\u201D is an unknown vendor extended pseudo-element
+
+warning.css-hack : \u201C%s\u201D is a CSS hack
+
 # used by org.w3c.css.parser.AtRule*
 error.noatruleyet: Other @rules than @import are not supported by CSS1 \u201C%s\u201D
 # used by org.w3c.css.parser.analyzer.CssParser

--- a/org/w3c/css/util/Messages.properties.fr
+++ b/org/w3c/css/util/Messages.properties.fr
@@ -415,6 +415,8 @@ error.notforatsc: \u201C%s\u201D ne peut pas être utilisé pour le profil ATSC
 error.notfortv: \u201C%s\u201D ne peut pas être utilisé pour le profil TV
 error.notversion: \u201C%s\u201D ne peut pas être utilisé pour cette version CSS: \u201C%s\u201D
 
+warning.css-hack : \u201C%s\u201D est un hack CSS
+
 warning.atsc : il se peut que \u201C%s\u201D ne soit pas supporté par atsc-tv
 error.onlyATSC : cette fonction est seulement pour le @media atsc-tv
 


### PR DESCRIPTION
This change causes the `0\0` value to be handled as a vendor extension if the
option to treat vendor extensions as warnings is set.