### PR TITLE
Fix the fact that some parse errors went missing after PR #112

### DIFF
--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -6134,14 +6134,7 @@ n.image = Util.strip(n.image);
 	 }
 	 token = oldToken;
 	 jj_kind = kind;
-	 if (kind == LBRACE) {
-	   if (ac.getTreatCssHacksAsWarnings()) {
-		ac.getFrame().addWarning("css-hack", skipStatement());
-	   } else {
-		addError(generateParseException(), skipStatement());
-	   }
-	 }
-	 return token;
+	 throw generateParseException();
   }
 
   @SuppressWarnings("serial")

--- a/org/w3c/css/parser/analyzer/patch.star-property-hack
+++ b/org/w3c/css/parser/analyzer/patch.star-property-hack
@@ -1,18 +1,25 @@
 --- CssParser.java
 +++ CssParser.java
-@@ -6134,7 +6135,14 @@ n.image = Util.strip(n.image);
- 	 }
- 	 token = oldToken;
- 	 jj_kind = kind;
--	 throw generateParseException();
-+	 if (kind == LBRACE) {
-+	   if (ac.getTreatCssHacksAsWarnings()) {
-+		ac.getFrame().addWarning("css-hack", skipStatement());
-+	   } else {
-+		addError(generateParseException(), skipStatement());
-+	   }
-+	 }
-+	 return token;
-   }
- 
-   @SuppressWarnings("serial")
+***************
+*** 6134,6140 ****
+  	 }
+  	 token = oldToken;
+  	 jj_kind = kind;
+! 	 throw generateParseException();
+    }
+  
+    @SuppressWarnings("serial")
+--- 6134,6146 ----
+  	 }
+  	 token = oldToken;
+  	 jj_kind = kind;
+! 	 if (kind == LBRACE) {
+! 	   if (ac.getTreatCssHacksAsWarnings()) {
+! 		ac.getFrame().addWarning("css-hack", skipStatement());
+! 		return token;
+! 	   } 
+! 	 }
+! 	throw generateParseException();
+    }
+  
+    @SuppressWarnings("serial")


### PR DESCRIPTION
(cf.  a8857e08416963d37bdb3d526e9148af88459922 )  
example:

```
body {
text-align center
}
```