### PR TITLE
Allow the user-select property & check it

### DIFF
--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -46,6 +46,9 @@ contain:                                org.w3c.css.properties.css3.CssContain
 # touch-action
 touch-action:                           org.w3c.css.properties.css3.CssTouchAction
 
+# user interface
+user-select:                            org.w3c.css.properties.css3.CssUserSelect
+
 # compositing
 background-blend-mode:                  org.w3c.css.properties.css3.CssBackgroundBlendMode
 isolation:                              org.w3c.css.properties.css3.CssIsolation

--- a/org/w3c/css/properties/CSS3SVGProperties.properties
+++ b/org/w3c/css/properties/CSS3SVGProperties.properties
@@ -88,6 +88,9 @@ contain:                                org.w3c.css.properties.css3.CssContain
 # touch-action
 touch-action:                           org.w3c.css.properties.css3.CssTouchAction
 
+# user interface
+user-select:                            org.w3c.css.properties.css3.CssUserSelect
+
 # compositing
 background-blend-mode:                  org.w3c.css.properties.css3.CssBackgroundBlendMode
 isolation:                              org.w3c.css.properties.css3.CssIsolation

--- a/org/w3c/css/properties/Media.properties
+++ b/org/w3c/css/properties/Media.properties
@@ -369,6 +369,7 @@ marker-end:                     handheld, print, projection, screen, tty, tv
 marker-mid:                     handheld, print, projection, screen, tty, tv
 lighting-color:                 handheld, print, projection, screen, tty, tv
 touch-action:                   handheld, print, projection, screen, tty, tv
+user-select:                    handheld, print, projection, screen, tty, tv
 
 
 # properties not yet implemented

--- a/org/w3c/css/properties/css/CssUserSelect.java
+++ b/org/w3c/css/properties/css/CssUserSelect.java
@@ -1,0 +1,112 @@
+// (c) COPYRIGHT MIT, ERCIM, Keio and Beihang, 2017.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssUserSelect extends CssProperty {
+
+	public CssValue value;
+
+	/**
+	 * Create a new CssUserSelect
+	 */
+	public CssUserSelect() {
+	}
+
+	/**
+	 * Creates a new CssUserSelect
+	 *
+	 * @param expression The expression for this property
+	 * @throws org.w3c.css.util.InvalidParamException
+	 *          Expressions are incorrect
+	 */
+	public CssUserSelect(ApplContext ac, CssExpression expression, //
+		boolean check) throws InvalidParamException {
+		throw new InvalidParamException("value",
+				expression.getValue().toString(),
+				getPropertyName(), ac);
+	}
+
+	public CssUserSelect(ApplContext ac, CssExpression expression)
+			throws InvalidParamException {
+		this(ac, expression, false);
+	}
+
+	/**
+	 * Returns the value of this property
+	 */
+	public Object get() {
+		return value;
+	}
+
+
+	/**
+	 * Returns the name of this property
+	 */
+	public final String getPropertyName() {
+		return "user-select";
+	}
+
+	/**
+	 * Returns true if this property is "softly" inherited
+	 * e.g. his value is equals to inherit
+	 */
+	public boolean isSoftlyInherited() {
+		return value.equals(inherit);
+	}
+
+	/**
+	 * Returns a string representation of the object.
+	 */
+	public String toString() {
+		return value.toString();
+	}
+
+	/**
+	 * Add this property to the CssStyle.
+	 *
+	 * @param style The CssStyle
+	 */
+	public void addToStyle(ApplContext ac, CssStyle style) {
+		Css3Style s = (Css3Style) style;
+		if (s.cssUserSelect != null) {
+			style.addRedefinitionWarning(ac, this);
+		}
+		s.cssUserSelect = this;
+	}
+
+
+	/**
+	 * Compares two properties for equality.
+	 *
+	 * @param property The other property.
+	 */
+	public boolean equals(CssProperty property) {
+		return (property instanceof CssUserSelect &&
+				value.equals(((CssUserSelect) property).value));
+	}
+
+
+	/**
+	 * Get this property in the style.
+	 *
+	 * @param style   The style where the property is
+	 * @param resolve if true, resolve the style to find this property
+	 */
+	public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+		if (resolve) {
+			return ((Css3Style) style).getUserSelect();
+		} else {
+			return ((Css3Style) style).cssUserSelect;
+		}
+	}
+}

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -180,6 +180,7 @@ import org.w3c.css.properties.css.CssTransitionDelay;
 import org.w3c.css.properties.css.CssTransitionDuration;
 import org.w3c.css.properties.css.CssTransitionProperty;
 import org.w3c.css.properties.css.CssTransitionTimingFunction;
+import org.w3c.css.properties.css.CssUserSelect;
 import org.w3c.css.properties.css.CssVoiceBalance;
 import org.w3c.css.properties.css.CssVoiceDuration;
 import org.w3c.css.properties.css.CssVoicePitch;
@@ -219,6 +220,7 @@ public class Css3Style extends ATSCStyle {
 
 	public CssWritingMode cssWritingMode;
 	public CssTouchAction cssTouchAction;
+	public CssUserSelect cssUserSelect;
 
 	public CssScrollSnapMarginBlockStart cssScrollSnapMarginBlockStart;
 	public CssScrollSnapMarginBlockEnd cssScrollSnapMarginBlockEnd;
@@ -455,6 +457,15 @@ public class Css3Style extends ATSCStyle {
 							style, selector);
 		}
 		return cssTouchAction;
+	}
+
+	public CssUserSelect getUserSelect() {
+		if (cssUserSelect == null) {
+			cssUserSelect =
+					(CssUserSelect) style.CascadingOrder(new CssUserSelect(),
+							style, selector);
+		}
+		return cssUserSelect;
 	}
 
 	public org.w3c.css.properties.css.counterstyle.CssSpeakAs getCounterStyleCssSpeakAs() {

--- a/org/w3c/css/properties/css3/CssUserSelect.java
+++ b/org/w3c/css/properties/css3/CssUserSelect.java
@@ -1,0 +1,95 @@
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2017.
+// Please first read the full copyright statement at:
+// https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssIdent;
+import org.w3c.css.values.CssTypes;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @spec https://www.w3.org/TR/2017/WD-css-ui-4-20171222/#propdef-user-select
+ */
+
+public class CssUserSelect extends org.w3c.css.properties.css.CssUserSelect {
+
+    public static final CssIdent auto = CssIdent.getIdent("auto");
+
+    public static final CssIdent[] allowed_values;
+
+    static {
+        int i = 0;
+        String[] _allowed_values = {"auto", "text", "none", "contain", "all"};
+        allowed_values = new CssIdent[_allowed_values.length];
+        i = 0;
+        for (String s : _allowed_values) {
+            allowed_values[i++] = CssIdent.getIdent(s);
+        }
+    }
+
+    public static CssIdent getAllowedIdent(CssIdent ident) {
+        for (CssIdent id : allowed_values) {
+            if (id.equals(ident)) {
+                return id;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Create a new CssUserSelect
+     */
+    public CssUserSelect() {
+        value = initial;
+    }
+
+    /**
+     * Create a new CssUserSelect
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Incorrect value
+     */
+    public CssUserSelect(ApplContext ac, CssExpression expression,
+            boolean check) throws InvalidParamException {
+
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+
+        setByUser();
+
+        CssValue val;
+
+        val = expression.getValue();
+
+        if (val.getType() == CssTypes.CSS_IDENT) {
+            CssIdent id = (CssIdent) val;
+            if (inherit.equals(id)) {
+                value = inherit;
+            } else {
+                value = getAllowedIdent(id);
+                if (value == null) {
+                    throw new InvalidParamException("value", val.toString(),
+                            getPropertyName(), ac);
+                }
+            }
+        } else {
+            throw new InvalidParamException("value", val.toString(),
+                    getPropertyName(), ac);
+        }
+        expression.next();
+    }
+
+    public CssUserSelect(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    public boolean isDefault() {
+        return ((value == auto) || (value == initial));
+    }
+}


### PR DESCRIPTION
This change makes the CSS checker recognize & check the `user-select` property.

The checking behavior conforms to the definition in Basic User Interface Module
Level 4 at https://www.w3.org/TR/2017/WD-css-ui-4-20171222/#propdef-user-select.

Fixes https://github.com/w3c/css-validator/issues/54. Thanks @nb000 & @cvrebert