### PR TITLE
Fix regression due to “star property hack” change

### DIFF
--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -6134,6 +6134,9 @@ n.image = Util.strip(n.image);
 	 }
 	 token = oldToken;
 	 jj_kind = kind;
+	 if (kind == COLON) {
+		throw generateParseException();
+	 }
 	 if (kind == LBRACE) {
 	   if (ac.getTreatCssHacksAsWarnings()) {
 		ac.getFrame().addWarning("css-hack", skipStatement());
@@ -6341,4 +6344,5 @@ n.image = Util.strip(n.image);
 	 int arg;
 	 JJCalls next;
   }
+
 }

--- a/org/w3c/css/parser/analyzer/patch.star-property-hack
+++ b/org/w3c/css/parser/analyzer/patch.star-property-hack
@@ -1,10 +1,13 @@
---- CssParser.java
-+++ CssParser.java
-@@ -6134,7 +6135,14 @@ n.image = Util.strip(n.image);
+--- CssParser.java	2018-01-08 07:34:31.629378071 +0900
++++ CssParser.java	2018-01-08 07:34:08.613652761 +0900
+@@ -6134,7 +6134,17 @@
  	 }
  	 token = oldToken;
  	 jj_kind = kind;
 -	 throw generateParseException();
++	 if (kind == COLON) {
++		throw generateParseException();
++	 }
 +	 if (kind == LBRACE) {
 +	   if (ac.getTreatCssHacksAsWarnings()) {
 +		ac.getFrame().addWarning("css-hack", skipStatement());


### PR DESCRIPTION
This change is a follow-up to a previous change made to cause special-case handling of instances of the “star property hack”. That change inadvertently regressed error reporting for cases like `a { text-align center }` — i.e., missing a colon between the property name and value. This change fixes that.

This is an alternative to PR #145 (that instead reverts the entire original “star property hack” change).
  