### PR TITLE
Refine error message for malformed linear-gradient

### DIFF
--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -275,6 +275,9 @@ error.zero: only \u201C0\u201D can be a \u201C%s\u201D. You must put a unit afte
 warning.zero:  only \u201C0\u201D can be a \u201C%s\u201D. You must put a unit after your number
 warning.dynamic: dynamic values cannot be checked as an unitless number. Please qualify it with an unit.
 
+# used by org.w3c.css.values.CssImage
+error.linear-gradient-missing-to: The first argument to the \u201Clinear-gradient\u201D function should be \u201C%s\u201D, not \u201C%s\u201D
+
 #used by org.w3c.css.properties.CssColumnCount
 error.strictly-positive: \u201C%s\u201D is not valid, only values greater than /u201C0/u201D allowed.
 

--- a/org/w3c/css/util/Messages.properties.fr
+++ b/org/w3c/css/util/Messages.properties.fr
@@ -230,6 +230,9 @@ warning.direction: au lieu de 'direction' pour les éléments block-level il vau
 # used by org.w3c.css.properties.CssTextDecoration
 error.same-value: \u201C%s\u201D apparait deux fois
 
+# used by org.w3c.css.values.CssImage
+error.linear-gradient-missing-to: Le premier paramètre de la fonction \u201Clinear-gradient\u201D doit être \u201C%s\u201D, et non pas \u201C%s\u201D
+
 error.generic-family.quote: Les noms de familles génériques sont des mots-clefs, \
 ils doivent donc être sans guillemets.
 

--- a/org/w3c/css/values/CssImage.java
+++ b/org/w3c/css/values/CssImage.java
@@ -298,6 +298,12 @@ public class CssImage extends CssValue {
 							((new Character(op)).toString()), ac);
 				}
 			}
+			if (top.equals(ident) || bottom.equals(ident)
+				|| left.equals(ident) || right.equals(ident)) {
+					throw new InvalidParamException( //
+						"linear-gradient-missing-to",
+						"to " + ident, ident, ac);
+			}
 		}
 		// now we a list of at least two color stops.
 		ArrayList<CssValue> stops = parseColorStops(exp, ac);


### PR DESCRIPTION
Given a case like the following:

> background:linear-gradient(top, #dd5959 0%,#c15252 100%)

...this change causes the checker to emit the following message:

> The first argument to the linear-gradient function should be “to top”, not “top”

That message is more helpful to users in fixing the cause of the problem than
the message reported prior to this change, which was the following:

> “top” is not a color value