### PR TITLE
Treat the 'zoom' property as a vendor extension

### DIFF
--- a/org/w3c/css/parser/CssPropertyFactory.java
+++ b/org/w3c/css/parser/CssPropertyFactory.java
@@ -32,6 +32,21 @@ import java.util.StringTokenizer;
  */
 public class CssPropertyFactory implements Cloneable {
 
+	private static final String[] NONSTANDARD_PROPERTIES = //
+		{"zoom"};
+
+	private static boolean isNonstandardProperty(String property) {
+		if (property.charAt(0) == '-' || property.charAt(0) == '_') {
+				return true;
+		}
+		for (String s : NONSTANDARD_PROPERTIES) {
+			if (s.equals(property)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	// all recognized properties are here.
 	private Utf8Properties properties;
 
@@ -284,7 +299,6 @@ public class CssPropertyFactory implements Cloneable {
 	}
 
 	private boolean isVendorExtension(String property) {
-		return property.length() > 0 &&
-				(property.charAt(0) == '-' || property.charAt(0) == '_');
+		return property.length() > 0 && isNonstandardProperty(property);
 	}
 }


### PR DESCRIPTION
This change causes the `zoom` property to be handled as a vendor extension if
the option to treat vendor extensions as warnings is set.

The change is implemented by providing a new hook in the code where the names of
any other commonly-used non-standard properties can be added later (if any other
than `zoom` ever end up being judged appropriate for similar special treatment).