### PR TITLE
Fix message bugs for selector after pseudo-element

### DIFF
--- a/org/w3c/css/selectors/PseudoClassSelector.java
+++ b/org/w3c/css/selectors/PseudoClassSelector.java
@@ -4,6 +4,8 @@
 // Please first read the full copyright statement in file COPYRIGHT.html
 package org.w3c.css.selectors;
 
+import java.util.Arrays;
+
 /**
  * PseudoClass<br />
  * Created: Sep 1, 2005 3:58:43 PM<br />
@@ -11,6 +13,10 @@ package org.w3c.css.selectors;
 public class PseudoClassSelector implements Selector {
 
 	String name;
+
+	private static final String[] USER_ACTION_CLASSES = {
+		"hover", "active", "focus"
+	};
 
 	/**
 	 * Creates a new pseudo-class given its name
@@ -49,6 +55,10 @@ public class PseudoClassSelector implements Selector {
 	 */
 	public boolean canApply(Selector other) {
 		return false;
+	}
+
+	public boolean isUserAction() {
+		return Arrays.asList(USER_ACTION_CLASSES).contains(this.name);
 	}
 
 }

--- a/org/w3c/css/selectors/SelectorsList.java
+++ b/org/w3c/css/selectors/SelectorsList.java
@@ -126,9 +126,12 @@ public class SelectorsList {
     public void addSelector(Selector selector) throws InvalidParamException {
         if (selectors.size() > 0) {
             Selector last = selectors.get(selectors.size() - 1);
-            if (last instanceof PseudoElementSelector) {
-                throw new InvalidParamException("pseudo-element", selector,
-                        ac.getMsg().getString(ac.getCssVersionString()), ac);
+            if (last instanceof PseudoElementSelector
+                    && !(selector instanceof PseudoClassSelector
+                            && ((PseudoClassSelector) selector)
+                                    .isUserAction())) {
+                throw new InvalidParamException("pseudo-element-not-last",
+                        selector, last, ac);
             }
         }
         selectors.add(selector);

--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -319,6 +319,7 @@ error.unknown: Unknown error
 
 # used by org.w3c.css.parser.CssSelectors
 error.pseudo-element: The pseudo-element \u201C%s\u201D can't appear here in the context \u201C%s\u201D
+error.pseudo-element-not-last: The selector \u201C%s\u201D can't appear after the pseudo-element selector \u201C%s\u201D
 error.pseudo-class: The pseudo-class .\u201C%s\u201D can't appear here in the HTML context \u201C%s\u201D
 error.pseudo: Unknown pseudo-element or pseudo-class \u201C%s\u201D
 error.id: ID selector #%s is invalid ! Only one ID selector can be specified in a simple selector: %s.


### PR DESCRIPTION
This change fixes a couple bugs in the error message that’s reported for the
case of a selector that appears after a pseudo-element selector, and adds a
method to check for user-action pseudo classes

The first bug fixed by this change is, given a case like `p::first-line.foo`,
the CSS checker previously would report the following message:

> The pseudo-element .foo can't appear here in the context CSS level <level>

That message was wrong for that case because `.foo` isn’t a pseudo-element.

So this change causes the checker to instead report the following message:

> The selector .foo can't appear after the pseudo-element selector ::first-line

The second bug fixed by the change is, given a case like `p::first-line:hover`,
the checker would emit the following message:

> The pseudo-element :hover can't appear here in the context CSS level <level>

That message is wrong for two reasons: the first reason it’s wrong is the same
reason as above: `:hover` isn’t a pseudo-element — it's a pseudo-class; and the
second reason it’s wrong is that the current CSS Selectors spec allows it:

> A pseudo-element may be immediately followed by any combination of the user
action pseudo-classes

https://www.w3.org/TR/2013/WD-selectors4-20130502/#pseudo-elements

So, for handling such cases, this change adds a method for checking whether or
not particular pseudo-class is a user-action pseudo-class.

That method enables a check to determine that no error should be reported for
`p::first-line:hover` (because `hover` is a user-action pseudo-class), while
still correctly reporting an error for `p::first-line:visited` (because
`visited`) isn’t a user-action pseudo-class).