### PR TITLE
Make CSS3+SVG the default profile

### DIFF
--- a/org/w3c/css/css/CssValidator.java
+++ b/org/w3c/css/css/CssValidator.java
@@ -54,12 +54,12 @@ public class CssValidator {
      */
     public CssValidator() {
         params = new HashMap<String, String>();
-        params.put("profile", CssVersion.getDefault().toString());
+        params.put("profile", "css3svg");
         params.put("medium", "all");
         params.put("output", "text");
         params.put("lang", "en");
         params.put("warning", "2");
-        params.put("vextwarning", "false");
+        params.put("vextwarning", "true");
     }
 
     public CssValidator(String profile, String medium, String lang, int warninglevel, boolean vextwarning, boolean followlinks) {
@@ -103,7 +103,7 @@ public class CssValidator {
             System.out.println("\t-profile PROFILE, --profile=PROFILE");
             System.out.println("\t\tChecks the Stylesheet against PROFILE");
             System.out.println("\t\tPossible values for PROFILE are css1, " +
-                    "css2, css21, css3 (default), css3svg, svg, svgbasic, svgtiny, " +
+                    "css2, css21, css3, css3svg (default), svg, svgbasic, svgtiny, " +
                     "atsc-tv, mobile, tv");
             System.out.println("\t-medium MEDIUM, --medium=MEDIUM");
             System.out.println("\t\tChecks the Stylesheet using the medium MEDIUM");

--- a/org/w3c/css/index/validator.vm
+++ b/org/w3c/css/index/validator.vm
@@ -14,8 +14,8 @@
         <option value="css1">$css1</option>
         <option value="css2">$css2</option>
         <option value="css21">$css21</option>
-        <option selected="selected" value="css3">$css3</option>
-        <option value="css3svg">$css3svg</option>
+        <option value="css3">$css3</option>
+        <option selected="selected" value="css3svg">$css3svg</option>
         <option value="svg">$svg</option>
         <option value="svgbasic">$svgbasic</option>
         <option value="svgtiny">$svgtiny</option>  

--- a/validator.html.bg
+++ b/validator.html.bg
@@ -54,8 +54,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.cs
+++ b/validator.html.cs
@@ -54,8 +54,8 @@
         <option value="css1">CSS Úroveň 1</option>
         <option value="css2">CSS Úroveň 2</option>
         <option value="css21">CSS Úroveň 2.1</option>
-        <option selected="selected" value="css3">CSS Úroveň 3</option>
-        <option value="css3svg">CSS Úroveň 3 + SVG</option>
+        <option value="css3">CSS Úroveň 3</option>
+        <option selected="selected" value="css3svg">CSS Úroveň 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG základní</option>
         <option value="svgtiny">SVG malý</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS Úroveň 1</option>
         <option value="css2">CSS Úroveň 2</option>
         <option value="css21">CSS Úroveň 2.1</option>
-        <option selected="selected" value="css3">CSS Úroveň 3</option>
-        <option value="css3svg">CSS Úroveň 3 + SVG</option>
+        <option value="css3">CSS Úroveň 3</option>
+        <option selected="selected" value="css3svg">CSS Úroveň 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG základní</option>
         <option value="svgtiny">SVG malý</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS Úroveň 1</option>
         <option value="css2">CSS Úroveň 2</option>
         <option value="css21">CSS Úroveň 2.1</option>
-        <option selected="selected" value="css3">CSS Úroveň 3</option>
-        <option value="css3svg">CSS Úroveň 3 + SVG</option>
+        <option value="css3">CSS Úroveň 3</option>
+        <option selected="selected" value="css3svg">CSS Úroveň 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG základní</option>
         <option value="svgtiny">SVG malý</option>  

--- a/validator.html.de
+++ b/validator.html.de
@@ -54,8 +54,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.el
+++ b/validator.html.el
@@ -54,8 +54,8 @@
         <option value="css1">Επίπεδο 1 CSS</option>
         <option value="css2">Επίπεδο 2 CSS</option>
         <option value="css21">Επίπεδο 2.1 CSS</option>
-        <option selected="selected" value="css3">Επίπεδο 3 CSS</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">Επίπεδο 3 CSS</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">Βασικό SVG</option>
         <option value="svgtiny">μικρό SVG</option>  
@@ -144,8 +144,8 @@
         <option value="css1">Επίπεδο 1 CSS</option>
         <option value="css2">Επίπεδο 2 CSS</option>
         <option value="css21">Επίπεδο 2.1 CSS</option>
-        <option selected="selected" value="css3">Επίπεδο 3 CSS</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">Επίπεδο 3 CSS</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">Βασικό SVG</option>
         <option value="svgtiny">μικρό SVG</option>  
@@ -234,8 +234,8 @@
         <option value="css1">Επίπεδο 1 CSS</option>
         <option value="css2">Επίπεδο 2 CSS</option>
         <option value="css21">Επίπεδο 2.1 CSS</option>
-        <option selected="selected" value="css3">Επίπεδο 3 CSS</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">Επίπεδο 3 CSS</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">Βασικό SVG</option>
         <option value="svgtiny">μικρό SVG</option>  

--- a/validator.html.en
+++ b/validator.html.en
@@ -54,8 +54,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.es
+++ b/validator.html.es
@@ -54,8 +54,8 @@
         <option value="css1">CSS versión 1</option>
         <option value="css2">CSS versión 2</option>
         <option value="css21">CSS versión 2.1</option>
-        <option selected="selected" value="css3">CSS versión 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS versión 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Básico</option>
         <option value="svgtiny">SVG Reducido</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS versión 1</option>
         <option value="css2">CSS versión 2</option>
         <option value="css21">CSS versión 2.1</option>
-        <option selected="selected" value="css3">CSS versión 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS versión 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Básico</option>
         <option value="svgtiny">SVG Reducido</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS versión 1</option>
         <option value="css2">CSS versión 2</option>
         <option value="css21">CSS versión 2.1</option>
-        <option selected="selected" value="css3">CSS versión 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS versión 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Básico</option>
         <option value="svgtiny">SVG Reducido</option>  

--- a/validator.html.fa
+++ b/validator.html.fa
@@ -54,8 +54,8 @@
         <option value="css1">سطح 1 CSS</option>
         <option value="css2">سطح 2 CSS</option>
         <option value="css21">سطح 2.1 CSS</option>
-        <option selected="selected" value="css3">سطح 3 CSS</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">سطح 3 CSS</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">بیسیک SVG</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">سطح 1 CSS</option>
         <option value="css2">سطح 2 CSS</option>
         <option value="css21">سطح 2.1 CSS</option>
-        <option selected="selected" value="css3">سطح 3 CSS</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">سطح 3 CSS</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">بیسیک SVG</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">سطح 1 CSS</option>
         <option value="css2">سطح 2 CSS</option>
         <option value="css21">سطح 2.1 CSS</option>
-        <option selected="selected" value="css3">سطح 3 CSS</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">سطح 3 CSS</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">بیسیک SVG</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.fr
+++ b/validator.html.fr
@@ -54,8 +54,8 @@
         <option value="css1">CSS niveau 1</option>
         <option value="css2">CSS niveau 2</option>
         <option value="css21">CSS niveau 2.1</option>
-        <option selected="selected" value="css3">CSS niveau 3</option>
-        <option value="css3svg">CSS niveau 3 + SVG</option>
+        <option value="css3">CSS niveau 3</option>
+        <option selected="selected" value="css3svg">CSS niveau 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS niveau 1</option>
         <option value="css2">CSS niveau 2</option>
         <option value="css21">CSS niveau 2.1</option>
-        <option selected="selected" value="css3">CSS niveau 3</option>
-        <option value="css3svg">CSS niveau 3 + SVG</option>
+        <option value="css3">CSS niveau 3</option>
+        <option selected="selected" value="css3svg">CSS niveau 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS niveau 1</option>
         <option value="css2">CSS niveau 2</option>
         <option value="css21">CSS niveau 2.1</option>
-        <option selected="selected" value="css3">CSS niveau 3</option>
-        <option value="css3svg">CSS niveau 3 + SVG</option>
+        <option value="css3">CSS niveau 3</option>
+        <option selected="selected" value="css3svg">CSS niveau 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.hi
+++ b/validator.html.hi
@@ -54,8 +54,8 @@
         <option value="css1">CSS स्तर 1</option>
         <option value="css2">CSS स्तर 2</option>
         <option value="css21">CSS स्तर 2.1</option>
-        <option selected="selected" value="css3">CSS स्तर 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS स्तर 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG बुनियादी</option>
         <option value="svgtiny">SVG छोटे</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS स्तर 1</option>
         <option value="css2">CSS स्तर 2</option>
         <option value="css21">CSS स्तर 2.1</option>
-        <option selected="selected" value="css3">CSS स्तर 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS स्तर 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG बुनियादी</option>
         <option value="svgtiny">SVG छोटे</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS स्तर 1</option>
         <option value="css2">CSS स्तर 2</option>
         <option value="css21">CSS स्तर 2.1</option>
-        <option selected="selected" value="css3">CSS स्तर 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS स्तर 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG बुनियादी</option>
         <option value="svgtiny">SVG छोटे</option>  

--- a/validator.html.hu
+++ b/validator.html.hu
@@ -54,8 +54,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS level 1</option>
         <option value="css2">CSS level 2</option>
         <option value="css21">CSS level 2.1</option>
-        <option selected="selected" value="css3">CSS level 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS level 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.it
+++ b/validator.html.it
@@ -54,8 +54,8 @@
         <option value="css1">CSS versione 1</option>
         <option value="css2">CSS versione 2</option>
         <option value="css21">CSS versione 2.1</option>
-        <option selected="selected" value="css3">CSS versione 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS versione 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS versione 1</option>
         <option value="css2">CSS versione 2</option>
         <option value="css21">CSS versione 2.1</option>
-        <option selected="selected" value="css3">CSS versione 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS versione 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS versione 1</option>
         <option value="css2">CSS versione 2</option>
         <option value="css21">CSS versione 2.1</option>
-        <option selected="selected" value="css3">CSS versione 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS versione 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.ja
+++ b/validator.html.ja
@@ -54,8 +54,8 @@
         <option value="css1">CSS レベル 1</option>
         <option value="css2">CSS レベル 2</option>
         <option value="css21">CSS レベル 2.1</option>
-        <option selected="selected" value="css3">CSS レベル 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS レベル 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS レベル 1</option>
         <option value="css2">CSS レベル 2</option>
         <option value="css21">CSS レベル 2.1</option>
-        <option selected="selected" value="css3">CSS レベル 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS レベル 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS レベル 1</option>
         <option value="css2">CSS レベル 2</option>
         <option value="css21">CSS レベル 2.1</option>
-        <option selected="selected" value="css3">CSS レベル 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS レベル 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.ko
+++ b/validator.html.ko
@@ -54,8 +54,8 @@
         <option value="css1">CSS 레벨 1</option>
         <option value="css2">CSS 레벨 2</option>
         <option value="css21">CSS 레벨 2.1</option>
-        <option selected="selected" value="css3">CSS 레벨 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS 레벨 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS 레벨 1</option>
         <option value="css2">CSS 레벨 2</option>
         <option value="css21">CSS 레벨 2.1</option>
-        <option selected="selected" value="css3">CSS 레벨 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS 레벨 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS 레벨 1</option>
         <option value="css2">CSS 레벨 2</option>
         <option value="css21">CSS 레벨 2.1</option>
-        <option selected="selected" value="css3">CSS 레벨 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS 레벨 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  

--- a/validator.html.nl
+++ b/validator.html.nl
@@ -54,8 +54,8 @@
         <option value="css1">CSS versie 1</option>
         <option value="css2">CSS versie 2</option>
         <option value="css21">CSS versie 2.1</option>
-        <option selected="selected" value="css3">CSS versie 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS versie 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS versie 1</option>
         <option value="css2">CSS versie 2</option>
         <option value="css21">CSS versie 2.1</option>
-        <option selected="selected" value="css3">CSS versie 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS versie 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS versie 1</option>
         <option value="css2">CSS versie 2</option>
         <option value="css21">CSS versie 2.1</option>
-        <option selected="selected" value="css3">CSS versie 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS versie 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.pl-PL
+++ b/validator.html.pl-PL
@@ -54,8 +54,8 @@
         <option value="css1">CSS wersja 1</option>
         <option value="css2">CSS wersja 2</option>
         <option value="css21">CSS wersja 2.1</option>
-        <option selected="selected" value="css3">CSS wersja 3</option>
-        <option value="css3svg">CSS wersja 3 + SVG</option>
+        <option value="css3">CSS wersja 3</option>
+        <option selected="selected" value="css3svg">CSS wersja 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS wersja 1</option>
         <option value="css2">CSS wersja 2</option>
         <option value="css21">CSS wersja 2.1</option>
-        <option selected="selected" value="css3">CSS wersja 3</option>
-        <option value="css3svg">CSS wersja 3 + SVG</option>
+        <option value="css3">CSS wersja 3</option>
+        <option selected="selected" value="css3svg">CSS wersja 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS wersja 1</option>
         <option value="css2">CSS wersja 2</option>
         <option value="css21">CSS wersja 2.1</option>
-        <option selected="selected" value="css3">CSS wersja 3</option>
-        <option value="css3svg">CSS wersja 3 + SVG</option>
+        <option value="css3">CSS wersja 3</option>
+        <option selected="selected" value="css3svg">CSS wersja 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.pt-BR
+++ b/validator.html.pt-BR
@@ -54,8 +54,8 @@
         <option value="css1">CSS nível 1</option>
         <option value="css2">CSS nível 2</option>
         <option value="css21">CSS nível 2.1</option>
-        <option selected="selected" value="css3">CSS nível 3</option>
-        <option value="css3svg">CSS nível 3 + SVG</option>
+        <option value="css3">CSS nível 3</option>
+        <option selected="selected" value="css3svg">CSS nível 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS nível 1</option>
         <option value="css2">CSS nível 2</option>
         <option value="css21">CSS nível 2.1</option>
-        <option selected="selected" value="css3">CSS nível 3</option>
-        <option value="css3svg">CSS nível 3 + SVG</option>
+        <option value="css3">CSS nível 3</option>
+        <option selected="selected" value="css3svg">CSS nível 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS nível 1</option>
         <option value="css2">CSS nível 2</option>
         <option value="css21">CSS nível 2.1</option>
-        <option selected="selected" value="css3">CSS nível 3</option>
-        <option value="css3svg">CSS nível 3 + SVG</option>
+        <option value="css3">CSS nível 3</option>
+        <option selected="selected" value="css3svg">CSS nível 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  

--- a/validator.html.ro
+++ b/validator.html.ro
@@ -54,8 +54,8 @@
         <option value="css1">CSS nivel 1</option>
         <option value="css2">CSS nivel 2</option>
         <option value="css21">CSS nivel 2.1</option>
-        <option selected="selected" value="css3">CSS nivel 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS nivel 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG mic</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS nivel 1</option>
         <option value="css2">CSS nivel 2</option>
         <option value="css21">CSS nivel 2.1</option>
-        <option selected="selected" value="css3">CSS nivel 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS nivel 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG mic</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS nivel 1</option>
         <option value="css2">CSS nivel 2</option>
         <option value="css21">CSS nivel 2.1</option>
-        <option selected="selected" value="css3">CSS nivel 3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS nivel 3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG mic</option>  

--- a/validator.html.ru
+++ b/validator.html.ru
@@ -54,8 +54,8 @@
         <option value="css1">CSS1</option>
         <option value="css2">CSS2</option>
         <option value="css21">CSS2.1</option>
-        <option selected="selected" value="css3">CSS3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS1</option>
         <option value="css2">CSS2</option>
         <option value="css21">CSS2.1</option>
-        <option selected="selected" value="css3">CSS3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS1</option>
         <option value="css2">CSS2</option>
         <option value="css21">CSS2.1</option>
-        <option selected="selected" value="css3">CSS3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.sv
+++ b/validator.html.sv
@@ -54,8 +54,8 @@
         <option value="css1">CSS nivå 1</option>
         <option value="css2">CSS nivå 2</option>
         <option value="css21">CSS nivå 2.1</option>
-        <option selected="selected" value="css3">CSS nivå 3</option>
-        <option value="css3svg">CSS nivå 3 + SVG</option>
+        <option value="css3">CSS nivå 3</option>
+        <option selected="selected" value="css3svg">CSS nivå 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS nivå 1</option>
         <option value="css2">CSS nivå 2</option>
         <option value="css21">CSS nivå 2.1</option>
-        <option selected="selected" value="css3">CSS nivå 3</option>
-        <option value="css3svg">CSS nivå 3 + SVG</option>
+        <option value="css3">CSS nivå 3</option>
+        <option selected="selected" value="css3svg">CSS nivå 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS nivå 1</option>
         <option value="css2">CSS nivå 2</option>
         <option value="css21">CSS nivå 2.1</option>
-        <option selected="selected" value="css3">CSS nivå 3</option>
-        <option value="css3svg">CSS nivå 3 + SVG</option>
+        <option value="css3">CSS nivå 3</option>
+        <option selected="selected" value="css3svg">CSS nivå 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  

--- a/validator.html.uk
+++ b/validator.html.uk
@@ -54,8 +54,8 @@
         <option value="css1">CSS1</option>
         <option value="css2">CSS2</option>
         <option value="css21">CSS2.1</option>
-        <option selected="selected" value="css3">CSS3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS1</option>
         <option value="css2">CSS2</option>
         <option value="css21">CSS2.1</option>
-        <option selected="selected" value="css3">CSS3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS1</option>
         <option value="css2">CSS2</option>
         <option value="css21">CSS2.1</option>
-        <option selected="selected" value="css3">CSS3</option>
-        <option value="css3svg">CSS Level 3 + SVG</option>
+        <option value="css3">CSS3</option>
+        <option selected="selected" value="css3svg">CSS Level 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG tiny</option>  

--- a/validator.html.zh-cn
+++ b/validator.html.zh-cn
@@ -54,8 +54,8 @@
         <option value="css1">CSS 版本 1</option>
         <option value="css2">CSS 版本 2</option>
         <option value="css21">CSS 版本 2.1</option>
-        <option selected="selected" value="css3">CSS 版本 3</option>
-        <option value="css3svg">CSS 版本 3 + SVG</option>
+        <option value="css3">CSS 版本 3</option>
+        <option selected="selected" value="css3svg">CSS 版本 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  
@@ -144,8 +144,8 @@
         <option value="css1">CSS 版本 1</option>
         <option value="css2">CSS 版本 2</option>
         <option value="css21">CSS 版本 2.1</option>
-        <option selected="selected" value="css3">CSS 版本 3</option>
-        <option value="css3svg">CSS 版本 3 + SVG</option>
+        <option value="css3">CSS 版本 3</option>
+        <option selected="selected" value="css3svg">CSS 版本 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  
@@ -234,8 +234,8 @@
         <option value="css1">CSS 版本 1</option>
         <option value="css2">CSS 版本 2</option>
         <option value="css21">CSS 版本 2.1</option>
-        <option selected="selected" value="css3">CSS 版本 3</option>
-        <option value="css3svg">CSS 版本 3 + SVG</option>
+        <option value="css3">CSS 版本 3</option>
+        <option selected="selected" value="css3svg">CSS 版本 3 + SVG</option>
         <option value="svg">SVG</option>
         <option value="svgbasic">SVG Basic</option>
         <option value="svgtiny">SVG Tiny</option>  


### PR DESCRIPTION
This change makes the CSS3 + SVG profile the default profile in the Web UI and
in command-line checker. It also sets the TreatVendorExtensionsAsWarnings option
for the command-line checker to “true” by default (which the same default the
Web UI already uses).