### PR TITLE
Make parser handle “star property hack” and related hacks

### DIFF
--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -665,7 +665,7 @@ String skip = charsetToken +
       case PSEUDOELEMENT_SYM:
       case CLASS:
       case FUNCTIONNOT:
-      case 106:{
+      case 107:{
         ruleSet();
         break;
         }
@@ -1045,7 +1045,7 @@ String media = getAtRule().toString();
         case PSEUDOELEMENT_SYM:
         case CLASS:
         case FUNCTIONNOT:
-        case 106:{
+        case 107:{
           ;
           break;
           }
@@ -2441,22 +2441,175 @@ connector = ' ' ;
  * @exception ParseException exception during the parse
  */
   final public String property() throws ParseException {Token n;
-    n = jj_consume_token(IDENT);
-    label_74:
-    while (true) {
+ Token hack= null;
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case PLUS:
+    case GREATER:
+    case COMMA:
+    case TILDE:
+    case IDENT:
+    case EQ:
+    case DIV:
+    case LBRACKET:
+    case RBRACKET:
+    case ANY:
+    case LPARAN:
+    case RPARAN:
+    case COLON:
+    case 106:{
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-      case S:{
-        ;
+      case PLUS:
+      case GREATER:
+      case COMMA:
+      case TILDE:
+      case EQ:
+      case DIV:
+      case LBRACKET:
+      case RBRACKET:
+      case ANY:
+      case LPARAN:
+      case RPARAN:
+      case COLON:
+      case 106:{
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case 106:{
+          hack = jj_consume_token(106);
+          break;
+          }
+        case ANY:{
+          hack = jj_consume_token(ANY);
+          break;
+          }
+        case EQ:{
+          hack = jj_consume_token(EQ);
+          break;
+          }
+        case RBRACKET:{
+          hack = jj_consume_token(RBRACKET);
+          break;
+          }
+        case LBRACKET:{
+          hack = jj_consume_token(LBRACKET);
+          break;
+          }
+        case LPARAN:{
+          hack = jj_consume_token(LPARAN);
+          break;
+          }
+        case RPARAN:{
+          hack = jj_consume_token(RPARAN);
+          break;
+          }
+        case COLON:{
+          hack = jj_consume_token(COLON);
+          break;
+          }
+        case TILDE:{
+          hack = jj_consume_token(TILDE);
+          break;
+          }
+        case PLUS:{
+          hack = jj_consume_token(PLUS);
+          break;
+          }
+        case COMMA:{
+          hack = jj_consume_token(COMMA);
+          break;
+          }
+        case GREATER:{
+          hack = jj_consume_token(GREATER);
+          break;
+          }
+        case DIV:{
+          hack = jj_consume_token(DIV);
+          break;
+          }
+        default:
+          jj_la1[94] = jj_gen;
+          jj_consume_token(-1);
+          throw new ParseException();
+        }
         break;
         }
       default:
-        jj_la1[94] = jj_gen;
-        break label_74;
+        jj_la1[95] = jj_gen;
+        ;
       }
-      jj_consume_token(S);
-    }
+      n = jj_consume_token(IDENT);
+      label_74:
+      while (true) {
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case S:{
+          ;
+          break;
+          }
+        default:
+          jj_la1[96] = jj_gen;
+          break label_74;
+        }
+        jj_consume_token(S);
+      }
 currentProperty = convertIdent(n.image);
-                         {if ("" != null) return currentProperty;}
+                 if (hack != null && !"".equals(hack)) {
+                   String hackp = hack.image+currentProperty;
+                   if (ac.getTreatCssHacksAsWarnings()) {
+                     ac.getFrame().addWarning("css-hack", hackp);
+                     {if ("" != null) return null;}
+                   } else {
+                     {if (true) throw new ParseException(String.format(ac.getMsg().getString("warning.css-hack"), hackp));}
+                   }
+                }
+                {if ("" != null) return currentProperty;}
+      break;
+      }
+    case HASHIDENT:
+    case ATKEYWORD:
+    case CLASS:{
+      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+      case HASHIDENT:{
+        n = jj_consume_token(HASHIDENT);
+        break;
+        }
+      case CLASS:{
+        n = jj_consume_token(CLASS);
+        break;
+        }
+      case ATKEYWORD:{
+        n = jj_consume_token(ATKEYWORD);
+        break;
+        }
+      default:
+        jj_la1[97] = jj_gen;
+        jj_consume_token(-1);
+        throw new ParseException();
+      }
+if (ac.getTreatCssHacksAsWarnings()) {
+                              ac.getFrame().addWarning("css-hack", n.image);
+                              // should we continue and validate the content, or skip ?
+                              currentProperty = convertIdent(n.image).substring(1);
+                              {if ("" != null) return null;}
+         }
+        {if (true) throw new ParseException(String.format(ac.getMsg().getString("warning.css-hack"), n.image));}
+      label_75:
+      while (true) {
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case S:{
+          ;
+          break;
+          }
+        default:
+          jj_la1[98] = jj_gen;
+          break label_75;
+        }
+        jj_consume_token(S);
+      }
+      break;
+      }
+    default:
+      jj_la1[99] = jj_gen;
+      jj_consume_token(-1);
+      throw new ParseException();
+    }
     throw new Error("Missing return statement in function");
   }
 
@@ -2472,7 +2625,7 @@ currentProperty = convertIdent(n.image);
 if (contextual != null) {
                     context_set.add(contextual);
                 }
-      label_75:
+      label_76:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case COMMA:{
@@ -2480,11 +2633,11 @@ if (contextual != null) {
           break;
           }
         default:
-          jj_la1[95] = jj_gen;
-          break label_75;
+          jj_la1[100] = jj_gen;
+          break label_76;
         }
         jj_consume_token(COMMA);
-        label_76:
+        label_77:
         while (true) {
           switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
           case S:{
@@ -2492,8 +2645,8 @@ if (contextual != null) {
             break;
             }
           default:
-            jj_la1[96] = jj_gen;
-            break label_76;
+            jj_la1[101] = jj_gen;
+            break label_77;
           }
           jj_consume_token(S);
         }
@@ -2504,21 +2657,6 @@ if (contextual != null) {
       }
       jj_consume_token(LBRACE);
 validSelector = (context_set.size() > 0);
-      label_77:
-      while (true) {
-        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-        case S:{
-          ;
-          break;
-          }
-        default:
-          jj_la1[97] = jj_gen;
-          break label_77;
-        }
-        jj_consume_token(S);
-      }
-      value_set = declarations();
-      jj_consume_token(RBRACE);
       label_78:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -2527,8 +2665,23 @@ validSelector = (context_set.size() > 0);
           break;
           }
         default:
-          jj_la1[98] = jj_gen;
+          jj_la1[102] = jj_gen;
           break label_78;
+        }
+        jj_consume_token(S);
+      }
+      value_set = declarations();
+      jj_consume_token(RBRACE);
+      label_79:
+      while (true) {
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case S:{
+          ;
+          break;
+          }
+        default:
+          jj_la1[103] = jj_gen;
+          break label_79;
         }
         jj_consume_token(S);
       }
@@ -2578,7 +2731,23 @@ addError(new ParseException(e.getMessage()), skipStatement());
     ArrayList<CssProperty> value_set   = new ArrayList<CssProperty>();
     boolean wrong_value = true;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case IDENT:{
+    case PLUS:
+    case GREATER:
+    case COMMA:
+    case TILDE:
+    case IDENT:
+    case HASHIDENT:
+    case EQ:
+    case DIV:
+    case LBRACKET:
+    case RBRACKET:
+    case ANY:
+    case LPARAN:
+    case RPARAN:
+    case COLON:
+    case ATKEYWORD:
+    case CLASS:
+    case 106:{
       values = declaration();
 if (values != null) {
                 value_set.add(values);
@@ -2590,10 +2759,10 @@ if (values != null) {
       break;
       }
     default:
-      jj_la1[99] = jj_gen;
+      jj_la1[104] = jj_gen;
       ;
     }
-    label_79:
+    label_80:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case SEMICOLON:{
@@ -2601,11 +2770,11 @@ if (values != null) {
         break;
         }
       default:
-        jj_la1[100] = jj_gen;
-        break label_79;
+        jj_la1[105] = jj_gen;
+        break label_80;
       }
       jj_consume_token(SEMICOLON);
-      label_80:
+      label_81:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case S:{
@@ -2613,13 +2782,29 @@ if (values != null) {
           break;
           }
         default:
-          jj_la1[101] = jj_gen;
-          break label_80;
+          jj_la1[106] = jj_gen;
+          break label_81;
         }
         jj_consume_token(S);
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-      case IDENT:{
+      case PLUS:
+      case GREATER:
+      case COMMA:
+      case TILDE:
+      case IDENT:
+      case HASHIDENT:
+      case EQ:
+      case DIV:
+      case LBRACKET:
+      case RBRACKET:
+      case ANY:
+      case LPARAN:
+      case RPARAN:
+      case COLON:
+      case ATKEYWORD:
+      case CLASS:
+      case 106:{
         values = declaration();
 if (values != null) {
                       value_set.add(values);
@@ -2631,7 +2816,7 @@ if (values != null) {
         break;
         }
       default:
-        jj_la1[102] = jj_gen;
+        jj_la1[107] = jj_gen;
         ;
       }
     }
@@ -2651,7 +2836,7 @@ if (!wrong_value) {
     CssSelectors current;
     try {
       current = simple_selector(null);
-      label_81:
+      label_82:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case S:
@@ -2662,8 +2847,8 @@ if (!wrong_value) {
           break;
           }
         default:
-          jj_la1[103] = jj_gen;
-          break label_81;
+          jj_la1[108] = jj_gen;
+          break label_82;
         }
         comb = combinator();
 if ((ac.getCssProfile() == CssProfile.MOBILE) ||
@@ -2747,7 +2932,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
  */
   final public CssSelectors externalSelector() throws ParseException {CssSelectors current;
     current = simple_selector(null);
-    label_82:
+    label_83:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case S:{
@@ -2755,10 +2940,10 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
         break;
         }
       default:
-        jj_la1[104] = jj_gen;
-        break label_82;
+        jj_la1[109] = jj_gen;
+        break label_83;
       }
-      label_83:
+      label_84:
       while (true) {
         jj_consume_token(S);
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -2767,8 +2952,8 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[105] = jj_gen;
-          break label_83;
+          jj_la1[110] = jj_gen;
+          break label_84;
         }
       }
       current = simple_selector(current);
@@ -2787,9 +2972,9 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IDENT:
     case ANY:
-    case 106:{
+    case 107:{
       element_name(selector);
-      label_84:
+      label_85:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case HASHIDENT:
@@ -2811,8 +2996,8 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[106] = jj_gen;
-          break label_84;
+          jj_la1[111] = jj_gen;
+          break label_85;
         }
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case HASHIDENT:
@@ -2846,7 +3031,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[107] = jj_gen;
+          jj_la1[112] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -2869,7 +3054,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
     case PSEUDOELEMENT_SYM:
     case CLASS:
     case FUNCTIONNOT:{
-      label_85:
+      label_86:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case HASHIDENT:
@@ -2903,7 +3088,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[108] = jj_gen;
+          jj_la1[113] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -2927,15 +3112,15 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[109] = jj_gen;
-          break label_85;
+          jj_la1[114] = jj_gen;
+          break label_86;
         }
       }
 {if ("" != null) return selector;}
       break;
       }
     default:
-      jj_la1[110] = jj_gen;
+      jj_la1[115] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3029,7 +3214,7 @@ if (n.image.charAt(0) == '.') {
       break;
       }
     default:
-      jj_la1[111] = jj_gen;
+      jj_la1[116] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3070,7 +3255,7 @@ if (n.image.charAt(0) == '.') {
       break;
       }
     default:
-      jj_la1[112] = jj_gen;
+      jj_la1[117] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3098,17 +3283,17 @@ if (n.image.charAt(0) == '.') {
           break;
           }
         default:
-          jj_la1[113] = jj_gen;
+          jj_la1[118] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
         }
       default:
-        jj_la1[114] = jj_gen;
+        jj_la1[119] = jj_gen;
         ;
       }
-      p = jj_consume_token(106);
+      p = jj_consume_token(107);
     } else {
       ;
     }
@@ -3158,7 +3343,7 @@ if (ac.getCssVersion() != CssVersion.CSS1) {
       break;
       }
     default:
-      jj_la1[115] = jj_gen;
+      jj_la1[120] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3171,20 +3356,6 @@ if (ac.getCssVersion() != CssVersion.CSS1) {
     Token val = null;
     int selectorType = CssSelectors.ATTRIBUTE_ANY;
     jj_consume_token(LBRACKET);
-    label_86:
-    while (true) {
-      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-      case S:{
-        ;
-        break;
-        }
-      default:
-        jj_la1[116] = jj_gen;
-        break label_86;
-      }
-      jj_consume_token(S);
-    }
-    att = jj_consume_token(IDENT);
     label_87:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -3193,8 +3364,22 @@ if (ac.getCssVersion() != CssVersion.CSS1) {
         break;
         }
       default:
-        jj_la1[117] = jj_gen;
+        jj_la1[121] = jj_gen;
         break label_87;
+      }
+      jj_consume_token(S);
+    }
+    att = jj_consume_token(IDENT);
+    label_88:
+    while (true) {
+      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+      case S:{
+        ;
+        break;
+        }
+      default:
+        jj_la1[122] = jj_gen;
+        break label_88;
       }
       jj_consume_token(S);
     }
@@ -3237,11 +3422,11 @@ selectorType = CssSelectors.ATTRIBUTE_SUBSTR;
         break;
         }
       default:
-        jj_la1[118] = jj_gen;
+        jj_la1[123] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
-      label_88:
+      label_89:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case S:{
@@ -3249,8 +3434,8 @@ selectorType = CssSelectors.ATTRIBUTE_SUBSTR;
           break;
           }
         default:
-          jj_la1[119] = jj_gen;
-          break label_88;
+          jj_la1[124] = jj_gen;
+          break label_89;
         }
         jj_consume_token(S);
       }
@@ -3266,11 +3451,11 @@ val.image = convertStringIndex(val.image, 1, val.image.length() -1, false);
         break;
         }
       default:
-        jj_la1[120] = jj_gen;
+        jj_la1[125] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
-      label_89:
+      label_90:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case S:{
@@ -3278,15 +3463,15 @@ val.image = convertStringIndex(val.image, 1, val.image.length() -1, false);
           break;
           }
         default:
-          jj_la1[121] = jj_gen;
-          break label_89;
+          jj_la1[126] = jj_gen;
+          break label_90;
         }
         jj_consume_token(S);
       }
       break;
       }
     default:
-      jj_la1[122] = jj_gen;
+      jj_la1[127] = jj_gen;
       ;
     }
     jj_consume_token(RBRACKET);
@@ -3362,7 +3547,7 @@ if (ac.getCssVersion() == CssVersion.CSS1) {
   final public void negation(CssSelectors s) throws ParseException {Token n;
     CssSelectors ns = new CssSelectors(ac, null);
     jj_consume_token(FUNCTIONNOT);
-    label_90:
+    label_91:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case S:{
@@ -3370,15 +3555,15 @@ if (ac.getCssVersion() == CssVersion.CSS1) {
         break;
         }
       default:
-        jj_la1[123] = jj_gen;
-        break label_90;
+        jj_la1[128] = jj_gen;
+        break label_91;
       }
       jj_consume_token(S);
     }
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IDENT:
     case ANY:
-    case 106:{
+    case 107:{
       element_name(ns);
       break;
       }
@@ -3409,11 +3594,11 @@ if (ac.getCssVersion() == CssVersion.CSS1) {
       break;
       }
     default:
-      jj_la1[124] = jj_gen;
+      jj_la1[129] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
-    label_91:
+    label_92:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case S:{
@@ -3421,8 +3606,8 @@ if (ac.getCssVersion() == CssVersion.CSS1) {
         break;
         }
       default:
-        jj_la1[125] = jj_gen;
-        break label_91;
+        jj_la1[130] = jj_gen;
+        break label_92;
       }
       jj_consume_token(S);
     }
@@ -3475,7 +3660,7 @@ try {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case FUNCTIONLANG:{
           n = jj_consume_token(FUNCTIONLANG);
-          label_92:
+          label_93:
           while (true) {
             switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
             case S:{
@@ -3483,8 +3668,8 @@ try {
               break;
               }
             default:
-              jj_la1[126] = jj_gen;
-              break label_92;
+              jj_la1[131] = jj_gen;
+              break label_93;
             }
             jj_consume_token(S);
           }
@@ -3502,11 +3687,11 @@ try {
             break;
             }
           default:
-            jj_la1[127] = jj_gen;
+            jj_la1[132] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
-          label_93:
+          label_94:
           while (true) {
             switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
             case S:{
@@ -3514,8 +3699,8 @@ try {
               break;
               }
             default:
-              jj_la1[128] = jj_gen;
-              break label_93;
+              jj_la1[133] = jj_gen;
+              break label_94;
             }
             jj_consume_token(S);
           }
@@ -3531,7 +3716,7 @@ try {
           }
         case FUNCTION:{
           n = jj_consume_token(FUNCTION);
-          label_94:
+          label_95:
           while (true) {
             switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
             case S:{
@@ -3539,8 +3724,8 @@ try {
               break;
               }
             default:
-              jj_la1[129] = jj_gen;
-              break label_94;
+              jj_la1[134] = jj_gen;
+              break label_95;
             }
             jj_consume_token(S);
           }
@@ -3557,7 +3742,7 @@ try {
           break;
           }
         default:
-          jj_la1[130] = jj_gen;
+          jj_la1[135] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -3565,14 +3750,14 @@ try {
         break;
         }
       default:
-        jj_la1[131] = jj_gen;
+        jj_la1[136] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[132] = jj_gen;
+      jj_la1[137] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3649,7 +3834,7 @@ n.image = n.image.substring(1);
       break;
       }
     default:
-      jj_la1[133] = jj_gen;
+      jj_la1[138] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3667,7 +3852,7 @@ n.image = n.image.substring(1);
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case COLON:{
         jj_consume_token(COLON);
-        label_95:
+        label_96:
         while (true) {
           switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
           case S:{
@@ -3675,8 +3860,8 @@ n.image = n.image.substring(1);
             break;
             }
           default:
-            jj_la1[134] = jj_gen;
-            break label_95;
+            jj_la1[139] = jj_gen;
+            break label_96;
           }
           jj_consume_token(S);
         }
@@ -3687,17 +3872,19 @@ n.image = n.image.substring(1);
           break;
           }
         default:
-          jj_la1[135] = jj_gen;
+          jj_la1[140] = jj_gen;
           ;
         }
         break;
         }
       default:
-        jj_la1[136] = jj_gen;
+        jj_la1[141] = jj_gen;
         ;
       }
 try {
-
+            if ( string_property == null) { // hack return code
+                {if ("" != null) return null;}
+            }
             setImportant(important);
 
             if (incompatible_error) {
@@ -3737,7 +3924,7 @@ setMediaDeclaration(false);
     try {
       string_property = property();
       jj_consume_token(COLON);
-      label_96:
+      label_97:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case S:{
@@ -3745,8 +3932,8 @@ setMediaDeclaration(false);
           break;
           }
         default:
-          jj_la1[137] = jj_gen;
-          break label_96;
+          jj_la1[142] = jj_gen;
+          break label_97;
         }
         jj_consume_token(S);
       }
@@ -3757,11 +3944,13 @@ setMediaDeclaration(false);
         break;
         }
       default:
-        jj_la1[138] = jj_gen;
+        jj_la1[143] = jj_gen;
         ;
       }
 try {
-
+            if (string_property == null) {
+              {if ("" != null) return null;}
+            }
             setImportant(important);
 
             if (incompatible_error) {
@@ -3815,7 +4004,7 @@ skipAfterExpression(e);
  */
   final public boolean prio() throws ParseException {
     jj_consume_token(IMPORTANT_SYM);
-    label_97:
+    label_98:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case S:{
@@ -3823,8 +4012,8 @@ skipAfterExpression(e);
         break;
         }
       default:
-        jj_la1[139] = jj_gen;
-        break label_97;
+        jj_la1[144] = jj_gen;
+        break label_98;
       }
       jj_consume_token(S);
     }
@@ -3835,7 +4024,7 @@ skipAfterExpression(e);
   final public CssExpression expression() throws ParseException {CssExpression exp = new CssExpression();
     char operator = ' ';
     Token n = null;
-    label_98:
+    label_99:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case PLUS:{
@@ -3874,11 +4063,11 @@ setValue(new CssIdent(), exp, operator, n, IDENT);
         break;
         }
       default:
-        jj_la1[140] = jj_gen;
+        jj_la1[145] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
-      label_99:
+      label_100:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case S:{
@@ -3886,8 +4075,8 @@ setValue(new CssIdent(), exp, operator, n, IDENT);
           break;
           }
         default:
-          jj_la1[141] = jj_gen;
-          break label_99;
+          jj_la1[146] = jj_gen;
+          break label_100;
         }
         jj_consume_token(S);
       }
@@ -3903,8 +4092,8 @@ setValue(new CssIdent(), exp, operator, n, IDENT);
         break;
         }
       default:
-        jj_la1[142] = jj_gen;
-        break label_98;
+        jj_la1[147] = jj_gen;
+        break label_99;
       }
     }
 {if ("" != null) return exp;}
@@ -3917,7 +4106,7 @@ setValue(new CssIdent(), exp, operator, n, IDENT);
   final public CssExpression expr() throws ParseException {CssExpression values = new CssExpression();
     try {
       term(values);
-      label_100:
+      label_101:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case PLUS:
@@ -3954,8 +4143,8 @@ setValue(new CssIdent(), exp, operator, n, IDENT);
           break;
           }
         default:
-          jj_la1[143] = jj_gen;
-          break label_100;
+          jj_la1[148] = jj_gen;
+          break label_101;
         }
         operator(values);
         term(values);
@@ -3972,7 +4161,7 @@ ac.getFrame().addWarning(e.getMessage(), e.getMessageArgs());
  */
   final public CssExpression mediaexpr() throws ParseException {CssExpression values = new CssExpression();
     mediaterm(values);
-    label_101:
+    label_102:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case PLUS:
@@ -4003,8 +4192,8 @@ ac.getFrame().addWarning(e.getMessage(), e.getMessageArgs());
         break;
         }
       default:
-        jj_la1[144] = jj_gen;
-        break label_101;
+        jj_la1[149] = jj_gen;
+        break label_102;
       }
       operator(values);
       mediaterm(values);
@@ -4044,7 +4233,7 @@ ac.getFrame().addWarning(e.getMessage(), e.getMessageArgs());
         break;
         }
       default:
-        jj_la1[145] = jj_gen;
+        jj_la1[150] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4140,7 +4329,7 @@ if (ac.getTreatCssHacksAsWarnings()) {
         break;
         }
       default:
-        jj_la1[146] = jj_gen;
+        jj_la1[151] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4196,7 +4385,7 @@ setValue(new CssSwitch(), exp, operator, n, DIV);
           break;
           }
         default:
-          jj_la1[147] = jj_gen;
+          jj_la1[152] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -4246,18 +4435,18 @@ setValue(new CssUnicodeRange(), exp, operator, n, UNICODERANGE);
         break;
         }
       default:
-        jj_la1[148] = jj_gen;
+        jj_la1[153] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[149] = jj_gen;
+      jj_la1[154] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
-    label_102:
+    label_103:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case S:{
@@ -4265,8 +4454,8 @@ setValue(new CssUnicodeRange(), exp, operator, n, UNICODERANGE);
         break;
         }
       default:
-        jj_la1[150] = jj_gen;
-        break label_102;
+        jj_la1[155] = jj_gen;
+        break label_103;
       }
       jj_consume_token(S);
     }
@@ -4303,7 +4492,7 @@ setValue(new CssUnicodeRange(), exp, operator, n, UNICODERANGE);
         break;
         }
       default:
-        jj_la1[151] = jj_gen;
+        jj_la1[156] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4318,7 +4507,7 @@ setValue(new CssNumber(), exp, operator, n, NUMBER);
             break;
             }
           default:
-            jj_la1[152] = jj_gen;
+            jj_la1[157] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -4408,11 +4597,11 @@ setValue(func, exp, operator, null, FUNCTION);
         break;
         }
       default:
-        jj_la1[153] = jj_gen;
+        jj_la1[158] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
-      label_103:
+      label_104:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case S:{
@@ -4420,8 +4609,8 @@ setValue(func, exp, operator, null, FUNCTION);
           break;
           }
         default:
-          jj_la1[154] = jj_gen;
-          break label_103;
+          jj_la1[159] = jj_gen;
+          break label_104;
         }
         jj_consume_token(S);
       }
@@ -4483,11 +4672,11 @@ setValue(new CssUnicodeRange(), exp, operator, n,
         break;
         }
       default:
-        jj_la1[155] = jj_gen;
+        jj_la1[160] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
-      label_104:
+      label_105:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case S:{
@@ -4495,15 +4684,15 @@ setValue(new CssUnicodeRange(), exp, operator, n,
           break;
           }
         default:
-          jj_la1[156] = jj_gen;
-          break label_104;
+          jj_la1[161] = jj_gen;
+          break label_105;
         }
         jj_consume_token(S);
       }
       break;
       }
     default:
-      jj_la1[157] = jj_gen;
+      jj_la1[162] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -4512,20 +4701,6 @@ setValue(new CssUnicodeRange(), exp, operator, n,
   final public CssCheckableValue mathcalc() throws ParseException {CssCheckableValue v;
 CssCalc c;
     jj_consume_token(FUNCTIONCALC);
-    label_105:
-    while (true) {
-      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-      case S:{
-        ;
-        break;
-        }
-      default:
-        jj_la1[158] = jj_gen;
-        break label_105;
-      }
-      jj_consume_token(S);
-    }
-    v = mathsum();
     label_106:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4534,8 +4709,22 @@ CssCalc c;
         break;
         }
       default:
-        jj_la1[159] = jj_gen;
+        jj_la1[163] = jj_gen;
         break label_106;
+      }
+      jj_consume_token(S);
+    }
+    v = mathsum();
+    label_107:
+    while (true) {
+      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+      case S:{
+        ;
+        break;
+        }
+      default:
+        jj_la1[164] = jj_gen;
+        break label_107;
       }
       jj_consume_token(S);
     }
@@ -4559,12 +4748,12 @@ if (v.getRawType() != CssTypes.CSS_CALC) {
     v1 = mathproduct();
 c = new CssCalc(ac, v1);
                           nb_pre_sp = 0;
-    label_107:
+    label_108:
     while (true) {
       if (jj_2_3(2)) {
         ;
       } else {
-        break label_107;
+        break label_108;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case PLUS:{
@@ -4573,7 +4762,7 @@ c = new CssCalc(ac, v1);
         }
       case S:
       case MINUS:{
-        label_108:
+        label_109:
         while (true) {
           switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
           case S:{
@@ -4581,8 +4770,8 @@ c = new CssCalc(ac, v1);
             break;
             }
           default:
-            jj_la1[160] = jj_gen;
-            break label_108;
+            jj_la1[165] = jj_gen;
+            break label_109;
           }
           jj_consume_token(S);
 nb_pre_sp++;
@@ -4591,14 +4780,14 @@ nb_pre_sp++;
         break;
         }
       default:
-        jj_la1[161] = jj_gen;
+        jj_la1[166] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
 if (o.image.length() < 2 && nb_pre_sp == 0) {
                 {if (true) throw new ParseException(ac.getMsg().getString("parser.calcwhitespace"));}
             }
-      label_109:
+      label_110:
       while (true) {
         jj_consume_token(S);
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4607,8 +4796,8 @@ if (o.image.length() < 2 && nb_pre_sp == 0) {
           break;
           }
         default:
-          jj_la1[162] = jj_gen;
-          break label_109;
+          jj_la1[167] = jj_gen;
+          break label_110;
         }
       }
       v2 = mathproduct();
@@ -4634,14 +4823,14 @@ nb_pre_sp = 0;
   boolean concat = false;
     v1 = mathunit();
 c = new CssCalc(ac, v1);
-    label_110:
+    label_111:
     while (true) {
       if (jj_2_4(2)) {
         ;
       } else {
-        break label_110;
+        break label_111;
       }
-      label_111:
+      label_112:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case S:{
@@ -4649,32 +4838,14 @@ c = new CssCalc(ac, v1);
           break;
           }
         default:
-          jj_la1[163] = jj_gen;
-          break label_111;
+          jj_la1[168] = jj_gen;
+          break label_112;
         }
         jj_consume_token(S);
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case ANY:{
         o = jj_consume_token(ANY);
-        label_112:
-        while (true) {
-          switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-          case S:{
-            ;
-            break;
-            }
-          default:
-            jj_la1[164] = jj_gen;
-            break label_112;
-          }
-          jj_consume_token(S);
-        }
-        v2 = mathunit();
-        break;
-        }
-      case DIV:{
-        o = jj_consume_token(DIV);
         label_113:
         while (true) {
           switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4683,8 +4854,26 @@ c = new CssCalc(ac, v1);
             break;
             }
           default:
-            jj_la1[165] = jj_gen;
+            jj_la1[169] = jj_gen;
             break label_113;
+          }
+          jj_consume_token(S);
+        }
+        v2 = mathunit();
+        break;
+        }
+      case DIV:{
+        o = jj_consume_token(DIV);
+        label_114:
+        while (true) {
+          switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+          case S:{
+            ;
+            break;
+            }
+          default:
+            jj_la1[170] = jj_gen;
+            break label_114;
           }
           jj_consume_token(S);
         }
@@ -4695,7 +4884,7 @@ c = new CssCalc(ac, v1);
           break;
           }
         default:
-          jj_la1[166] = jj_gen;
+          jj_la1[171] = jj_gen;
           ;
         }
         n = jj_consume_token(NUMBER);
@@ -4703,7 +4892,7 @@ v2 = new CssNumber(); v2.set(addOperator(operator, n.image), ac);
         break;
         }
       default:
-        jj_la1[167] = jj_gen;
+        jj_la1[172] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4742,7 +4931,7 @@ char operator = ' ';
         break;
         }
       default:
-        jj_la1[168] = jj_gen;
+        jj_la1[173] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4792,7 +4981,7 @@ v= new CssFrequency(); v.set(addOperator(operator, n.image), ac);
         break;
         }
       default:
-        jj_la1[169] = jj_gen;
+        jj_la1[174] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4800,20 +4989,6 @@ v= new CssFrequency(); v.set(addOperator(operator, n.image), ac);
       }
     case RPARAN:{
       jj_consume_token(RPARAN);
-      label_114:
-      while (true) {
-        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-        case S:{
-          ;
-          break;
-          }
-        default:
-          jj_la1[170] = jj_gen;
-          break label_114;
-        }
-        jj_consume_token(S);
-      }
-      v = mathsum();
       label_115:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4822,8 +4997,22 @@ v= new CssFrequency(); v.set(addOperator(operator, n.image), ac);
           break;
           }
         default:
-          jj_la1[171] = jj_gen;
+          jj_la1[175] = jj_gen;
           break label_115;
+        }
+        jj_consume_token(S);
+      }
+      v = mathsum();
+      label_116:
+      while (true) {
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case S:{
+          ;
+          break;
+          }
+        default:
+          jj_la1[176] = jj_gen;
+          break label_116;
         }
         jj_consume_token(S);
       }
@@ -4840,7 +5029,7 @@ v= new CssFrequency(); v.set(addOperator(operator, n.image), ac);
       break;
       }
     default:
-      jj_la1[172] = jj_gen;
+      jj_la1[177] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -4852,20 +5041,6 @@ v= new CssFrequency(); v.set(addOperator(operator, n.image), ac);
 Token n = null;
 CssExpression exp = null;
     jj_consume_token(FUNCTIONATTR);
-    label_116:
-    while (true) {
-      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-      case S:{
-        ;
-        break;
-        }
-      default:
-        jj_la1[173] = jj_gen;
-        break label_116;
-      }
-      jj_consume_token(S);
-    }
-    n = jj_consume_token(IDENT);
     label_117:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4874,8 +5049,22 @@ CssExpression exp = null;
         break;
         }
       default:
-        jj_la1[174] = jj_gen;
+        jj_la1[178] = jj_gen;
         break label_117;
+      }
+      jj_consume_token(S);
+    }
+    n = jj_consume_token(IDENT);
+    label_118:
+    while (true) {
+      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+      case S:{
+        ;
+        break;
+        }
+      default:
+        jj_la1[179] = jj_gen;
+        break label_118;
       }
       jj_consume_token(S);
     }
@@ -4883,45 +5072,22 @@ exp = new CssExpression();
             setValue(new CssIdent(), exp, ' ', n, IDENT);
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IDENT:
-    case 107:{
+    case 108:{
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case IDENT:{
         n = jj_consume_token(IDENT);
         break;
         }
-      case 107:{
-        n = jj_consume_token(107);
+      case 108:{
+        n = jj_consume_token(108);
         break;
         }
       default:
-        jj_la1[175] = jj_gen;
+        jj_la1[180] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
 setValue(new CssIdent(), exp, ' ', n, IDENT);
-      label_118:
-      while (true) {
-        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-        case S:{
-          ;
-          break;
-          }
-        default:
-          jj_la1[176] = jj_gen;
-          break label_118;
-        }
-        jj_consume_token(S);
-      }
-      break;
-      }
-    default:
-      jj_la1[177] = jj_gen;
-      ;
-    }
-    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case COMMA:{
-      jj_consume_token(COMMA);
-exp.setOperator(',');
       label_119:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4930,8 +5096,31 @@ exp.setOperator(',');
           break;
           }
         default:
-          jj_la1[178] = jj_gen;
+          jj_la1[181] = jj_gen;
           break label_119;
+        }
+        jj_consume_token(S);
+      }
+      break;
+      }
+    default:
+      jj_la1[182] = jj_gen;
+      ;
+    }
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case COMMA:{
+      jj_consume_token(COMMA);
+exp.setOperator(',');
+      label_120:
+      while (true) {
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case S:{
+          ;
+          break;
+          }
+        default:
+          jj_la1[183] = jj_gen;
+          break label_120;
         }
         jj_consume_token(S);
       }
@@ -4939,7 +5128,7 @@ exp.setOperator(',');
       break;
       }
     default:
-      jj_la1[179] = jj_gen;
+      jj_la1[184] = jj_gen;
       ;
     }
     jj_consume_token(LPARAN);
@@ -4956,7 +5145,7 @@ v = new CssAttr();
  CssExpression exp;
  CssColor color = new CssColor();
     n = jj_consume_token(FUNCTION);
-    label_120:
+    label_121:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case S:{
@@ -4964,8 +5153,8 @@ v = new CssAttr();
         break;
         }
       default:
-        jj_la1[180] = jj_gen;
-        break label_120;
+        jj_la1[185] = jj_gen;
+        break label_121;
       }
       jj_consume_token(S);
     }
@@ -5032,7 +5221,7 @@ String funcname = n.image.toLowerCase();
         break;
         }
       default:
-        jj_la1[181] = jj_gen;
+        jj_la1[186] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5064,7 +5253,7 @@ String funcname = n.image.toLowerCase();
       break;
       }
     default:
-      jj_la1[182] = jj_gen;
+      jj_la1[187] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5360,296 +5549,30 @@ n.image = Util.strip(n.image);
     finally { jj_save(4, xla); }
   }
 
-  private boolean jj_3R_149()
- {
-    if (jj_scan_token(FUNCTIONCALC)) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
-    }
-    if (jj_3R_182()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_134()
- {
-    if (jj_3R_150()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_125()
- {
-    if (jj_3R_129()) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3R_130()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_133()
- {
-    if (jj_3R_149()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_132()
- {
-    if (jj_scan_token(RPARAN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_183()
- {
-    if (jj_scan_token(IDENT)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_148()
- {
-    if (jj_scan_token(FREQ)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_147()
- {
-    if (jj_scan_token(TIME)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_146()
- {
-    if (jj_scan_token(ANGLE)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_145()
- {
-    if (jj_scan_token(FLEX)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_144()
- {
-    if (jj_scan_token(ABSOLUTLENGTH)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_143()
- {
-    if (jj_scan_token(RELVIEWLENGTH)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_139()
- {
-    if (jj_3R_135()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_142()
- {
-    if (jj_scan_token(RELFONTLENGTH)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_141()
- {
-    if (jj_scan_token(PERCENTAGE)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_131()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_139()) jj_scanpos = xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_140()) {
-    jj_scanpos = xsp;
-    if (jj_3R_141()) {
-    jj_scanpos = xsp;
-    if (jj_3R_142()) {
-    jj_scanpos = xsp;
-    if (jj_3R_143()) {
-    jj_scanpos = xsp;
-    if (jj_3R_144()) {
-    jj_scanpos = xsp;
-    if (jj_3R_145()) {
-    jj_scanpos = xsp;
-    if (jj_3R_146()) {
-    jj_scanpos = xsp;
-    if (jj_3R_147()) {
-    jj_scanpos = xsp;
-    if (jj_3R_148()) return true;
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_175()
- {
-    if (jj_scan_token(IDENT)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_174()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(48)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(47)) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_127()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_131()) {
-    jj_scanpos = xsp;
-    if (jj_3R_132()) {
-    jj_scanpos = xsp;
-    if (jj_3R_133()) {
-    jj_scanpos = xsp;
-    if (jj_3R_134()) return true;
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_124()
- {
-    if (jj_scan_token(DIV)) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
-    }
-    xsp = jj_scanpos;
-    if (jj_3R_128()) jj_scanpos = xsp;
-    if (jj_scan_token(NUMBER)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_173()
- {
-    if (jj_scan_token(DIV)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_172()
- {
-    if (jj_scan_token(STRING)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_171()
- {
-    if (jj_3R_180()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_123()
- {
-    if (jj_scan_token(ANY)) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
-    }
-    if (jj_3R_127()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_170()
- {
-    if (jj_3R_150()) return true;
-    return false;
-  }
-
   private boolean jj_3R_169()
- {
-    if (jj_3R_149()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_137()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_169()) {
-    jj_scanpos = xsp;
-    if (jj_3R_170()) {
-    jj_scanpos = xsp;
-    if (jj_3R_171()) {
-    jj_scanpos = xsp;
-    if (jj_3R_172()) {
-    jj_scanpos = xsp;
-    if (jj_3R_173()) {
-    jj_scanpos = xsp;
-    if (jj_3R_174()) {
-    jj_scanpos = xsp;
-    if (jj_3R_175()) {
-    jj_scanpos = xsp;
-    if (jj_3R_176()) {
-    jj_scanpos = xsp;
-    if (jj_3R_177()) {
-    jj_scanpos = xsp;
-    if (jj_3R_178()) return true;
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_168()
  {
     if (jj_scan_token(IMPORTANT_NOT)) return true;
     return false;
   }
 
-  private boolean jj_3R_126()
+  private boolean jj_3R_127()
  {
     if (jj_scan_token(S)) return true;
     return false;
   }
 
-  private boolean jj_3R_122()
+  private boolean jj_3R_123()
  {
     Token xsp;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_126()) { jj_scanpos = xsp; break; }
+      if (jj_3R_127()) { jj_scanpos = xsp; break; }
     }
     if (jj_scan_token(MINUS)) return true;
     return false;
   }
 
-  private boolean jj_3R_152()
- {
-    if (jj_scan_token(PLUS)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_167()
+  private boolean jj_3R_168()
  {
     if (jj_scan_token(PROGID)) return true;
     return false;
@@ -5657,35 +5580,30 @@ n.image = Util.strip(n.image);
 
   private boolean jj_3_5()
  {
-    if (jj_3R_125()) return true;
+    if (jj_3R_126()) return true;
     if (jj_scan_token(LPARAN)) return true;
     return false;
   }
 
-  private boolean jj_3R_151()
+  private boolean jj_3R_185()
  {
-    if (jj_scan_token(MINUS)) return true;
+    if (jj_3R_128()) return true;
     return false;
   }
 
-  private boolean jj_3R_135()
+  private boolean jj_3R_167()
  {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_151()) {
-    jj_scanpos = xsp;
-    if (jj_3R_152()) return true;
-    }
+    if (jj_scan_token(DIMEN)) return true;
     return false;
   }
 
-  private boolean jj_3R_184()
+  private boolean jj_3R_166()
  {
-    if (jj_3R_127()) return true;
+    if (jj_scan_token(SPL)) return true;
     return false;
   }
 
-  private boolean jj_3R_121()
+  private boolean jj_3R_122()
  {
     Token xsp;
     xsp = jj_scanpos;
@@ -5696,61 +5614,49 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_166()
- {
-    if (jj_scan_token(DIMEN)) return true;
-    return false;
-  }
-
   private boolean jj_3R_165()
- {
-    if (jj_scan_token(SPL)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_164()
  {
     if (jj_scan_token(ST)) return true;
     return false;
   }
 
-  private boolean jj_3R_163()
+  private boolean jj_3R_164()
  {
     if (jj_scan_token(RESOLUTION)) return true;
     return false;
   }
 
-  private boolean jj_3R_162()
+  private boolean jj_3R_163()
  {
     if (jj_scan_token(FREQ)) return true;
     return false;
   }
 
-  private boolean jj_3R_161()
+  private boolean jj_3R_162()
  {
     if (jj_scan_token(TIME)) return true;
     return false;
   }
 
-  private boolean jj_3R_160()
+  private boolean jj_3R_161()
  {
     if (jj_scan_token(ANGLE)) return true;
     return false;
   }
 
-  private boolean jj_3R_159()
+  private boolean jj_3R_160()
  {
     if (jj_scan_token(FLEX)) return true;
     return false;
   }
 
-  private boolean jj_3R_158()
+  private boolean jj_3R_159()
  {
     if (jj_scan_token(ABSOLUTLENGTH)) return true;
     return false;
   }
 
-  private boolean jj_3R_157()
+  private boolean jj_3R_158()
  {
     if (jj_scan_token(RELVIEWLENGTH)) return true;
     return false;
@@ -5768,36 +5674,27 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_156()
+  private boolean jj_3R_157()
  {
     if (jj_scan_token(RELFONTLENGTH)) return true;
     return false;
   }
 
-  private boolean jj_3R_155()
+  private boolean jj_3R_156()
  {
     if (jj_scan_token(PERCENTAGE)) return true;
     return false;
   }
 
-  private boolean jj_3_1()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_121()) jj_scanpos = xsp;
-    if (jj_scan_token(106)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_154()
+  private boolean jj_3R_155()
  {
     if (jj_scan_token(NUMBER)) return true;
     return false;
   }
 
-  private boolean jj_3R_153()
+  private boolean jj_3R_154()
  {
-    if (jj_3R_135()) return true;
+    if (jj_3R_136()) return true;
     return false;
   }
 
@@ -5807,7 +5704,7 @@ n.image = Util.strip(n.image);
     xsp = jj_scanpos;
     if (jj_scan_token(27)) {
     jj_scanpos = xsp;
-    if (jj_3R_122()) return true;
+    if (jj_3R_123()) return true;
     }
     if (jj_scan_token(21)) return true;
     while (true) {
@@ -5817,7 +5714,16 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_180()
+  private boolean jj_3_1()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_122()) jj_scanpos = xsp;
+    if (jj_scan_token(107)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_181()
  {
     if (jj_scan_token(FUNCTION)) return true;
     Token xsp;
@@ -5828,19 +5734,17 @@ n.image = Util.strip(n.image);
     xsp = jj_scanpos;
     if (jj_3_5()) {
     jj_scanpos = xsp;
-    if (jj_3R_183()) return true;
+    if (jj_3R_184()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_136()
+  private boolean jj_3R_137()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_153()) jj_scanpos = xsp;
+    if (jj_3R_154()) jj_scanpos = xsp;
     xsp = jj_scanpos;
-    if (jj_3R_154()) {
-    jj_scanpos = xsp;
     if (jj_3R_155()) {
     jj_scanpos = xsp;
     if (jj_3R_156()) {
@@ -5867,7 +5771,9 @@ n.image = Util.strip(n.image);
     jj_scanpos = xsp;
     if (jj_3R_167()) {
     jj_scanpos = xsp;
-    if (jj_3R_168()) return true;
+    if (jj_3R_168()) {
+    jj_scanpos = xsp;
+    if (jj_3R_169()) return true;
     }
     }
     }
@@ -5885,13 +5791,19 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_129()
+  private boolean jj_3R_153()
+ {
+    if (jj_scan_token(PLUS)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_130()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_136()) {
+    if (jj_3R_137()) {
     jj_scanpos = xsp;
-    if (jj_3R_137()) return true;
+    if (jj_3R_138()) return true;
     }
     while (true) {
       xsp = jj_scanpos;
@@ -5900,46 +5812,49 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_179()
+  private boolean jj_3R_152()
  {
-    if (jj_scan_token(COMMA)) return true;
+    if (jj_scan_token(MINUS)) return true;
     return false;
   }
 
-  private boolean jj_3R_182()
- {
-    if (jj_3R_184()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_138()
+  private boolean jj_3R_136()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_179()) jj_scanpos = xsp;
+    if (jj_3R_152()) {
+    jj_scanpos = xsp;
+    if (jj_3R_153()) return true;
+    }
     return false;
   }
 
-  private boolean jj_3R_140()
+  private boolean jj_3R_183()
+ {
+    if (jj_3R_185()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_141()
  {
     if (jj_scan_token(NUMBER)) return true;
     return false;
   }
 
-  private boolean jj_3R_178()
+  private boolean jj_3R_179()
  {
     if (jj_scan_token(UNICODERANGE)) return true;
     return false;
   }
 
-  private boolean jj_3R_130()
+  private boolean jj_3R_131()
  {
-    if (jj_3R_138()) return true;
-    if (jj_3R_129()) return true;
+    if (jj_3R_139()) return true;
+    if (jj_3R_130()) return true;
     return false;
   }
 
-  private boolean jj_3R_181()
+  private boolean jj_3R_182()
  {
     Token xsp;
     xsp = jj_scanpos;
@@ -5950,13 +5865,13 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_177()
+  private boolean jj_3R_178()
  {
     if (jj_scan_token(URL)) return true;
     return false;
   }
 
-  private boolean jj_3R_150()
+  private boolean jj_3R_151()
  {
     if (jj_scan_token(FUNCTIONATTR)) return true;
     Token xsp;
@@ -5968,9 +5883,9 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_176()
+  private boolean jj_3R_177()
  {
-    if (jj_3R_181()) return true;
+    if (jj_3R_182()) return true;
     return false;
   }
 
@@ -5982,16 +5897,290 @@ n.image = Util.strip(n.image);
       if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
     }
     xsp = jj_scanpos;
-    if (jj_3R_123()) {
+    if (jj_3R_124()) {
     jj_scanpos = xsp;
-    if (jj_3R_124()) return true;
+    if (jj_3R_125()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_129()
+ {
+    if (jj_3R_136()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_150()
+ {
+    if (jj_scan_token(FUNCTIONCALC)) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
+    }
+    if (jj_3R_183()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_135()
+ {
+    if (jj_3R_151()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_134()
+ {
+    if (jj_3R_150()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_126()
+ {
+    if (jj_3R_130()) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3R_131()) { jj_scanpos = xsp; break; }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_180()
+ {
+    if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_133()
+ {
+    if (jj_scan_token(RPARAN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_184()
+ {
+    if (jj_scan_token(IDENT)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_139()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_180()) jj_scanpos = xsp;
+    return false;
+  }
+
+  private boolean jj_3R_149()
+ {
+    if (jj_scan_token(FREQ)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_148()
+ {
+    if (jj_scan_token(TIME)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_147()
+ {
+    if (jj_scan_token(ANGLE)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_146()
+ {
+    if (jj_scan_token(FLEX)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_145()
+ {
+    if (jj_scan_token(ABSOLUTLENGTH)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_144()
+ {
+    if (jj_scan_token(RELVIEWLENGTH)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_140()
+ {
+    if (jj_3R_136()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_143()
+ {
+    if (jj_scan_token(RELFONTLENGTH)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_142()
+ {
+    if (jj_scan_token(PERCENTAGE)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_132()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_140()) jj_scanpos = xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_141()) {
+    jj_scanpos = xsp;
+    if (jj_3R_142()) {
+    jj_scanpos = xsp;
+    if (jj_3R_143()) {
+    jj_scanpos = xsp;
+    if (jj_3R_144()) {
+    jj_scanpos = xsp;
+    if (jj_3R_145()) {
+    jj_scanpos = xsp;
+    if (jj_3R_146()) {
+    jj_scanpos = xsp;
+    if (jj_3R_147()) {
+    jj_scanpos = xsp;
+    if (jj_3R_148()) {
+    jj_scanpos = xsp;
+    if (jj_3R_149()) return true;
+    }
+    }
+    }
+    }
+    }
+    }
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_176()
+ {
+    if (jj_scan_token(IDENT)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_175()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(48)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(47)) return true;
     }
     return false;
   }
 
   private boolean jj_3R_128()
  {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_132()) {
+    jj_scanpos = xsp;
+    if (jj_3R_133()) {
+    jj_scanpos = xsp;
+    if (jj_3R_134()) {
+    jj_scanpos = xsp;
     if (jj_3R_135()) return true;
+    }
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_125()
+ {
+    if (jj_scan_token(DIV)) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
+    }
+    xsp = jj_scanpos;
+    if (jj_3R_129()) jj_scanpos = xsp;
+    if (jj_scan_token(NUMBER)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_174()
+ {
+    if (jj_scan_token(DIV)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_173()
+ {
+    if (jj_scan_token(STRING)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_172()
+ {
+    if (jj_3R_181()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_124()
+ {
+    if (jj_scan_token(ANY)) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
+    }
+    if (jj_3R_128()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_171()
+ {
+    if (jj_3R_151()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_170()
+ {
+    if (jj_3R_150()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_138()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_170()) {
+    jj_scanpos = xsp;
+    if (jj_3R_171()) {
+    jj_scanpos = xsp;
+    if (jj_3R_172()) {
+    jj_scanpos = xsp;
+    if (jj_3R_173()) {
+    jj_scanpos = xsp;
+    if (jj_3R_174()) {
+    jj_scanpos = xsp;
+    if (jj_3R_175()) {
+    jj_scanpos = xsp;
+    if (jj_3R_176()) {
+    jj_scanpos = xsp;
+    if (jj_3R_177()) {
+    jj_scanpos = xsp;
+    if (jj_3R_178()) {
+    jj_scanpos = xsp;
+    if (jj_3R_179()) return true;
+    }
+    }
+    }
+    }
+    }
+    }
+    }
+    }
+    }
     return false;
   }
 
@@ -6006,7 +6195,7 @@ n.image = Util.strip(n.image);
   private Token jj_scanpos, jj_lastpos;
   private int jj_la;
   private int jj_gen;
-  final private int[] jj_la1 = new int[183];
+  final private int[] jj_la1 = new int[188];
   static private int[] jj_la1_0;
   static private int[] jj_la1_1;
   static private int[] jj_la1_2;
@@ -6018,16 +6207,16 @@ n.image = Util.strip(n.image);
 	   jj_la1_init_3();
 	}
 	private static void jj_la1_init_0() {
-	   jj_la1_0 = new int[] {0x0,0x0,0x0,0xe00000,0xe00000,0x0,0x0,0x200000,0x200000,0x0,0xc00000,0xc00000,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x200000,0x200000,0x40000000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x0,0x200000,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x200000,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x200000,0x200000,0x18000000,0x18000000,0x18000000,0x200000,0x200000,0x200000,0x200000,0x18000000,0x40000000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x40000000,0xa8000000,0x200000,0x200000,0xa8200000,0x18000000,0x200000,0x40000000,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x0,0xa8200000,0x200000,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200000,0x200000,0x3000000,0x200000,0x0,0x200000,0x3000000,0x200000,0x0,0x200000,0x200000,0x0,0x200000,0x200000,0x0,0x0,0x0,0x0,0x200000,0x0,0x0,0x200000,0x0,0x200000,0x18000000,0x200000,0x18000000,0x58000000,0x58000000,0x18000000,0x0,0x0,0x0,0x18000000,0x200000,0x18000000,0x0,0x0,0x200000,0x0,0x200000,0x18000000,0x200000,0x200000,0x200000,0x18200000,0x200000,0x200000,0x200000,0x200000,0x18000000,0x0,0x18000000,0x0,0x200000,0x200000,0x18000000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x40000000,0x200000,0x0,0x0,};
+	   jj_la1_0 = new int[] {0x0,0x0,0x0,0xe00000,0xe00000,0x0,0x0,0x200000,0x200000,0x0,0xc00000,0xc00000,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x200000,0x200000,0x40000000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x0,0x200000,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x200000,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x200000,0x200000,0x18000000,0x18000000,0x18000000,0x200000,0x200000,0x200000,0x200000,0x18000000,0x40000000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x40000000,0xa8000000,0x200000,0x200000,0xa8200000,0x18000000,0xe8000000,0xe8000000,0x200000,0x0,0x200000,0xe8000000,0x40000000,0x200000,0x200000,0x200000,0xe8000000,0x0,0x200000,0xe8000000,0xa8200000,0x200000,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200000,0x200000,0x3000000,0x200000,0x0,0x200000,0x3000000,0x200000,0x0,0x200000,0x200000,0x0,0x200000,0x200000,0x0,0x0,0x0,0x0,0x200000,0x0,0x0,0x200000,0x0,0x200000,0x18000000,0x200000,0x18000000,0x58000000,0x58000000,0x18000000,0x0,0x0,0x0,0x18000000,0x200000,0x18000000,0x0,0x0,0x200000,0x0,0x200000,0x18000000,0x200000,0x200000,0x200000,0x18200000,0x200000,0x200000,0x200000,0x200000,0x18000000,0x0,0x18000000,0x0,0x200000,0x200000,0x18000000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x40000000,0x200000,0x0,0x0,};
 	}
 	private static void jj_la1_init_1() {
-	   jj_la1_1 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xcba28070,0x0,0x0,0x0,0x0,0x0,0x10,0x400004,0x0,0x0,0x0,0x400004,0x0,0x100012,0x0,0x0,0x0,0xcba28070,0x0,0x0,0x0,0x0,0x0,0x0,0x2,0x0,0x1,0x0,0x1,0x0,0x100012,0x0,0x0,0x0,0x200000,0x0,0x0,0x0,0x0,0x0,0x10,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x10,0x2000,0x0,0x10,0x0,0x0,0x0,0xcba08060,0xcba08060,0xcba08060,0xcba08060,0xcba28070,0xcb800000,0xcb800000,0x20010,0x20010,0x20010,0x0,0x0,0x1e00,0x0,0x14,0x0,0x1e00,0x0,0xcba28070,0x0,0x0,0x14,0x0,0x0,0x0,0x10,0x200000,0x60,0x0,0x0,0x200000,0x0,0x0,0x0,0x14,0x0,0x14,0xffc1c0f4,0xffc00074,0x0,0xff800080,0x18000,0x41c074,0xffc1c0f4,0x0,0x0,0x0,0xff800000,0x0,0x400074,0x0,0xffc00074,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x24000,0x0,0xcf800000,0x0,0x0,0xcf900000,0x0,0x0,0x10,0x0,0x10,0x0,0x0,0x0,0x10,0x60,};
+	   jj_la1_1 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xcba28070,0x0,0x0,0x0,0x0,0x0,0x10,0x400004,0x0,0x0,0x0,0x400004,0x0,0x100012,0x0,0x0,0x0,0xcba28070,0x0,0x0,0x0,0x0,0x0,0x0,0x2,0x0,0x1,0x0,0x1,0x0,0x100012,0x0,0x0,0x0,0x200000,0x0,0x0,0x0,0x0,0x0,0x10,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3bd000,0x3bd000,0x0,0x20,0x0,0x3bd030,0x0,0x0,0x0,0x0,0x3bd030,0x2000,0x0,0x3bd030,0x0,0x0,0x0,0xcba08060,0xcba08060,0xcba08060,0xcba08060,0xcba28070,0xcb800000,0xcb800000,0x20010,0x20010,0x20010,0x0,0x0,0x1e00,0x0,0x14,0x0,0x1e00,0x0,0xcba28070,0x0,0x0,0x14,0x0,0x0,0x0,0x10,0x200000,0x60,0x0,0x0,0x200000,0x0,0x0,0x0,0x14,0x0,0x14,0xffc1c0f4,0xffc00074,0x0,0xff800080,0x18000,0x41c074,0xffc1c0f4,0x0,0x0,0x0,0xff800000,0x0,0x400074,0x0,0xffc00074,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x24000,0x0,0xcf800000,0x0,0x0,0xcf900000,0x0,0x0,0x10,0x0,0x10,0x0,0x0,0x0,0x10,0x60,};
 	}
 	private static void jj_la1_init_2() {
-	   jj_la1_2 = new int[] {0x0,0x0,0x80,0x0,0x0,0x100,0x200,0x0,0x0,0xe0fc43,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x43,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xf0000,0xf0000,0x0,0x0,0x0,0x0,0x0,0x0,0x4,0x0,0x0,0x0,0x0,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x43,0x43,0x43,0x43,0x43,0x3,0x3,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x43,0x0,0x0,0x8,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x10,0x0,0x0,0x10,0x0,0xe,0x0,0xe,0x2f,0x2f,0x0,0x2f,0x0,0x0,0x2f,0x0,0x0,0x8,0x2f,0x0,0x0,0x0,0x2f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xc,0x0,0x0,0xc,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_2 = new int[] {0x0,0x0,0x80,0x0,0x0,0x100,0x200,0x0,0x0,0xe0fc43,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x43,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xf0000,0xf0000,0x0,0x0,0x0,0x0,0x0,0x0,0x4,0x0,0x0,0x0,0x0,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x800000,0x0,0x800000,0x0,0x0,0x0,0x0,0x800000,0x0,0x0,0x800000,0x0,0x0,0x0,0x43,0x43,0x43,0x43,0x43,0x3,0x3,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x43,0x0,0x0,0x8,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x10,0x0,0x0,0x10,0x0,0xe,0x0,0xe,0x2f,0x2f,0x0,0x2f,0x0,0x0,0x2f,0x0,0x0,0x8,0x2f,0x0,0x0,0x0,0x2f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xc,0x0,0x0,0xc,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_3() {
-	   jj_la1_3 = new int[] {0x300,0x300,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x414,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x414,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x14,0x14,0x14,0x14,0x414,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x404,0x0,0x0,0x0,0x0,0x0,0x88,0x88,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xe2,0x82,0x0,0x0,0x0,0xe2,0xe2,0x0,0x0,0x0,0x80,0x0,0x2,0x0,0x82,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x60,0x0,0x0,0x800,0x0,0x800,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_3 = new int[] {0x300,0x300,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x814,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x814,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x400,0x400,0x0,0x4,0x0,0x404,0x0,0x0,0x0,0x0,0x404,0x0,0x0,0x404,0x0,0x0,0x0,0x14,0x14,0x14,0x14,0x814,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x804,0x0,0x0,0x0,0x0,0x0,0x88,0x88,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xe2,0x82,0x0,0x0,0x0,0xe2,0xe2,0x0,0x0,0x0,0x80,0x0,0x2,0x0,0x82,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x60,0x0,0x0,0x1000,0x0,0x1000,0x0,0x0,0x0,0x0,0x0,};
 	}
   final private JJCalls[] jj_2_rtns = new JJCalls[5];
   private boolean jj_rescan = false;
@@ -6044,7 +6233,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 183; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 188; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6059,7 +6248,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 183; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 188; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6070,7 +6259,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 183; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 188; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6089,7 +6278,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 183; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 188; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6099,7 +6288,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 183; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 188; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6109,7 +6298,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 183; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 188; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6235,12 +6424,12 @@ n.image = Util.strip(n.image);
   /** Generate ParseException. */
   public ParseException generateParseException() {
 	 jj_expentries.clear();
-	 boolean[] la1tokens = new boolean[108];
+	 boolean[] la1tokens = new boolean[109];
 	 if (jj_kind >= 0) {
 	   la1tokens[jj_kind] = true;
 	   jj_kind = -1;
 	 }
-	 for (int i = 0; i < 183; i++) {
+	 for (int i = 0; i < 188; i++) {
 	   if (jj_la1[i] == jj_gen) {
 		 for (int j = 0; j < 32; j++) {
 		   if ((jj_la1_0[i] & (1<<j)) != 0) {
@@ -6258,7 +6447,7 @@ n.image = Util.strip(n.image);
 		 }
 	   }
 	 }
-	 for (int i = 0; i < 108; i++) {
+	 for (int i = 0; i < 109; i++) {
 	   if (la1tokens[i]) {
 		 jj_expentry = new int[1];
 		 jj_expentry[0] = i;
@@ -6334,4 +6523,5 @@ n.image = Util.strip(n.image);
 	 int arg;
 	 JJCalls next;
   }
+
 }

--- a/org/w3c/css/parser/analyzer/CssParser.jj
+++ b/org/w3c/css/parser/analyzer/CssParser.jj
@@ -1570,10 +1570,34 @@ char unaryOperator() :
  * @exception ParseException exception during the parse
  */
 String property() :
-{Token n; }
+{Token n;
+ Token hack= null; }
 {
-    n=<IDENT> ( <S> )* { currentProperty = convertIdent(n.image); 
-			 return currentProperty; }
+ // ( hack? ident | hackedIdent ) ( <S> )*
+    ( (hack=<[ "!", "$", "%", "&", "/", "`", "?",  "<", "|" ]> | hack=<ANY> | hack=<EQ> | hack=<RBRACKET> | hack=<LBRACKET> | hack=<LPARAN> | hack=<RPARAN> | hack=<COLON> | hack=<TILDE> | hack=<PLUS> | hack=<COMMA> | hack=<GREATER> | hack=<DIV>)?
+    n=<IDENT>) ( <S> )* {
+                 currentProperty = convertIdent(n.image);
+                 if (hack != null && !"".equals(hack)) {
+                   String hackp = hack.image+currentProperty;
+                   if (ac.getTreatCssHacksAsWarnings()) {
+                     ac.getFrame().addWarning("css-hack", hackp);
+                     return null;
+                   } else {
+                     throw new ParseException(String.format(ac.getMsg().getString("warning.css-hack"), hackp));
+                   }
+                }
+                return currentProperty;
+               }
+  | ( n=<HASHIDENT> | n=<CLASS> | n=<ATKEYWORD> ) {
+         if (ac.getTreatCssHacksAsWarnings()) {
+                              ac.getFrame().addWarning("css-hack", n.image);
+                              // should we continue and validate the content, or skip ?
+                              currentProperty = convertIdent(n.image).substring(1);
+                              return null;
+         }
+        throw new ParseException(String.format(ac.getMsg().getString("warning.css-hack"), n.image));
+     }
+   ( <S> )*
 }
 
 /**
@@ -2232,7 +2256,9 @@ try {
     {
 	
 	try {
-	
+            if ( string_property == null) { // hack return code
+                return null;
+            }
 	    setImportant(important);
 	
 	    if (incompatible_error) {
@@ -2278,7 +2304,9 @@ try {
       values=expr() ( important=prio() )?
     {
 	try {
-	
+            if (string_property == null) {
+              return null;
+            }
 	    setImportant(important);
 	
 	    if (incompatible_error) {

--- a/org/w3c/css/parser/analyzer/CssParserConstants.java
+++ b/org/w3c/css/parser/analyzer/CssParserConstants.java
@@ -332,6 +332,7 @@ public interface CssParserConstants {
     "<FUNCTION>",
     "<HTMLSTARTTAG>",
     "<HTMLENDTAG>",
+    "<token of kind 106>",
     "\"|\"",
     "\"%\"",
   };

--- a/org/w3c/css/parser/analyzer/CssParserTokenManager.java
+++ b/org/w3c/css/parser/analyzer/CssParserTokenManager.java
@@ -95,7 +95,7 @@ private int jjMoveStringLiteralDfa0_0(){
       case 36:
          return jjMoveStringLiteralDfa1_0(0x40000000000L, 0x0L);
       case 37:
-         jjmatchedKind = 107;
+         jjmatchedKind = 108;
          return jjMoveNfa_0(7, 0);
       case 40:
          jjmatchedKind = 52;
@@ -146,7 +146,7 @@ private int jjMoveStringLiteralDfa0_0(){
       case 108:
          return jjMoveStringLiteralDfa1_0(0x0L, 0x800000000L);
       case 124:
-         jjmatchedKind = 106;
+         jjmatchedKind = 107;
          return jjMoveStringLiteralDfa1_0(0x2000000L, 0x0L);
       case 125:
          jjmatchedKind = 40;
@@ -838,7 +838,7 @@ private int jjMoveNfa_0(int startState, int curPos)
    catch(java.io.IOException e) { throw new Error("Internal Error"); }
    curPos = 0;
    int startsAt = 0;
-   jjnewStateCnt = 824;
+   jjnewStateCnt = 825;
    int i = 1;
    jjstateSet[0] = startState;
    int kind = 0x7fffffff;
@@ -860,34 +860,35 @@ private int jjMoveNfa_0(int startState, int curPos)
                         kind = 67;
                      { jjCheckNAddStates(0, 104); }
                   }
+                  else if ((0x9000807200000000L & l) != 0L)
+                  {
+                     if (kind > 106)
+                        kind = 106;
+                  }
                   else if ((0x100003600L & l) != 0L)
                   {
                      if (kind > 21)
                         kind = 21;
                      { jjCheckNAddStates(105, 124); }
                   }
-                  else if (curChar == 33)
-                     { jjCheckNAddStates(125, 128); }
                   else if (curChar == 46)
-                     { jjCheckNAddStates(129, 156); }
+                     { jjCheckNAddStates(125, 152); }
                   else if (curChar == 35)
-                     { jjCheckNAddStates(157, 161); }
+                     { jjCheckNAddStates(153, 157); }
                   else if (curChar == 45)
-                     { jjAddStates(162, 165); }
+                     { jjAddStates(158, 161); }
                   else if (curChar == 39)
                   {
                      if (kind > 35)
                         kind = 35;
-                     { jjCheckNAddStates(166, 170); }
+                     { jjCheckNAddStates(162, 166); }
                   }
                   else if (curChar == 34)
                   {
                      if (kind > 35)
                         kind = 35;
-                     { jjCheckNAddStates(171, 175); }
+                     { jjCheckNAddStates(167, 171); }
                   }
-                  else if (curChar == 60)
-                     jjstateSet[jjnewStateCnt++] = 215;
                   else if (curChar == 44)
                   {
                      if (kind > 30)
@@ -903,6 +904,10 @@ private int jjMoveNfa_0(int startState, int curPos)
                      if (kind > 27)
                         kind = 27;
                   }
+                  if (curChar == 33)
+                     { jjCheckNAddStates(172, 175); }
+                  else if (curChar == 60)
+                     jjstateSet[jjnewStateCnt++] = 215;
                   else if (curChar == 47)
                      jjstateSet[jjnewStateCnt++] = 0;
                   if (curChar == 60)
@@ -1704,1246 +1709,1246 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 215;
                   break;
                case 258:
+                  if ((0x9000807200000000L & l) != 0L && kind > 106)
+                     kind = 106;
+                  break;
+               case 259:
                   if ((0x100003600L & l) == 0L)
                      break;
                   if (kind > 21)
                      kind = 21;
                   { jjCheckNAddStates(105, 124); }
                   break;
-               case 259:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(260, 261); }
-                  break;
                case 260:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(260, 261); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(261, 262); }
                   break;
                case 261:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(261, 262); }
+                  break;
+               case 262:
                   if (curChar == 42)
                      { jjCheckNAddStates(837, 839); }
                   break;
-               case 262:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(263, 264); }
-                  break;
                case 263:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(263, 264); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(264, 265); }
                   break;
                case 264:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(264, 265); }
+                  break;
+               case 265:
                   if (curChar == 42)
                      { jjCheckNAddStates(840, 842); }
                   break;
-               case 265:
+               case 266:
                   if (curChar != 47)
                      break;
                   if (kind > 21)
                      kind = 21;
-                  { jjCheckNAddTwoStates(266, 267); }
-                  break;
-               case 266:
-                  if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 259;
+                  { jjCheckNAddTwoStates(267, 268); }
                   break;
                case 267:
+                  if (curChar == 47)
+                     jjstateSet[jjnewStateCnt++] = 260;
+                  break;
+               case 268:
                   if ((0x100003600L & l) == 0L)
                      break;
                   if (kind > 21)
                      kind = 21;
-                  { jjCheckNAddTwoStates(266, 267); }
-                  break;
-               case 268:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(269, 270); }
+                  { jjCheckNAddTwoStates(267, 268); }
                   break;
                case 269:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(269, 270); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(270, 271); }
                   break;
                case 270:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(270, 271); }
+                  break;
+               case 271:
                   if (curChar == 42)
                      { jjCheckNAddStates(843, 845); }
                   break;
-               case 271:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(272, 273); }
-                  break;
                case 272:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(272, 273); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(273, 274); }
                   break;
                case 273:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(273, 274); }
+                  break;
+               case 274:
                   if (curChar == 42)
                      { jjCheckNAddStates(846, 848); }
                   break;
-               case 274:
+               case 275:
                   if (curChar == 47)
                      { jjCheckNAddStates(849, 851); }
                   break;
-               case 275:
-                  if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 268;
-                  break;
                case 276:
+                  if (curChar == 47)
+                     jjstateSet[jjnewStateCnt++] = 269;
+                  break;
+               case 277:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(849, 851); }
                   break;
-               case 278:
+               case 279:
                   if (curChar == 61 && kind > 24)
                      kind = 24;
                   break;
-               case 279:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(280, 281); }
-                  break;
                case 280:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(280, 281); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(281, 282); }
                   break;
                case 281:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(281, 282); }
+                  break;
+               case 282:
                   if (curChar == 42)
                      { jjCheckNAddStates(852, 854); }
                   break;
-               case 282:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(283, 284); }
-                  break;
                case 283:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(283, 284); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(284, 285); }
                   break;
                case 284:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(284, 285); }
+                  break;
+               case 285:
                   if (curChar == 42)
                      { jjCheckNAddStates(855, 857); }
                   break;
-               case 285:
+               case 286:
                   if (curChar == 47)
                      { jjCheckNAddStates(858, 860); }
                   break;
-               case 286:
-                  if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 279;
-                  break;
                case 287:
+                  if (curChar == 47)
+                     jjstateSet[jjnewStateCnt++] = 280;
+                  break;
+               case 288:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(858, 860); }
                   break;
-               case 288:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(289, 290); }
-                  break;
                case 289:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(289, 290); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(290, 291); }
                   break;
                case 290:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(290, 291); }
+                  break;
+               case 291:
                   if (curChar == 42)
                      { jjCheckNAddStates(861, 863); }
                   break;
-               case 291:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(292, 293); }
-                  break;
                case 292:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(292, 293); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(293, 294); }
                   break;
                case 293:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(293, 294); }
+                  break;
+               case 294:
                   if (curChar == 42)
                      { jjCheckNAddStates(864, 866); }
                   break;
-               case 294:
+               case 295:
                   if (curChar == 47)
                      { jjCheckNAddStates(867, 869); }
                   break;
-               case 295:
-                  if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 288;
-                  break;
                case 296:
+                  if (curChar == 47)
+                     jjstateSet[jjnewStateCnt++] = 289;
+                  break;
+               case 297:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(867, 869); }
                   break;
-               case 297:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(298, 299); }
-                  break;
                case 298:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(298, 299); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(299, 300); }
                   break;
                case 299:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(299, 300); }
+                  break;
+               case 300:
                   if (curChar == 42)
                      { jjCheckNAddStates(870, 872); }
                   break;
-               case 300:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(301, 302); }
-                  break;
                case 301:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(301, 302); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(302, 303); }
                   break;
                case 302:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(302, 303); }
+                  break;
+               case 303:
                   if (curChar == 42)
                      { jjCheckNAddStates(873, 875); }
                   break;
-               case 303:
+               case 304:
                   if (curChar == 47)
                      { jjCheckNAddStates(876, 878); }
                   break;
-               case 304:
-                  if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 297;
-                  break;
                case 305:
+                  if (curChar == 47)
+                     jjstateSet[jjnewStateCnt++] = 298;
+                  break;
+               case 306:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(876, 878); }
                   break;
-               case 306:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(307, 308); }
-                  break;
                case 307:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(307, 308); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(308, 309); }
                   break;
                case 308:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(308, 309); }
+                  break;
+               case 309:
                   if (curChar == 42)
                      { jjCheckNAddStates(879, 881); }
                   break;
-               case 309:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(310, 311); }
-                  break;
                case 310:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(310, 311); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(311, 312); }
                   break;
                case 311:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(311, 312); }
+                  break;
+               case 312:
                   if (curChar == 42)
                      { jjCheckNAddStates(882, 884); }
                   break;
-               case 312:
+               case 313:
                   if (curChar == 47)
                      { jjCheckNAddStates(885, 887); }
                   break;
-               case 313:
-                  if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 306;
-                  break;
                case 314:
+                  if (curChar == 47)
+                     jjstateSet[jjnewStateCnt++] = 307;
+                  break;
+               case 315:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(885, 887); }
                   break;
-               case 315:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(316, 317); }
-                  break;
                case 316:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(316, 317); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(317, 318); }
                   break;
                case 317:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(317, 318); }
+                  break;
+               case 318:
                   if (curChar == 42)
                      { jjCheckNAddStates(888, 890); }
                   break;
-               case 318:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(319, 320); }
-                  break;
                case 319:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(319, 320); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(320, 321); }
                   break;
                case 320:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(320, 321); }
+                  break;
+               case 321:
                   if (curChar == 42)
                      { jjCheckNAddStates(891, 893); }
                   break;
-               case 321:
+               case 322:
                   if (curChar == 47)
                      { jjCheckNAddStates(894, 896); }
                   break;
-               case 322:
-                  if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 315;
-                  break;
                case 323:
+                  if (curChar == 47)
+                     jjstateSet[jjnewStateCnt++] = 316;
+                  break;
+               case 324:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(894, 896); }
                   break;
-               case 326:
+               case 327:
                   if (curChar != 34)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(171, 175); }
+                  { jjCheckNAddStates(167, 171); }
                   break;
-               case 327:
+               case 328:
                   if ((0xfffffffbffffcbffL & l) != 0L)
                      { jjCheckNAddStates(897, 899); }
                   break;
-               case 328:
+               case 329:
                   if (curChar == 34 && kind > 34)
                      kind = 34;
                   break;
-               case 330:
+               case 331:
                   if ((0x3400L & l) != 0L)
                      { jjCheckNAddStates(897, 899); }
                   break;
-               case 331:
+               case 332:
                   if (curChar == 10)
                      { jjCheckNAddStates(897, 899); }
                   break;
-               case 332:
-               case 335:
-                  if (curChar == 13)
-                     { jjCheckNAdd(331); }
-                  break;
                case 333:
+               case 336:
+                  if (curChar == 13)
+                     { jjCheckNAdd(332); }
+                  break;
+               case 334:
                   if ((0xfc00ffffffffcbffL & l) != 0L)
                      { jjCheckNAddStates(897, 899); }
                   break;
-               case 334:
+               case 335:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(900, 905); }
                   break;
-               case 336:
+               case 337:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(897, 899); }
                   break;
-               case 337:
+               case 338:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(906, 914); }
                   break;
-               case 338:
+               case 339:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(915, 919); }
                   break;
-               case 339:
+               case 340:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(920, 925); }
                   break;
-               case 340:
+               case 341:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(926, 932); }
                   break;
-               case 341:
+               case 342:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(933, 940); }
                   break;
-               case 342:
+               case 343:
                   if ((0xfffffffbffffcbffL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(342, 343); }
+                  { jjCheckNAddTwoStates(343, 344); }
                   break;
-               case 344:
+               case 345:
                   if ((0x3400L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(342, 343); }
+                  { jjCheckNAddTwoStates(343, 344); }
                   break;
-               case 345:
+               case 346:
                   if (curChar != 10)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(342, 343); }
-                  break;
-               case 346:
-               case 349:
-                  if (curChar == 13)
-                     { jjCheckNAdd(345); }
+                  { jjCheckNAddTwoStates(343, 344); }
                   break;
                case 347:
+               case 350:
+                  if (curChar == 13)
+                     { jjCheckNAdd(346); }
+                  break;
+               case 348:
                   if ((0xfc00ffffffffcbffL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(342, 343); }
+                  { jjCheckNAddTwoStates(343, 344); }
                   break;
-               case 348:
+               case 349:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(941, 945); }
                   break;
-               case 350:
+               case 351:
                   if ((0x100003600L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(342, 343); }
-                  break;
-               case 351:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 35)
-                     kind = 35;
-                  { jjCheckNAddStates(946, 953); }
+                  { jjCheckNAddTwoStates(343, 344); }
                   break;
                case 352:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(954, 957); }
+                  { jjCheckNAddStates(946, 953); }
                   break;
                case 353:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(958, 962); }
+                  { jjCheckNAddStates(954, 957); }
                   break;
                case 354:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(963, 968); }
+                  { jjCheckNAddStates(958, 962); }
                   break;
                case 355:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(969, 975); }
+                  { jjCheckNAddStates(963, 968); }
                   break;
                case 356:
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 35)
+                     kind = 35;
+                  { jjCheckNAddStates(969, 975); }
+                  break;
+               case 357:
                   if (curChar != 39)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(166, 170); }
+                  { jjCheckNAddStates(162, 166); }
                   break;
-               case 357:
+               case 358:
                   if ((0xffffff7fffffcbffL & l) != 0L)
                      { jjCheckNAddStates(976, 978); }
                   break;
-               case 358:
+               case 359:
                   if (curChar == 39 && kind > 34)
                      kind = 34;
                   break;
-               case 360:
+               case 361:
                   if ((0x3400L & l) != 0L)
                      { jjCheckNAddStates(976, 978); }
                   break;
-               case 361:
+               case 362:
                   if (curChar == 10)
                      { jjCheckNAddStates(976, 978); }
                   break;
-               case 362:
-               case 365:
-                  if (curChar == 13)
-                     { jjCheckNAdd(361); }
-                  break;
                case 363:
+               case 366:
+                  if (curChar == 13)
+                     { jjCheckNAdd(362); }
+                  break;
+               case 364:
                   if ((0xfc00ffffffffcbffL & l) != 0L)
                      { jjCheckNAddStates(976, 978); }
                   break;
-               case 364:
+               case 365:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(979, 984); }
                   break;
-               case 366:
+               case 367:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(976, 978); }
                   break;
-               case 367:
+               case 368:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(985, 993); }
                   break;
-               case 368:
+               case 369:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(994, 998); }
                   break;
-               case 369:
+               case 370:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(999, 1004); }
                   break;
-               case 370:
+               case 371:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1005, 1011); }
                   break;
-               case 371:
+               case 372:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1012, 1019); }
                   break;
-               case 372:
+               case 373:
                   if ((0xffffff7fffffcbffL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(372, 373); }
+                  { jjCheckNAddTwoStates(373, 374); }
                   break;
-               case 374:
+               case 375:
                   if ((0x3400L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(372, 373); }
+                  { jjCheckNAddTwoStates(373, 374); }
                   break;
-               case 375:
+               case 376:
                   if (curChar != 10)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(372, 373); }
-                  break;
-               case 376:
-               case 379:
-                  if (curChar == 13)
-                     { jjCheckNAdd(375); }
+                  { jjCheckNAddTwoStates(373, 374); }
                   break;
                case 377:
+               case 380:
+                  if (curChar == 13)
+                     { jjCheckNAdd(376); }
+                  break;
+               case 378:
                   if ((0xfc00ffffffffcbffL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(372, 373); }
+                  { jjCheckNAddTwoStates(373, 374); }
                   break;
-               case 378:
+               case 379:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(1020, 1024); }
                   break;
-               case 380:
+               case 381:
                   if ((0x100003600L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(372, 373); }
-                  break;
-               case 381:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 35)
-                     kind = 35;
-                  { jjCheckNAddStates(1025, 1032); }
+                  { jjCheckNAddTwoStates(373, 374); }
                   break;
                case 382:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(1033, 1036); }
+                  { jjCheckNAddStates(1025, 1032); }
                   break;
                case 383:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(1037, 1041); }
+                  { jjCheckNAddStates(1033, 1036); }
                   break;
                case 384:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(1042, 1047); }
+                  { jjCheckNAddStates(1037, 1041); }
                   break;
                case 385:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddStates(1048, 1054); }
+                  { jjCheckNAddStates(1042, 1047); }
                   break;
                case 386:
-                  if (curChar == 45)
-                     { jjAddStates(162, 165); }
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 35)
+                     kind = 35;
+                  { jjCheckNAddStates(1048, 1054); }
                   break;
-               case 388:
+               case 387:
+                  if (curChar == 45)
+                     { jjAddStates(158, 161); }
+                  break;
+               case 389:
                   if ((0x3ff200000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddTwoStates(388, 389); }
+                  { jjCheckNAddTwoStates(389, 390); }
                   break;
-               case 390:
+               case 391:
                   if ((0xfc00ffffffffcbffL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddTwoStates(388, 389); }
+                  { jjCheckNAddTwoStates(389, 390); }
                   break;
-               case 391:
+               case 392:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1055, 1059); }
                   break;
-               case 392:
+               case 393:
                   if (curChar != 10)
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddTwoStates(388, 389); }
-                  break;
-               case 393:
-               case 424:
-                  if (curChar == 13)
-                     { jjCheckNAdd(392); }
+                  { jjCheckNAddTwoStates(389, 390); }
                   break;
                case 394:
+               case 425:
+                  if (curChar == 13)
+                     { jjCheckNAdd(393); }
+                  break;
+               case 395:
                   if ((0x100003600L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddTwoStates(388, 389); }
-                  break;
-               case 395:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 36)
-                     kind = 36;
-                  { jjCheckNAddStates(1060, 1067); }
+                  { jjCheckNAddTwoStates(389, 390); }
                   break;
                case 396:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddStates(1068, 1071); }
+                  { jjCheckNAddStates(1060, 1067); }
                   break;
                case 397:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddStates(1072, 1076); }
+                  { jjCheckNAddStates(1068, 1071); }
                   break;
                case 398:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddStates(1077, 1082); }
+                  { jjCheckNAddStates(1072, 1076); }
                   break;
                case 399:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
+                  { jjCheckNAddStates(1077, 1082); }
+                  break;
+               case 400:
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 36)
+                     kind = 36;
                   { jjCheckNAddStates(1083, 1089); }
                   break;
-               case 401:
+               case 402:
                   if ((0x3ff200000000000L & l) != 0L)
                      { jjCheckNAddStates(1090, 1092); }
                   break;
-               case 402:
+               case 403:
                   if (curChar == 40 && kind > 103)
                      kind = 103;
                   break;
-               case 404:
+               case 405:
                   if ((0xfc00ffffffffcbffL & l) != 0L)
                      { jjCheckNAddStates(1090, 1092); }
                   break;
-               case 405:
+               case 406:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1093, 1098); }
                   break;
-               case 406:
+               case 407:
                   if (curChar == 10)
                      { jjCheckNAddStates(1090, 1092); }
                   break;
-               case 407:
-               case 416:
-                  if (curChar == 13)
-                     { jjCheckNAdd(406); }
-                  break;
                case 408:
+               case 417:
+                  if (curChar == 13)
+                     { jjCheckNAdd(407); }
+                  break;
+               case 409:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(1090, 1092); }
                   break;
-               case 409:
+               case 410:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1099, 1107); }
                   break;
-               case 410:
+               case 411:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1108, 1112); }
                   break;
-               case 411:
+               case 412:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1113, 1118); }
                   break;
-               case 412:
+               case 413:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1119, 1125); }
                   break;
-               case 413:
+               case 414:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1126, 1133); }
                   break;
-               case 415:
+               case 416:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1134, 1139); }
                   break;
-               case 417:
+               case 418:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1140, 1148); }
                   break;
-               case 418:
+               case 419:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1149, 1153); }
                   break;
-               case 419:
+               case 420:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1154, 1159); }
                   break;
-               case 420:
+               case 421:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1160, 1166); }
                   break;
-               case 421:
+               case 422:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1167, 1174); }
                   break;
-               case 423:
+               case 424:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1175, 1179); }
                   break;
-               case 425:
+               case 426:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1180, 1187); }
                   break;
-               case 426:
+               case 427:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1188, 1191); }
                   break;
-               case 427:
+               case 428:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1192, 1196); }
                   break;
-               case 428:
+               case 429:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1197, 1202); }
                   break;
-               case 429:
+               case 430:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1203, 1209); }
                   break;
-               case 431:
-                  if (curChar == 35)
-                     { jjCheckNAddStates(157, 161); }
-                  break;
                case 432:
-                  if (curChar == 45)
-                     { jjCheckNAddTwoStates(433, 446); }
+                  if (curChar == 35)
+                     { jjCheckNAddStates(153, 157); }
                   break;
-               case 434:
+               case 433:
+                  if (curChar == 45)
+                     { jjCheckNAddTwoStates(434, 447); }
+                  break;
+               case 435:
                   if ((0x3ff200000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddTwoStates(434, 435); }
+                  { jjCheckNAddTwoStates(435, 436); }
                   break;
-               case 436:
+               case 437:
                   if ((0xfc00ffffffffcbffL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddTwoStates(434, 435); }
+                  { jjCheckNAddTwoStates(435, 436); }
                   break;
-               case 437:
+               case 438:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1210, 1214); }
                   break;
-               case 438:
+               case 439:
                   if (curChar != 10)
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddTwoStates(434, 435); }
-                  break;
-               case 439:
-               case 448:
-                  if (curChar == 13)
-                     { jjCheckNAdd(438); }
+                  { jjCheckNAddTwoStates(435, 436); }
                   break;
                case 440:
+               case 449:
+                  if (curChar == 13)
+                     { jjCheckNAdd(439); }
+                  break;
+               case 441:
                   if ((0x100003600L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddTwoStates(434, 435); }
-                  break;
-               case 441:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 37)
-                     kind = 37;
-                  { jjCheckNAddStates(1215, 1222); }
+                  { jjCheckNAddTwoStates(435, 436); }
                   break;
                case 442:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddStates(1223, 1226); }
+                  { jjCheckNAddStates(1215, 1222); }
                   break;
                case 443:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddStates(1227, 1231); }
+                  { jjCheckNAddStates(1223, 1226); }
                   break;
                case 444:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddStates(1232, 1237); }
+                  { jjCheckNAddStates(1227, 1231); }
                   break;
                case 445:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
+                  { jjCheckNAddStates(1232, 1237); }
+                  break;
+               case 446:
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 37)
+                     kind = 37;
                   { jjCheckNAddStates(1238, 1244); }
                   break;
-               case 447:
+               case 448:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1245, 1249); }
                   break;
-               case 449:
+               case 450:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1250, 1257); }
                   break;
-               case 450:
+               case 451:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1258, 1261); }
                   break;
-               case 451:
+               case 452:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1262, 1266); }
                   break;
-               case 452:
+               case 453:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1267, 1272); }
                   break;
-               case 453:
+               case 454:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1273, 1279); }
                   break;
-               case 454:
+               case 455:
                   if ((0x3ff200000000000L & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddTwoStates(454, 455); }
+                  { jjCheckNAddTwoStates(455, 456); }
                   break;
-               case 456:
+               case 457:
                   if ((0xfc00ffffffffcbffL & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddTwoStates(454, 455); }
+                  { jjCheckNAddTwoStates(455, 456); }
                   break;
-               case 457:
+               case 458:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
                   { jjCheckNAddStates(1280, 1284); }
                   break;
-               case 458:
+               case 459:
                   if (curChar != 10)
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddTwoStates(454, 455); }
-                  break;
-               case 459:
-                  if (curChar == 13)
-                     jjstateSet[jjnewStateCnt++] = 458;
+                  { jjCheckNAddTwoStates(455, 456); }
                   break;
                case 460:
+                  if (curChar == 13)
+                     jjstateSet[jjnewStateCnt++] = 459;
+                  break;
+               case 461:
                   if ((0x100003600L & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddTwoStates(454, 455); }
-                  break;
-               case 461:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 38)
-                     kind = 38;
-                  { jjCheckNAddStates(1285, 1292); }
+                  { jjCheckNAddTwoStates(455, 456); }
                   break;
                case 462:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddStates(1293, 1296); }
+                  { jjCheckNAddStates(1285, 1292); }
                   break;
                case 463:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddStates(1297, 1301); }
+                  { jjCheckNAddStates(1293, 1296); }
                   break;
                case 464:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddStates(1302, 1307); }
+                  { jjCheckNAddStates(1297, 1301); }
                   break;
                case 465:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
+                  { jjCheckNAddStates(1302, 1307); }
+                  break;
+               case 466:
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 38)
+                     kind = 38;
                   { jjCheckNAddStates(1308, 1314); }
                   break;
-               case 467:
+               case 468:
                   if (curChar == 40)
                      { jjCheckNAddStates(1315, 1320); }
                   break;
-               case 468:
-                  if (curChar == 34)
-                     { jjCheckNAddStates(1321, 1323); }
-                  break;
                case 469:
-                  if ((0xfffffffbffffcbffL & l) != 0L)
+                  if (curChar == 34)
                      { jjCheckNAddStates(1321, 1323); }
                   break;
                case 470:
-                  if (curChar == 34)
-                     { jjCheckNAddTwoStates(471, 480); }
+                  if ((0xfffffffbffffcbffL & l) != 0L)
+                     { jjCheckNAddStates(1321, 1323); }
                   break;
                case 471:
+                  if (curChar == 34)
+                     { jjCheckNAddTwoStates(472, 481); }
+                  break;
+               case 472:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(1324, 1326); }
                   break;
-               case 472:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(473, 474); }
-                  break;
                case 473:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(473, 474); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(474, 475); }
                   break;
                case 474:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(474, 475); }
+                  break;
+               case 475:
                   if (curChar == 42)
                      { jjCheckNAddStates(1327, 1329); }
                   break;
-               case 475:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(476, 477); }
-                  break;
                case 476:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(476, 477); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(477, 478); }
                   break;
                case 477:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(477, 478); }
+                  break;
+               case 478:
                   if (curChar == 42)
                      { jjCheckNAddStates(1330, 1332); }
                   break;
-               case 478:
+               case 479:
                   if (curChar == 47)
                      { jjCheckNAddStates(1324, 1326); }
                   break;
-               case 479:
-                  if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 472;
-                  break;
                case 480:
+                  if (curChar == 47)
+                     jjstateSet[jjnewStateCnt++] = 473;
+                  break;
+               case 481:
                   if (curChar == 41 && kind > 54)
                      kind = 54;
                   break;
-               case 482:
-                  if ((0x3400L & l) != 0L)
-                     { jjCheckNAddStates(1321, 1323); }
-                  break;
                case 483:
-                  if (curChar == 10)
+                  if ((0x3400L & l) != 0L)
                      { jjCheckNAddStates(1321, 1323); }
                   break;
                case 484:
-               case 487:
-                  if (curChar == 13)
-                     { jjCheckNAdd(483); }
+                  if (curChar == 10)
+                     { jjCheckNAddStates(1321, 1323); }
                   break;
                case 485:
+               case 488:
+                  if (curChar == 13)
+                     { jjCheckNAdd(484); }
+                  break;
+               case 486:
                   if ((0xfc00ffffffffcbffL & l) != 0L)
                      { jjCheckNAddStates(1321, 1323); }
                   break;
-               case 486:
+               case 487:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1333, 1338); }
                   break;
-               case 488:
+               case 489:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(1321, 1323); }
                   break;
-               case 489:
+               case 490:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1339, 1347); }
                   break;
-               case 490:
+               case 491:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1348, 1352); }
                   break;
-               case 491:
+               case 492:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1353, 1358); }
                   break;
-               case 492:
+               case 493:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1359, 1365); }
                   break;
-               case 493:
+               case 494:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1366, 1373); }
                   break;
-               case 494:
-                  if (curChar == 39)
-                     { jjCheckNAddStates(1374, 1376); }
-                  break;
                case 495:
-                  if ((0xffffff7fffffcbffL & l) != 0L)
+                  if (curChar == 39)
                      { jjCheckNAddStates(1374, 1376); }
                   break;
                case 496:
-                  if (curChar == 39)
-                     { jjCheckNAddTwoStates(471, 480); }
+                  if ((0xffffff7fffffcbffL & l) != 0L)
+                     { jjCheckNAddStates(1374, 1376); }
                   break;
-               case 498:
+               case 497:
+                  if (curChar == 39)
+                     { jjCheckNAddTwoStates(472, 481); }
+                  break;
+               case 499:
                   if ((0x3400L & l) != 0L)
                      { jjCheckNAddStates(1374, 1376); }
                   break;
-               case 499:
+               case 500:
                   if (curChar == 10)
                      { jjCheckNAddStates(1374, 1376); }
                   break;
-               case 500:
-               case 503:
-                  if (curChar == 13)
-                     { jjCheckNAdd(499); }
-                  break;
                case 501:
+               case 504:
+                  if (curChar == 13)
+                     { jjCheckNAdd(500); }
+                  break;
+               case 502:
                   if ((0xfc00ffffffffcbffL & l) != 0L)
                      { jjCheckNAddStates(1374, 1376); }
                   break;
-               case 502:
+               case 503:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1377, 1382); }
                   break;
-               case 504:
+               case 505:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(1374, 1376); }
                   break;
-               case 505:
+               case 506:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1383, 1391); }
                   break;
-               case 506:
+               case 507:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1392, 1396); }
                   break;
-               case 507:
+               case 508:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1397, 1402); }
                   break;
-               case 508:
+               case 509:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1403, 1409); }
                   break;
-               case 509:
+               case 510:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1410, 1417); }
                   break;
-               case 510:
+               case 511:
                   if ((0xfffffc7a00000000L & l) != 0L)
                      { jjCheckNAddStates(1418, 1421); }
                   break;
-               case 512:
+               case 513:
                   if ((0xfc00ffffffffcbffL & l) != 0L)
                      { jjCheckNAddStates(1418, 1421); }
                   break;
-               case 513:
+               case 514:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1422, 1427); }
                   break;
-               case 514:
+               case 515:
                   if (curChar == 10)
                      { jjCheckNAddStates(1418, 1421); }
                   break;
-               case 515:
-                  if (curChar == 13)
-                     jjstateSet[jjnewStateCnt++] = 514;
-                  break;
                case 516:
+                  if (curChar == 13)
+                     jjstateSet[jjnewStateCnt++] = 515;
+                  break;
+               case 517:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(1428, 1433); }
                   break;
-               case 517:
+               case 518:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1434, 1442); }
                   break;
-               case 518:
+               case 519:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1443, 1447); }
                   break;
-               case 519:
+               case 520:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1448, 1453); }
                   break;
-               case 520:
+               case 521:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1454, 1460); }
                   break;
-               case 521:
+               case 522:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1461, 1468); }
                   break;
-               case 522:
+               case 523:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(1469, 1477); }
                   break;
-               case 523:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(524, 525); }
-                  break;
                case 524:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(524, 525); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(525, 526); }
                   break;
                case 525:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(525, 526); }
+                  break;
+               case 526:
                   if (curChar == 42)
                      { jjCheckNAddStates(1478, 1480); }
                   break;
-               case 526:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(527, 528); }
-                  break;
                case 527:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(527, 528); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(528, 529); }
                   break;
                case 528:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(528, 529); }
+                  break;
+               case 529:
                   if (curChar == 42)
                      { jjCheckNAddStates(1481, 1483); }
                   break;
-               case 529:
+               case 530:
                   if (curChar == 47)
                      { jjCheckNAddStates(1484, 1490); }
                   break;
-               case 530:
+               case 531:
                   if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 523;
-                  break;
-               case 533:
-                  if (curChar == 43)
-                     { jjAddStates(1491, 1492); }
+                     jjstateSet[jjnewStateCnt++] = 524;
                   break;
                case 534:
-                  if (curChar != 63)
-                     break;
-                  if (kind > 97)
-                     kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 535;
+                  if (curChar == 43)
+                     { jjAddStates(1491, 1492); }
                   break;
                case 535:
                   if (curChar != 63)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddStates(1493, 1496); }
+                  jjstateSet[jjnewStateCnt++] = 536;
                   break;
                case 536:
+                  if (curChar != 63)
+                     break;
+                  if (kind > 97)
+                     kind = 97;
+                  { jjCheckNAddStates(1493, 1496); }
+                  break;
+               case 537:
                   if (curChar == 63 && kind > 97)
                      kind = 97;
                   break;
-               case 537:
-               case 553:
-               case 557:
-               case 560:
-               case 563:
-                  if (curChar != 63)
-                     break;
-                  if (kind > 97)
-                     kind = 97;
-                  { jjCheckNAdd(536); }
-                  break;
                case 538:
+               case 554:
+               case 558:
+               case 561:
+               case 564:
                   if (curChar != 63)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddTwoStates(536, 537); }
+                  { jjCheckNAdd(537); }
                   break;
                case 539:
                   if (curChar != 63)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddStates(1497, 1499); }
+                  { jjCheckNAddTwoStates(537, 538); }
                   break;
                case 540:
+                  if (curChar != 63)
+                     break;
+                  if (kind > 97)
+                     kind = 97;
+                  { jjCheckNAddStates(1497, 1499); }
+                  break;
+               case 541:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
                   { jjAddStates(1500, 1505); }
-                  break;
-               case 541:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 542;
                   break;
                case 542:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -2955,15 +2960,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 544:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(545); }
+                     jjstateSet[jjnewStateCnt++] = 545;
                   break;
                case 545:
-                  if ((0x3ff000000000000L & l) != 0L && kind > 97)
-                     kind = 97;
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAdd(546); }
                   break;
                case 546:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 547;
+                  if ((0x3ff000000000000L & l) != 0L && kind > 97)
+                     kind = 97;
                   break;
                case 547:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -2974,892 +2979,896 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 549;
                   break;
                case 549:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 550;
+                  break;
+               case 550:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAdd(536); }
-                  break;
-               case 550:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 551;
+                  { jjCheckNAdd(537); }
                   break;
                case 551:
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 552;
                   break;
                case 552:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 553;
+                  break;
+               case 553:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 553;
-                  break;
-               case 554:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 555;
+                  jjstateSet[jjnewStateCnt++] = 554;
                   break;
                case 555:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 556;
+                  break;
+               case 556:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 556;
+                  jjstateSet[jjnewStateCnt++] = 557;
                   break;
-               case 556:
+               case 557:
                   if (curChar != 63)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddTwoStates(536, 557); }
+                  { jjCheckNAddTwoStates(537, 558); }
                   break;
-               case 558:
+               case 559:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 559;
+                  jjstateSet[jjnewStateCnt++] = 560;
                   break;
-               case 559:
+               case 560:
                   if (curChar != 63)
                      break;
                   if (kind > 97)
                      kind = 97;
                   { jjCheckNAddStates(1506, 1508); }
                   break;
-               case 561:
+               case 562:
                   if (curChar != 63)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddTwoStates(536, 560); }
+                  { jjCheckNAddTwoStates(537, 561); }
                   break;
-               case 562:
+               case 563:
                   if (curChar != 63)
                      break;
                   if (kind > 97)
                      kind = 97;
                   { jjCheckNAddStates(1509, 1512); }
                   break;
-               case 564:
+               case 565:
                   if (curChar != 63)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddTwoStates(536, 563); }
+                  { jjCheckNAddTwoStates(537, 564); }
                   break;
-               case 565:
+               case 566:
                   if (curChar != 63)
                      break;
                   if (kind > 97)
                      kind = 97;
                   { jjCheckNAddStates(1513, 1515); }
                   break;
-               case 566:
-                  if (curChar == 43)
-                     jjstateSet[jjnewStateCnt++] = 567;
-                  break;
                case 567:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(568, 574); }
+                  if (curChar == 43)
+                     jjstateSet[jjnewStateCnt++] = 568;
                   break;
                case 568:
-                  if (curChar == 45)
-                     jjstateSet[jjnewStateCnt++] = 569;
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(569, 575); }
                   break;
                case 569:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 97)
-                     kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 570;
+                  if (curChar == 45)
+                     jjstateSet[jjnewStateCnt++] = 570;
                   break;
                case 570:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddStates(1516, 1519); }
+                  jjstateSet[jjnewStateCnt++] = 571;
                   break;
                case 571:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAdd(545); }
+                  { jjCheckNAddStates(1516, 1519); }
                   break;
                case 572:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddTwoStates(545, 571); }
+                  { jjCheckNAdd(546); }
                   break;
                case 573:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddStates(1520, 1522); }
+                  { jjCheckNAddTwoStates(546, 572); }
                   break;
                case 574:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(1523, 1527); }
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 97)
+                     kind = 97;
+                  { jjCheckNAddStates(1520, 1522); }
                   break;
                case 575:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(568); }
+                     { jjCheckNAddStates(1523, 1527); }
                   break;
                case 576:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(575, 568); }
+                     { jjCheckNAdd(569); }
                   break;
                case 577:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(1528, 1530); }
+                     { jjCheckNAddTwoStates(576, 569); }
                   break;
                case 578:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(1531, 1534); }
+                     { jjCheckNAddStates(1528, 1530); }
                   break;
                case 579:
-                  if (curChar == 46)
-                     { jjCheckNAddStates(129, 156); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(1531, 1534); }
                   break;
                case 580:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(580, 582); }
+                  if (curChar == 46)
+                     { jjCheckNAddStates(125, 152); }
                   break;
-               case 583:
+               case 581:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(583, 585); }
+                     { jjCheckNAddTwoStates(581, 583); }
                   break;
-               case 586:
+               case 584:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(586, 588); }
+                     { jjCheckNAddTwoStates(584, 586); }
                   break;
-               case 589:
+               case 587:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(589, 591); }
+                     { jjCheckNAddTwoStates(587, 589); }
                   break;
-               case 592:
+               case 590:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(592, 594); }
+                     { jjCheckNAddTwoStates(590, 592); }
                   break;
-               case 595:
+               case 593:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(595, 597); }
+                     { jjCheckNAddTwoStates(593, 595); }
                   break;
-               case 598:
+               case 596:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(598, 602); }
+                     { jjCheckNAddTwoStates(596, 598); }
                   break;
-               case 603:
+               case 599:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(603, 607); }
+                     { jjCheckNAddTwoStates(599, 603); }
                   break;
-               case 608:
+               case 604:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(608, 610); }
+                     { jjCheckNAddTwoStates(604, 608); }
                   break;
-               case 611:
+               case 609:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(611, 612); }
+                     { jjCheckNAddTwoStates(609, 611); }
                   break;
-               case 613:
+               case 612:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(613, 614); }
+                     { jjCheckNAddTwoStates(612, 613); }
                   break;
-               case 615:
+               case 614:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(615, 617); }
+                     { jjCheckNAddTwoStates(614, 615); }
                   break;
-               case 618:
+               case 616:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(618, 620); }
+                     { jjCheckNAddTwoStates(616, 618); }
                   break;
-               case 621:
+               case 619:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(621, 623); }
+                     { jjCheckNAddTwoStates(619, 621); }
                   break;
-               case 624:
+               case 622:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(624, 626); }
+                     { jjCheckNAddTwoStates(622, 624); }
                   break;
-               case 627:
+               case 625:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(627, 629); }
+                     { jjCheckNAddTwoStates(625, 627); }
                   break;
-               case 630:
+               case 628:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(628, 630); }
+                  break;
+               case 631:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1535, 1539); }
                   break;
-               case 644:
+               case 645:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(644, 646); }
+                     { jjCheckNAddTwoStates(645, 647); }
                   break;
-               case 647:
+               case 648:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(647, 649); }
+                     { jjCheckNAddTwoStates(648, 650); }
                   break;
-               case 650:
+               case 651:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1540, 1542); }
                   break;
-               case 654:
+               case 655:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1543, 1545); }
                   break;
-               case 659:
+               case 660:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(659, 660); }
+                     { jjCheckNAddTwoStates(660, 661); }
                   break;
-               case 669:
+               case 670:
                   if ((0x3ff000000000000L & l) != 0L)
                      { jjCheckNAddStates(1546, 1548); }
                   break;
-               case 671:
+               case 672:
                   if ((0x3ff200000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddTwoStates(671, 672); }
+                  { jjCheckNAddTwoStates(672, 673); }
                   break;
-               case 673:
+               case 674:
                   if ((0xfc00ffffffffcbffL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddTwoStates(671, 672); }
+                  { jjCheckNAddTwoStates(672, 673); }
                   break;
-               case 674:
+               case 675:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1549, 1553); }
                   break;
-               case 675:
+               case 676:
                   if (curChar != 10)
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddTwoStates(671, 672); }
-                  break;
-               case 676:
-               case 685:
-                  if (curChar == 13)
-                     { jjCheckNAdd(675); }
+                  { jjCheckNAddTwoStates(672, 673); }
                   break;
                case 677:
+               case 686:
+                  if (curChar == 13)
+                     { jjCheckNAdd(676); }
+                  break;
+               case 678:
                   if ((0x100003600L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddTwoStates(671, 672); }
-                  break;
-               case 678:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 65)
-                     kind = 65;
-                  { jjCheckNAddStates(1554, 1561); }
+                  { jjCheckNAddTwoStates(672, 673); }
                   break;
                case 679:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddStates(1562, 1565); }
+                  { jjCheckNAddStates(1554, 1561); }
                   break;
                case 680:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddStates(1566, 1570); }
+                  { jjCheckNAddStates(1562, 1565); }
                   break;
                case 681:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddStates(1571, 1576); }
+                  { jjCheckNAddStates(1566, 1570); }
                   break;
                case 682:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
+                  { jjCheckNAddStates(1571, 1576); }
+                  break;
+               case 683:
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 65)
+                     kind = 65;
                   { jjCheckNAddStates(1577, 1583); }
                   break;
-               case 684:
+               case 685:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1584, 1588); }
                   break;
-               case 686:
+               case 687:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1589, 1596); }
                   break;
-               case 687:
+               case 688:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1597, 1600); }
                   break;
-               case 688:
+               case 689:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1601, 1605); }
                   break;
-               case 689:
+               case 690:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1606, 1611); }
                   break;
-               case 690:
+               case 691:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1612, 1618); }
                   break;
-               case 691:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(691, 692); }
-                  break;
                case 692:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(692, 693); }
+                  break;
+               case 693:
                   if (curChar == 37 && kind > 66)
                      kind = 66;
                   break;
-               case 693:
+               case 694:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 67)
                      kind = 67;
-                  { jjCheckNAdd(693); }
+                  { jjCheckNAdd(694); }
                   break;
-               case 694:
+               case 695:
                   if (curChar == 45)
-                     { jjCheckNAddTwoStates(695, 708); }
+                     { jjCheckNAddTwoStates(696, 709); }
                   break;
-               case 696:
+               case 697:
                   if ((0x3ff200000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddTwoStates(696, 697); }
+                  { jjCheckNAddTwoStates(697, 698); }
                   break;
-               case 698:
+               case 699:
                   if ((0xfc00ffffffffcbffL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddTwoStates(696, 697); }
+                  { jjCheckNAddTwoStates(697, 698); }
                   break;
-               case 699:
+               case 700:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1619, 1623); }
                   break;
-               case 700:
+               case 701:
                   if (curChar != 10)
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddTwoStates(696, 697); }
-                  break;
-               case 701:
-               case 710:
-                  if (curChar == 13)
-                     { jjCheckNAdd(700); }
+                  { jjCheckNAddTwoStates(697, 698); }
                   break;
                case 702:
+               case 711:
+                  if (curChar == 13)
+                     { jjCheckNAdd(701); }
+                  break;
+               case 703:
                   if ((0x100003600L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddTwoStates(696, 697); }
-                  break;
-               case 703:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 98)
-                     kind = 98;
-                  { jjCheckNAddStates(1624, 1631); }
+                  { jjCheckNAddTwoStates(697, 698); }
                   break;
                case 704:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddStates(1632, 1635); }
+                  { jjCheckNAddStates(1624, 1631); }
                   break;
                case 705:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddStates(1636, 1640); }
+                  { jjCheckNAddStates(1632, 1635); }
                   break;
                case 706:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddStates(1641, 1646); }
+                  { jjCheckNAddStates(1636, 1640); }
                   break;
                case 707:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
+                  { jjCheckNAddStates(1641, 1646); }
+                  break;
+               case 708:
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 98)
+                     kind = 98;
                   { jjCheckNAddStates(1647, 1653); }
                   break;
-               case 709:
+               case 710:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1654, 1658); }
                   break;
-               case 711:
+               case 712:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1659, 1666); }
                   break;
-               case 712:
+               case 713:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1667, 1670); }
                   break;
-               case 713:
+               case 714:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1671, 1675); }
                   break;
-               case 714:
+               case 715:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1676, 1681); }
                   break;
-               case 715:
+               case 716:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1682, 1688); }
                   break;
-               case 716:
-                  if (curChar == 33)
-                     { jjCheckNAddStates(125, 128); }
-                  break;
                case 717:
+                  if (curChar == 33)
+                     { jjCheckNAddStates(172, 175); }
+                  break;
+               case 718:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(1689, 1691); }
                   break;
-               case 718:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(719, 720); }
-                  break;
                case 719:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(719, 720); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(720, 721); }
                   break;
                case 720:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(720, 721); }
+                  break;
+               case 721:
                   if (curChar == 42)
                      { jjCheckNAddStates(1692, 1694); }
                   break;
-               case 721:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(722, 723); }
-                  break;
                case 722:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(722, 723); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(723, 724); }
                   break;
                case 723:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(723, 724); }
+                  break;
+               case 724:
                   if (curChar == 42)
                      { jjCheckNAddStates(1695, 1697); }
                   break;
-               case 724:
+               case 725:
                   if (curChar == 47)
                      { jjCheckNAddStates(1689, 1691); }
                   break;
-               case 725:
+               case 726:
                   if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 718;
+                     jjstateSet[jjnewStateCnt++] = 719;
                   break;
-               case 735:
+               case 736:
                   if ((0x100003600L & l) != 0L)
                      { jjCheckNAddStates(1698, 1700); }
                   break;
-               case 736:
-                  if (curChar == 42)
-                     { jjCheckNAddTwoStates(737, 738); }
-                  break;
                case 737:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(737, 738); }
+                  if (curChar == 42)
+                     { jjCheckNAddTwoStates(738, 739); }
                   break;
                case 738:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(738, 739); }
+                  break;
+               case 739:
                   if (curChar == 42)
                      { jjCheckNAddStates(1701, 1703); }
                   break;
-               case 739:
-                  if ((0xffff7bffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(740, 741); }
-                  break;
                case 740:
-                  if ((0xfffffbffffffffffL & l) != 0L)
-                     { jjCheckNAddTwoStates(740, 741); }
+                  if ((0xffff7bffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(741, 742); }
                   break;
                case 741:
+                  if ((0xfffffbffffffffffL & l) != 0L)
+                     { jjCheckNAddTwoStates(741, 742); }
+                  break;
+               case 742:
                   if (curChar == 42)
                      { jjCheckNAddStates(1704, 1706); }
                   break;
-               case 742:
+               case 743:
                   if (curChar == 47)
                      { jjCheckNAddStates(1698, 1700); }
                   break;
-               case 743:
+               case 744:
                   if (curChar == 47)
-                     jjstateSet[jjnewStateCnt++] = 736;
+                     jjstateSet[jjnewStateCnt++] = 737;
                   break;
-               case 745:
+               case 746:
                   if ((0x280000000000000L & l) != 0L && kind > 69)
                      kind = 69;
                   break;
-               case 748:
+               case 749:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 67)
                      kind = 67;
                   { jjCheckNAddStates(0, 104); }
                   break;
-               case 749:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(749, 582); }
-                  break;
                case 750:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(750, 751); }
+                     { jjCheckNAddTwoStates(750, 583); }
                   break;
                case 751:
-                  if (curChar == 46)
-                     { jjCheckNAdd(580); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(751, 752); }
                   break;
                case 752:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(752, 585); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(581); }
                   break;
                case 753:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(753, 754); }
+                     { jjCheckNAddTwoStates(753, 586); }
                   break;
                case 754:
-                  if (curChar == 46)
-                     { jjCheckNAdd(583); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(754, 755); }
                   break;
                case 755:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(755, 588); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(584); }
                   break;
                case 756:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(756, 757); }
+                     { jjCheckNAddTwoStates(756, 589); }
                   break;
                case 757:
-                  if (curChar == 46)
-                     { jjCheckNAdd(586); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(757, 758); }
                   break;
                case 758:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(758, 591); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(587); }
                   break;
                case 759:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(759, 760); }
+                     { jjCheckNAddTwoStates(759, 592); }
                   break;
                case 760:
-                  if (curChar == 46)
-                     { jjCheckNAdd(589); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(760, 761); }
                   break;
                case 761:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(761, 594); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(590); }
                   break;
                case 762:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(762, 763); }
+                     { jjCheckNAddTwoStates(762, 595); }
                   break;
                case 763:
-                  if (curChar == 46)
-                     { jjCheckNAdd(592); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(763, 764); }
                   break;
                case 764:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(764, 597); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(593); }
                   break;
                case 765:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(765, 766); }
+                     { jjCheckNAddTwoStates(765, 598); }
                   break;
                case 766:
-                  if (curChar == 46)
-                     { jjCheckNAdd(595); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(766, 767); }
                   break;
                case 767:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(767, 602); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(596); }
                   break;
                case 768:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(768, 769); }
+                     { jjCheckNAddTwoStates(768, 603); }
                   break;
                case 769:
-                  if (curChar == 46)
-                     { jjCheckNAdd(598); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(769, 770); }
                   break;
                case 770:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(770, 607); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(599); }
                   break;
                case 771:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(771, 772); }
+                     { jjCheckNAddTwoStates(771, 608); }
                   break;
                case 772:
-                  if (curChar == 46)
-                     { jjCheckNAdd(603); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(772, 773); }
                   break;
                case 773:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(773, 610); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(604); }
                   break;
                case 774:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(774, 775); }
+                     { jjCheckNAddTwoStates(774, 611); }
                   break;
                case 775:
-                  if (curChar == 46)
-                     { jjCheckNAdd(608); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(775, 776); }
                   break;
                case 776:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(776, 612); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(609); }
                   break;
                case 777:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(777, 778); }
+                     { jjCheckNAddTwoStates(777, 613); }
                   break;
                case 778:
-                  if (curChar == 46)
-                     { jjCheckNAdd(611); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(778, 779); }
                   break;
                case 779:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(779, 614); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(612); }
                   break;
                case 780:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(780, 781); }
+                     { jjCheckNAddTwoStates(780, 615); }
                   break;
                case 781:
-                  if (curChar == 46)
-                     { jjCheckNAdd(613); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(781, 782); }
                   break;
                case 782:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(782, 617); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(614); }
                   break;
                case 783:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(783, 784); }
+                     { jjCheckNAddTwoStates(783, 618); }
                   break;
                case 784:
-                  if (curChar == 46)
-                     { jjCheckNAdd(615); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(784, 785); }
                   break;
                case 785:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(785, 620); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(616); }
                   break;
                case 786:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(786, 787); }
+                     { jjCheckNAddTwoStates(786, 621); }
                   break;
                case 787:
-                  if (curChar == 46)
-                     { jjCheckNAdd(618); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(787, 788); }
                   break;
                case 788:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(788, 623); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(619); }
                   break;
                case 789:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(789, 790); }
+                     { jjCheckNAddTwoStates(789, 624); }
                   break;
                case 790:
-                  if (curChar == 46)
-                     { jjCheckNAdd(621); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(790, 791); }
                   break;
                case 791:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(791, 626); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(622); }
                   break;
                case 792:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(792, 793); }
+                     { jjCheckNAddTwoStates(792, 627); }
                   break;
                case 793:
-                  if (curChar == 46)
-                     { jjCheckNAdd(624); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(793, 794); }
                   break;
                case 794:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(794, 629); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(625); }
                   break;
                case 795:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(795, 796); }
+                     { jjCheckNAddTwoStates(795, 630); }
                   break;
                case 796:
-                  if (curChar == 46)
-                     { jjCheckNAdd(627); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(796, 797); }
                   break;
                case 797:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(1707, 1711); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(628); }
                   break;
                case 798:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(798, 799); }
+                     { jjCheckNAddStates(1707, 1711); }
                   break;
                case 799:
-                  if (curChar == 46)
-                     { jjCheckNAdd(630); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(799, 800); }
                   break;
                case 800:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(800, 646); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(631); }
                   break;
                case 801:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(801, 802); }
+                     { jjCheckNAddTwoStates(801, 647); }
                   break;
                case 802:
-                  if (curChar == 46)
-                     { jjCheckNAdd(644); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(802, 803); }
                   break;
                case 803:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(803, 649); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(645); }
                   break;
                case 804:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(804, 805); }
+                     { jjCheckNAddTwoStates(804, 650); }
                   break;
                case 805:
-                  if (curChar == 46)
-                     { jjCheckNAdd(647); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(805, 806); }
                   break;
                case 806:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(1712, 1714); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(648); }
                   break;
                case 807:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(807, 808); }
+                     { jjCheckNAddStates(1712, 1714); }
                   break;
                case 808:
-                  if (curChar == 46)
-                     { jjCheckNAdd(650); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(808, 809); }
                   break;
                case 809:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(1715, 1717); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(651); }
                   break;
                case 810:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(810, 811); }
+                     { jjCheckNAddStates(1715, 1717); }
                   break;
                case 811:
-                  if (curChar == 46)
-                     { jjCheckNAdd(654); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(811, 812); }
                   break;
                case 812:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(812, 660); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(655); }
                   break;
                case 813:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(813, 814); }
+                     { jjCheckNAddTwoStates(813, 661); }
                   break;
                case 814:
-                  if (curChar == 46)
-                     { jjCheckNAdd(659); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(814, 815); }
                   break;
                case 815:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(1718, 1720); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(660); }
                   break;
                case 816:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(816, 817); }
+                     { jjCheckNAddStates(1718, 1720); }
                   break;
                case 817:
-                  if (curChar == 46)
-                     { jjCheckNAdd(669); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(817, 818); }
                   break;
                case 818:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(818, 692); }
+                  if (curChar == 46)
+                     { jjCheckNAdd(670); }
                   break;
                case 819:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(819, 820); }
+                     { jjCheckNAddTwoStates(819, 693); }
                   break;
                case 820:
-                  if (curChar == 46)
-                     { jjCheckNAdd(691); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(820, 821); }
                   break;
                case 821:
+                  if (curChar == 46)
+                     { jjCheckNAdd(692); }
+                  break;
+               case 822:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 67)
                      kind = 67;
-                  { jjCheckNAdd(821); }
-                  break;
-               case 822:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(822, 823); }
+                  { jjCheckNAdd(822); }
                   break;
                case 823:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddTwoStates(823, 824); }
+                  break;
+               case 824:
                   if (curChar == 46)
-                     { jjCheckNAdd(693); }
+                     { jjCheckNAdd(694); }
                   break;
                default : break;
             }
@@ -3879,13 +3888,18 @@ private int jjMoveNfa_0(int startState, int curPos)
                         kind = 36;
                      { jjCheckNAddStates(1721, 1725); }
                   }
+                  else if ((0x1000000100000000L & l) != 0L)
+                  {
+                     if (kind > 106)
+                        kind = 106;
+                  }
                   else if (curChar == 92)
                      { jjCheckNAddStates(1726, 1729); }
                   else if (curChar == 126)
                   {
                      if (kind > 31)
                         kind = 31;
-                     { jjCheckNAdd(278); }
+                     { jjCheckNAdd(279); }
                   }
                   else if (curChar == 64)
                      { jjAddStates(1730, 1732); }
@@ -4579,752 +4593,752 @@ private int jjMoveNfa_0(int startState, int curPos)
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(829, 836); }
                   break;
-               case 260:
+               case 258:
+                  if ((0x1000000100000000L & l) != 0L && kind > 106)
+                     kind = 106;
+                  break;
+               case 261:
                   { jjAddStates(1768, 1769); }
                   break;
-               case 262:
                case 263:
-                  { jjCheckNAddTwoStates(263, 264); }
+               case 264:
+                  { jjCheckNAddTwoStates(264, 265); }
                   break;
-               case 269:
+               case 270:
                   { jjAddStates(1770, 1771); }
                   break;
-               case 271:
                case 272:
-                  { jjCheckNAddTwoStates(272, 273); }
+               case 273:
+                  { jjCheckNAddTwoStates(273, 274); }
                   break;
-               case 277:
+               case 278:
                   if (curChar == 126)
-                     { jjCheckNAdd(278); }
+                     { jjCheckNAdd(279); }
                   break;
-               case 280:
+               case 281:
                   { jjAddStates(1772, 1773); }
                   break;
-               case 282:
                case 283:
-                  { jjCheckNAddTwoStates(283, 284); }
+               case 284:
+                  { jjCheckNAddTwoStates(284, 285); }
                   break;
-               case 289:
+               case 290:
                   { jjAddStates(1774, 1775); }
                   break;
-               case 291:
                case 292:
-                  { jjCheckNAddTwoStates(292, 293); }
+               case 293:
+                  { jjCheckNAddTwoStates(293, 294); }
                   break;
-               case 298:
+               case 299:
                   { jjAddStates(1776, 1777); }
                   break;
-               case 300:
                case 301:
-                  { jjCheckNAddTwoStates(301, 302); }
+               case 302:
+                  { jjCheckNAddTwoStates(302, 303); }
                   break;
-               case 307:
+               case 308:
                   { jjAddStates(1778, 1779); }
                   break;
-               case 309:
                case 310:
-                  { jjCheckNAddTwoStates(310, 311); }
+               case 311:
+                  { jjCheckNAddTwoStates(311, 312); }
                   break;
-               case 316:
+               case 317:
                   { jjAddStates(1780, 1781); }
                   break;
-               case 318:
                case 319:
-                  { jjCheckNAddTwoStates(319, 320); }
+               case 320:
+                  { jjCheckNAddTwoStates(320, 321); }
                   break;
-               case 324:
+               case 325:
                   if (curChar == 126 && kind > 31)
                      kind = 31;
                   break;
-               case 325:
+               case 326:
                   if (curChar != 126)
                      break;
                   if (kind > 31)
                      kind = 31;
-                  { jjCheckNAdd(278); }
+                  { jjCheckNAdd(279); }
                   break;
-               case 327:
+               case 328:
                   if ((0xffffffffefffffffL & l) != 0L)
                      { jjCheckNAddStates(897, 899); }
                   break;
-               case 329:
+               case 330:
                   if (curChar == 92)
                      { jjAddStates(1782, 1785); }
                   break;
-               case 333:
+               case 334:
                   if ((0xffffff81ffffff81L & l) != 0L)
                      { jjCheckNAddStates(897, 899); }
                   break;
-               case 334:
+               case 335:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(900, 905); }
                   break;
-               case 337:
+               case 338:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(906, 914); }
                   break;
-               case 338:
+               case 339:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(915, 919); }
                   break;
-               case 339:
+               case 340:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(920, 925); }
                   break;
-               case 340:
+               case 341:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(926, 932); }
                   break;
-               case 341:
+               case 342:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(933, 940); }
                   break;
-               case 342:
+               case 343:
                   if ((0xffffffffefffffffL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(342, 343); }
+                  { jjCheckNAddTwoStates(343, 344); }
                   break;
-               case 343:
+               case 344:
                   if (curChar == 92)
                      { jjAddStates(1786, 1789); }
                   break;
-               case 347:
+               case 348:
                   if ((0xffffff81ffffff81L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(342, 343); }
+                  { jjCheckNAddTwoStates(343, 344); }
                   break;
-               case 348:
+               case 349:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(941, 945); }
                   break;
-               case 351:
+               case 352:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(946, 953); }
                   break;
-               case 352:
+               case 353:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(954, 957); }
                   break;
-               case 353:
+               case 354:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(958, 962); }
                   break;
-               case 354:
+               case 355:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(963, 968); }
                   break;
-               case 355:
+               case 356:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(969, 975); }
                   break;
-               case 357:
+               case 358:
                   if ((0xffffffffefffffffL & l) != 0L)
                      { jjCheckNAddStates(976, 978); }
                   break;
-               case 359:
+               case 360:
                   if (curChar == 92)
                      { jjAddStates(1790, 1793); }
                   break;
-               case 363:
+               case 364:
                   if ((0xffffff81ffffff81L & l) != 0L)
                      { jjCheckNAddStates(976, 978); }
                   break;
-               case 364:
+               case 365:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(979, 984); }
                   break;
-               case 367:
+               case 368:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(985, 993); }
                   break;
-               case 368:
+               case 369:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(994, 998); }
                   break;
-               case 369:
+               case 370:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(999, 1004); }
                   break;
-               case 370:
+               case 371:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1005, 1011); }
                   break;
-               case 371:
+               case 372:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1012, 1019); }
                   break;
-               case 372:
+               case 373:
                   if ((0xffffffffefffffffL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(372, 373); }
+                  { jjCheckNAddTwoStates(373, 374); }
                   break;
-               case 373:
+               case 374:
                   if (curChar == 92)
                      { jjAddStates(1794, 1797); }
                   break;
-               case 377:
+               case 378:
                   if ((0xffffff81ffffff81L & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(372, 373); }
+                  { jjCheckNAddTwoStates(373, 374); }
                   break;
-               case 378:
+               case 379:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(1020, 1024); }
                   break;
-               case 381:
+               case 382:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(1025, 1032); }
                   break;
-               case 382:
+               case 383:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(1033, 1036); }
                   break;
-               case 383:
+               case 384:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(1037, 1041); }
                   break;
-               case 384:
+               case 385:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(1042, 1047); }
                   break;
-               case 385:
+               case 386:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 35)
                      kind = 35;
                   { jjCheckNAddStates(1048, 1054); }
                   break;
-               case 387:
                case 388:
+               case 389:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddTwoStates(388, 389); }
-                  break;
-               case 389:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(390, 391); }
+                  { jjCheckNAddTwoStates(389, 390); }
                   break;
                case 390:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(391, 392); }
+                  break;
+               case 391:
                   if ((0xffffff81ffffff81L & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddTwoStates(388, 389); }
+                  { jjCheckNAddTwoStates(389, 390); }
                   break;
-               case 391:
+               case 392:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1055, 1059); }
                   break;
-               case 395:
+               case 396:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1060, 1067); }
                   break;
-               case 396:
+               case 397:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1068, 1071); }
                   break;
-               case 397:
+               case 398:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1072, 1076); }
                   break;
-               case 398:
+               case 399:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1077, 1082); }
                   break;
-               case 399:
+               case 400:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1083, 1089); }
                   break;
-               case 400:
                case 401:
+               case 402:
                   if ((0x7fffffe87fffffeL & l) != 0L)
                      { jjCheckNAddStates(1090, 1092); }
                   break;
-               case 403:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(404, 405); }
-                  break;
                case 404:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(405, 406); }
+                  break;
+               case 405:
                   if ((0xffffff81ffffff81L & l) != 0L)
                      { jjCheckNAddStates(1090, 1092); }
                   break;
-               case 405:
+               case 406:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1093, 1098); }
                   break;
-               case 409:
+               case 410:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1099, 1107); }
                   break;
-               case 410:
+               case 411:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1108, 1112); }
                   break;
-               case 411:
+               case 412:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1113, 1118); }
                   break;
-               case 412:
+               case 413:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1119, 1125); }
                   break;
-               case 413:
+               case 414:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1126, 1133); }
                   break;
-               case 414:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(404, 415); }
-                  break;
                case 415:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(405, 416); }
+                  break;
+               case 416:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1134, 1139); }
                   break;
-               case 417:
+               case 418:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1140, 1148); }
                   break;
-               case 418:
+               case 419:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1149, 1153); }
                   break;
-               case 419:
+               case 420:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1154, 1159); }
                   break;
-               case 420:
+               case 421:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1160, 1166); }
                   break;
-               case 421:
+               case 422:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1167, 1174); }
                   break;
-               case 422:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(390, 423); }
-                  break;
                case 423:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(391, 424); }
+                  break;
+               case 424:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1175, 1179); }
                   break;
-               case 425:
+               case 426:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1180, 1187); }
                   break;
-               case 426:
+               case 427:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1188, 1191); }
                   break;
-               case 427:
+               case 428:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1192, 1196); }
                   break;
-               case 428:
+               case 429:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1197, 1202); }
                   break;
-               case 429:
+               case 430:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1203, 1209); }
                   break;
-               case 430:
+               case 431:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
                   if (kind > 36)
                      kind = 36;
                   { jjCheckNAddStates(1721, 1725); }
                   break;
-               case 433:
                case 434:
+               case 435:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddTwoStates(434, 435); }
-                  break;
-               case 435:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(436, 437); }
+                  { jjCheckNAddTwoStates(435, 436); }
                   break;
                case 436:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(437, 438); }
+                  break;
+               case 437:
                   if ((0xffffff81ffffff81L & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddTwoStates(434, 435); }
+                  { jjCheckNAddTwoStates(435, 436); }
                   break;
-               case 437:
+               case 438:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1210, 1214); }
                   break;
-               case 441:
+               case 442:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1215, 1222); }
                   break;
-               case 442:
+               case 443:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1223, 1226); }
                   break;
-               case 443:
+               case 444:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1227, 1231); }
                   break;
-               case 444:
+               case 445:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1232, 1237); }
                   break;
-               case 445:
+               case 446:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1238, 1244); }
                   break;
-               case 446:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(436, 447); }
-                  break;
                case 447:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(437, 448); }
+                  break;
+               case 448:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1245, 1249); }
                   break;
-               case 449:
+               case 450:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1250, 1257); }
                   break;
-               case 450:
+               case 451:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1258, 1261); }
                   break;
-               case 451:
+               case 452:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1262, 1266); }
                   break;
-               case 452:
+               case 453:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1267, 1272); }
                   break;
-               case 453:
+               case 454:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 37)
                      kind = 37;
                   { jjCheckNAddStates(1273, 1279); }
                   break;
-               case 454:
+               case 455:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddTwoStates(454, 455); }
+                  { jjCheckNAddTwoStates(455, 456); }
                   break;
-               case 455:
+               case 456:
                   if (curChar == 92)
                      { jjAddStates(1798, 1799); }
                   break;
-               case 456:
+               case 457:
                   if ((0xffffff81ffffff81L & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddTwoStates(454, 455); }
+                  { jjCheckNAddTwoStates(455, 456); }
                   break;
-               case 457:
+               case 458:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
                   { jjCheckNAddStates(1280, 1284); }
                   break;
-               case 461:
+               case 462:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
                   { jjCheckNAddStates(1285, 1292); }
                   break;
-               case 462:
+               case 463:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
                   { jjCheckNAddStates(1293, 1296); }
                   break;
-               case 463:
+               case 464:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
                   { jjCheckNAddStates(1297, 1301); }
                   break;
-               case 464:
+               case 465:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
                   { jjCheckNAddStates(1302, 1307); }
                   break;
-               case 465:
+               case 466:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 38)
                      kind = 38;
                   { jjCheckNAddStates(1308, 1314); }
                   break;
-               case 466:
+               case 467:
                   if ((0x20000000200000L & l) != 0L)
                      { jjAddStates(1733, 1735); }
                   break;
-               case 469:
+               case 470:
                   if ((0xffffffffefffffffL & l) != 0L)
                      { jjCheckNAddStates(1321, 1323); }
                   break;
-               case 473:
+               case 474:
                   { jjAddStates(1800, 1801); }
                   break;
-               case 475:
                case 476:
-                  { jjCheckNAddTwoStates(476, 477); }
+               case 477:
+                  { jjCheckNAddTwoStates(477, 478); }
                   break;
-               case 481:
+               case 482:
                   if (curChar == 92)
                      { jjAddStates(1802, 1805); }
                   break;
-               case 485:
+               case 486:
                   if ((0xffffff81ffffff81L & l) != 0L)
                      { jjCheckNAddStates(1321, 1323); }
                   break;
-               case 486:
+               case 487:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1333, 1338); }
                   break;
-               case 489:
+               case 490:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1339, 1347); }
                   break;
-               case 490:
+               case 491:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1348, 1352); }
                   break;
-               case 491:
+               case 492:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1353, 1358); }
                   break;
-               case 492:
+               case 493:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1359, 1365); }
                   break;
-               case 493:
+               case 494:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1366, 1373); }
                   break;
-               case 495:
+               case 496:
                   if ((0xffffffffefffffffL & l) != 0L)
                      { jjCheckNAddStates(1374, 1376); }
                   break;
-               case 497:
+               case 498:
                   if (curChar == 92)
                      { jjAddStates(1806, 1809); }
                   break;
-               case 501:
+               case 502:
                   if ((0xffffff81ffffff81L & l) != 0L)
                      { jjCheckNAddStates(1374, 1376); }
                   break;
-               case 502:
+               case 503:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1377, 1382); }
                   break;
-               case 505:
+               case 506:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1383, 1391); }
                   break;
-               case 506:
+               case 507:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1392, 1396); }
                   break;
-               case 507:
+               case 508:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1397, 1402); }
                   break;
-               case 508:
+               case 509:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1403, 1409); }
                   break;
-               case 509:
+               case 510:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1410, 1417); }
                   break;
-               case 510:
+               case 511:
                   if ((0x7fffffffefffffffL & l) != 0L)
                      { jjCheckNAddStates(1418, 1421); }
                   break;
-               case 511:
+               case 512:
                   if (curChar == 92)
                      { jjAddStates(1810, 1811); }
                   break;
-               case 512:
+               case 513:
                   if ((0xffffff81ffffff81L & l) != 0L)
                      { jjCheckNAddStates(1418, 1421); }
                   break;
-               case 513:
+               case 514:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1422, 1427); }
                   break;
-               case 517:
+               case 518:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1434, 1442); }
                   break;
-               case 518:
+               case 519:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1443, 1447); }
                   break;
-               case 519:
+               case 520:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1448, 1453); }
                   break;
-               case 520:
+               case 521:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1454, 1460); }
                   break;
-               case 521:
+               case 522:
                   if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1461, 1468); }
                   break;
-               case 524:
+               case 525:
                   { jjAddStates(1812, 1813); }
                   break;
-               case 526:
                case 527:
-                  { jjCheckNAddTwoStates(527, 528); }
-                  break;
-               case 531:
-                  if ((0x100000001000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 467;
+               case 528:
+                  { jjCheckNAddTwoStates(528, 529); }
                   break;
                case 532:
-                  if ((0x4000000040000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 531;
+                  if ((0x100000001000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 468;
                   break;
-               case 540:
+               case 533:
+                  if ((0x4000000040000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 532;
+                  break;
+               case 541:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
                   { jjAddStates(1500, 1505); }
-                  break;
-               case 541:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 542;
                   break;
                case 542:
                   if ((0x7e0000007eL & l) != 0L)
@@ -5336,15 +5350,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 544:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(545); }
+                     jjstateSet[jjnewStateCnt++] = 545;
                   break;
                case 545:
-                  if ((0x7e0000007eL & l) != 0L && kind > 97)
-                     kind = 97;
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAdd(546); }
                   break;
                case 546:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 547;
+                  if ((0x7e0000007eL & l) != 0L && kind > 97)
+                     kind = 97;
                   break;
                case 547:
                   if ((0x7e0000007eL & l) != 0L)
@@ -5355,636 +5369,640 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 549;
                   break;
                case 549:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 550;
+                  break;
+               case 550:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 536;
-                  break;
-               case 550:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 551;
+                  jjstateSet[jjnewStateCnt++] = 537;
                   break;
                case 551:
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 552;
                   break;
                case 552:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 553;
+                  break;
+               case 553:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 553;
-                  break;
-               case 554:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 555;
+                  jjstateSet[jjnewStateCnt++] = 554;
                   break;
                case 555:
-                  if ((0x7e0000007eL & l) == 0L)
-                     break;
-                  if (kind > 97)
-                     kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 556;
-                  break;
-               case 558:
-                  if ((0x7e0000007eL & l) == 0L)
-                     break;
-                  if (kind > 97)
-                     kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 559;
-                  break;
-               case 567:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddTwoStates(568, 574); }
+                     jjstateSet[jjnewStateCnt++] = 556;
                   break;
-               case 569:
+               case 556:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  jjstateSet[jjnewStateCnt++] = 570;
+                  jjstateSet[jjnewStateCnt++] = 557;
+                  break;
+               case 559:
+                  if ((0x7e0000007eL & l) == 0L)
+                     break;
+                  if (kind > 97)
+                     kind = 97;
+                  jjstateSet[jjnewStateCnt++] = 560;
+                  break;
+               case 568:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddTwoStates(569, 575); }
                   break;
                case 570:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddStates(1516, 1519); }
+                  jjstateSet[jjnewStateCnt++] = 571;
                   break;
                case 571:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAdd(545); }
+                  { jjCheckNAddStates(1516, 1519); }
                   break;
                case 572:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddTwoStates(545, 571); }
+                  { jjCheckNAdd(546); }
                   break;
                case 573:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAddStates(1520, 1522); }
+                  { jjCheckNAddTwoStates(546, 572); }
                   break;
                case 574:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(1523, 1527); }
+                  if ((0x7e0000007eL & l) == 0L)
+                     break;
+                  if (kind > 97)
+                     kind = 97;
+                  { jjCheckNAddStates(1520, 1522); }
                   break;
                case 575:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(568); }
+                     { jjCheckNAddStates(1523, 1527); }
                   break;
                case 576:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddTwoStates(575, 568); }
+                     { jjCheckNAdd(569); }
                   break;
                case 577:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(1528, 1530); }
+                     { jjCheckNAddTwoStates(576, 569); }
                   break;
                case 578:
                   if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(1528, 1530); }
+                  break;
+               case 579:
+                  if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAddStates(1531, 1534); }
                   break;
-               case 581:
+               case 582:
                   if ((0x200000002000L & l) != 0L && kind > 55)
                      kind = 55;
                   break;
-               case 582:
-               case 590:
+               case 583:
+               case 591:
                   if ((0x2000000020L & l) != 0L)
-                     { jjCheckNAdd(581); }
+                     { jjCheckNAdd(582); }
                   break;
-               case 584:
+               case 585:
                   if ((0x100000001000000L & l) != 0L && kind > 55)
                      kind = 55;
                   break;
-               case 585:
+               case 586:
                   if ((0x2000000020L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 584;
+                     jjstateSet[jjnewStateCnt++] = 585;
                   break;
-               case 587:
+               case 588:
                   if ((0x10000000100L & l) != 0L && kind > 55)
                      kind = 55;
                   break;
-               case 588:
+               case 589:
                   if ((0x800000008L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 587;
+                     jjstateSet[jjnewStateCnt++] = 588;
                   break;
-               case 591:
+               case 592:
                   if ((0x4000000040000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 590;
+                     jjstateSet[jjnewStateCnt++] = 591;
                   break;
-               case 593:
+               case 594:
                   if ((0x80000000800000L & l) != 0L && kind > 56)
                      kind = 56;
                   break;
-               case 594:
+               case 595:
                   if ((0x40000000400000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 593;
+                     jjstateSet[jjnewStateCnt++] = 594;
                   break;
-               case 596:
+               case 597:
                   if ((0x10000000100L & l) != 0L && kind > 56)
                      kind = 56;
                   break;
-               case 597:
+               case 598:
                   if ((0x40000000400000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 596;
+                     jjstateSet[jjnewStateCnt++] = 597;
                   break;
-               case 599:
+               case 600:
                   if ((0x400000004000L & l) != 0L && kind > 56)
                      kind = 56;
                   break;
-               case 600:
-                  if ((0x20000000200L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 599;
-                  break;
                case 601:
-                  if ((0x200000002000L & l) != 0L)
+                  if ((0x20000000200L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 600;
                   break;
                case 602:
-                  if ((0x40000000400000L & l) != 0L)
+                  if ((0x200000002000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 601;
                   break;
-               case 604:
+               case 603:
+                  if ((0x40000000400000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 602;
+                  break;
+               case 605:
                   if ((0x100000001000000L & l) != 0L && kind > 56)
                      kind = 56;
                   break;
-               case 605:
-                  if ((0x200000002L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 604;
-                  break;
                case 606:
-                  if ((0x200000002000L & l) != 0L)
+                  if ((0x200000002L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 605;
                   break;
                case 607:
-                  if ((0x40000000400000L & l) != 0L)
+                  if ((0x200000002000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 606;
                   break;
-               case 609:
+               case 608:
+                  if ((0x40000000400000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 607;
+                  break;
+               case 610:
                   if ((0x200000002000L & l) != 0L && kind > 57)
                      kind = 57;
                   break;
-               case 610:
+               case 611:
                   if ((0x800000008L & l) != 0L)
-                     { jjCheckNAdd(609); }
+                     { jjCheckNAdd(610); }
                   break;
-               case 612:
+               case 613:
                   if ((0x200000002000L & l) != 0L)
-                     { jjCheckNAdd(609); }
+                     { jjCheckNAdd(610); }
                   break;
-               case 614:
+               case 615:
                   if ((0x2000000020000L & l) != 0L && kind > 57)
                      kind = 57;
                   break;
-               case 616:
+               case 617:
                   if ((0x400000004000L & l) != 0L && kind > 57)
                      kind = 57;
                   break;
-               case 617:
+               case 618:
                   if ((0x20000000200L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 616;
+                     jjstateSet[jjnewStateCnt++] = 617;
                   break;
-               case 619:
+               case 620:
                   if ((0x10000000100000L & l) != 0L && kind > 57)
                      kind = 57;
                   break;
-               case 620:
+               case 621:
                   if ((0x1000000010000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 619;
+                     jjstateSet[jjnewStateCnt++] = 620;
                   break;
-               case 622:
+               case 623:
                   if ((0x800000008L & l) != 0L && kind > 57)
                      kind = 57;
                   break;
-               case 623:
+               case 624:
                   if ((0x1000000010000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 622;
+                     jjstateSet[jjnewStateCnt++] = 623;
                   break;
-               case 625:
+               case 626:
                   if ((0x100000001000000L & l) != 0L && kind > 57)
                      kind = 57;
                   break;
-               case 626:
+               case 627:
                   if ((0x1000000010000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 625;
+                     jjstateSet[jjnewStateCnt++] = 626;
                   break;
-               case 628:
+               case 629:
                   if ((0x4000000040000L & l) != 0L && kind > 58)
                      kind = 58;
                   break;
-               case 629:
+               case 630:
                   if ((0x4000000040L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 628;
+                     jjstateSet[jjnewStateCnt++] = 629;
                   break;
-               case 631:
+               case 632:
                   if ((0x8000000080L & l) != 0L && kind > 59)
                      kind = 59;
                   break;
-               case 632:
-                  if ((0x2000000020L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 631;
-                  break;
                case 633:
-                  if ((0x1000000010L & l) != 0L)
+                  if ((0x2000000020L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 632;
                   break;
                case 634:
+                  if ((0x1000000010L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 633;
+                  break;
+               case 635:
                   if ((0x1000000010L & l) != 0L && kind > 59)
                      kind = 59;
                   break;
-               case 635:
-               case 638:
-                  if ((0x200000002L & l) != 0L)
-                     { jjCheckNAdd(634); }
-                  break;
                case 636:
-                  if ((0x4000000040000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 635;
+               case 639:
+                  if ((0x200000002L & l) != 0L)
+                     { jjCheckNAdd(635); }
                   break;
                case 637:
-                  if ((0x8000000080L & l) != 0L)
+                  if ((0x4000000040000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 636;
                   break;
-               case 639:
-                  if ((0x4000000040000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 638;
+               case 638:
+                  if ((0x8000000080L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 637;
                   break;
                case 640:
+                  if ((0x4000000040000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 639;
+                  break;
+               case 641:
                   if ((0x400000004000L & l) != 0L && kind > 59)
                      kind = 59;
                   break;
-               case 641:
-                  if ((0x4000000040000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 640;
-                  break;
                case 642:
-                  if ((0x20000000200000L & l) != 0L)
+                  if ((0x4000000040000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 641;
                   break;
                case 643:
-                  if ((0x10000000100000L & l) != 0L)
+                  if ((0x20000000200000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 642;
                   break;
-               case 645:
+               case 644:
+                  if ((0x10000000100000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 643;
+                  break;
+               case 646:
                   if ((0x400000004L & l) != 0L && kind > 60)
                      kind = 60;
                   break;
-               case 646:
+               case 647:
                   if ((0x1000000010L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 645;
+                     jjstateSet[jjnewStateCnt++] = 646;
                   break;
-               case 648:
+               case 649:
                   if ((0x10000000100000L & l) != 0L && kind > 61)
                      kind = 61;
                   break;
-               case 649:
+               case 650:
                   if ((0x8000000080000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 648;
+                     jjstateSet[jjnewStateCnt++] = 649;
                   break;
-               case 651:
-               case 653:
+               case 652:
+               case 654:
                   if ((0x8000000080000L & l) != 0L && kind > 62)
                      kind = 62;
                   break;
-               case 652:
+               case 653:
                   if ((0x200000002000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 651;
+                     jjstateSet[jjnewStateCnt++] = 652;
                   break;
-               case 655:
+               case 656:
                   if ((0x400000004000000L & l) != 0L && kind > 63)
                      kind = 63;
                   break;
-               case 656:
                case 657:
-                  if ((0x10000000100L & l) != 0L)
-                     { jjCheckNAdd(655); }
-                  break;
                case 658:
-                  if ((0x80000000800L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 657;
+                  if ((0x10000000100L & l) != 0L)
+                     { jjCheckNAdd(656); }
                   break;
-               case 660:
+               case 659:
+                  if ((0x80000000800L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 658;
+                  break;
+               case 661:
                   if ((0x1000000010L & l) != 0L)
                      { jjAddStates(1814, 1816); }
                   break;
-               case 661:
+               case 662:
                   if ((0x20000000200L & l) != 0L && kind > 64)
                      kind = 64;
                   break;
-               case 662:
-                  if ((0x1000000010000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 661;
-                  break;
                case 663:
+                  if ((0x1000000010000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 662;
+                  break;
+               case 664:
                   if ((0x200000002000L & l) != 0L && kind > 64)
                      kind = 64;
                   break;
-               case 664:
-                  if ((0x800000008L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 663;
-                  break;
                case 665:
-                  if ((0x1000000010000L & l) != 0L)
+                  if ((0x800000008L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 664;
                   break;
                case 666:
-                  if ((0x100000001000000L & l) != 0L && kind > 64)
-                     kind = 64;
+                  if ((0x1000000010000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 665;
                   break;
                case 667:
-                  if ((0x1000000010000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 666;
+                  if ((0x100000001000000L & l) != 0L && kind > 64)
+                     kind = 64;
                   break;
                case 668:
                   if ((0x1000000010000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 667;
                   break;
-               case 670:
+               case 669:
+                  if ((0x1000000010000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 668;
+                  break;
                case 671:
+               case 672:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddTwoStates(671, 672); }
-                  break;
-               case 672:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(673, 674); }
+                  { jjCheckNAddTwoStates(672, 673); }
                   break;
                case 673:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(674, 675); }
+                  break;
+               case 674:
                   if ((0xffffff81ffffff81L & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddTwoStates(671, 672); }
+                  { jjCheckNAddTwoStates(672, 673); }
                   break;
-               case 674:
+               case 675:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1549, 1553); }
                   break;
-               case 678:
+               case 679:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1554, 1561); }
                   break;
-               case 679:
+               case 680:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1562, 1565); }
                   break;
-               case 680:
+               case 681:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1566, 1570); }
                   break;
-               case 681:
+               case 682:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1571, 1576); }
                   break;
-               case 682:
+               case 683:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1577, 1583); }
                   break;
-               case 683:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(673, 684); }
-                  break;
                case 684:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(674, 685); }
+                  break;
+               case 685:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1584, 1588); }
                   break;
-               case 686:
+               case 687:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1589, 1596); }
                   break;
-               case 687:
+               case 688:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1597, 1600); }
                   break;
-               case 688:
+               case 689:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1601, 1605); }
                   break;
-               case 689:
+               case 690:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1606, 1611); }
                   break;
-               case 690:
+               case 691:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 65)
                      kind = 65;
                   { jjCheckNAddStates(1612, 1618); }
                   break;
-               case 695:
                case 696:
+               case 697:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddTwoStates(696, 697); }
-                  break;
-               case 697:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(698, 699); }
+                  { jjCheckNAddTwoStates(697, 698); }
                   break;
                case 698:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(699, 700); }
+                  break;
+               case 699:
                   if ((0xffffff81ffffff81L & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddTwoStates(696, 697); }
+                  { jjCheckNAddTwoStates(697, 698); }
                   break;
-               case 699:
+               case 700:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1619, 1623); }
                   break;
-               case 703:
+               case 704:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1624, 1631); }
                   break;
-               case 704:
+               case 705:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1632, 1635); }
                   break;
-               case 705:
+               case 706:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1636, 1640); }
                   break;
-               case 706:
+               case 707:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1641, 1646); }
                   break;
-               case 707:
+               case 708:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1647, 1653); }
                   break;
-               case 708:
-                  if (curChar == 92)
-                     { jjCheckNAddTwoStates(698, 709); }
-                  break;
                case 709:
+                  if (curChar == 92)
+                     { jjCheckNAddTwoStates(699, 710); }
+                  break;
+               case 710:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1654, 1658); }
                   break;
-               case 711:
+               case 712:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1659, 1666); }
                   break;
-               case 712:
+               case 713:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1667, 1670); }
                   break;
-               case 713:
+               case 714:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1671, 1675); }
                   break;
-               case 714:
+               case 715:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1676, 1681); }
                   break;
-               case 715:
+               case 716:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 98)
                      kind = 98;
                   { jjCheckNAddStates(1682, 1688); }
                   break;
-               case 719:
+               case 720:
                   { jjAddStates(1817, 1818); }
                   break;
-               case 721:
                case 722:
-                  { jjCheckNAddTwoStates(722, 723); }
+               case 723:
+                  { jjCheckNAddTwoStates(723, 724); }
                   break;
-               case 726:
+               case 727:
                   if ((0x10000000100000L & l) != 0L && kind > 68)
                      kind = 68;
                   break;
-               case 727:
-                  if ((0x400000004000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 726;
-                  break;
                case 728:
-                  if ((0x200000002L & l) != 0L)
+                  if ((0x400000004000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 727;
                   break;
                case 729:
-                  if ((0x10000000100000L & l) != 0L)
+                  if ((0x200000002L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 728;
                   break;
                case 730:
-                  if ((0x4000000040000L & l) != 0L)
+                  if ((0x10000000100000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 729;
                   break;
                case 731:
-                  if ((0x800000008000L & l) != 0L)
+                  if ((0x4000000040000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 730;
                   break;
                case 732:
-                  if ((0x1000000010000L & l) != 0L)
+                  if ((0x800000008000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 731;
                   break;
                case 733:
-                  if ((0x200000002000L & l) != 0L)
+                  if ((0x1000000010000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 732;
                   break;
                case 734:
-                  if ((0x20000000200L & l) != 0L)
+                  if ((0x200000002000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 733;
                   break;
-               case 737:
+               case 735:
+                  if ((0x20000000200L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 734;
+                  break;
+               case 738:
                   { jjAddStates(1819, 1820); }
                   break;
-               case 739:
                case 740:
-                  { jjCheckNAddTwoStates(740, 741); }
+               case 741:
+                  { jjCheckNAddTwoStates(741, 742); }
                   break;
-               case 744:
+               case 745:
                   if ((0x2000000020L & l) == 0L)
                      break;
                   if (kind > 69)
                      kind = 69;
-                  jjstateSet[jjnewStateCnt++] = 745;
-                  break;
-               case 746:
-                  if ((0x20000000200L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 744;
+                  jjstateSet[jjnewStateCnt++] = 746;
                   break;
                case 747:
+                  if ((0x20000000200L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 745;
+                  break;
+               case 748:
                   if (curChar == 92)
                      { jjCheckNAddStates(1726, 1729); }
                   break;
@@ -6111,195 +6129,195 @@ private int jjMoveNfa_0(int startState, int curPos)
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjCheckNAddTwoStates(233, 234); }
                   break;
-               case 260:
+               case 261:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1768, 1769); }
                   break;
-               case 262:
                case 263:
+               case 264:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(263, 264); }
+                     { jjCheckNAddTwoStates(264, 265); }
                   break;
-               case 269:
+               case 270:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1770, 1771); }
                   break;
-               case 271:
                case 272:
+               case 273:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(272, 273); }
+                     { jjCheckNAddTwoStates(273, 274); }
                   break;
-               case 280:
+               case 281:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1772, 1773); }
                   break;
-               case 282:
                case 283:
+               case 284:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(283, 284); }
+                     { jjCheckNAddTwoStates(284, 285); }
                   break;
-               case 289:
+               case 290:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1774, 1775); }
                   break;
-               case 291:
                case 292:
+               case 293:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(292, 293); }
+                     { jjCheckNAddTwoStates(293, 294); }
                   break;
-               case 298:
+               case 299:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1776, 1777); }
                   break;
-               case 300:
                case 301:
+               case 302:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(301, 302); }
+                     { jjCheckNAddTwoStates(302, 303); }
                   break;
-               case 307:
+               case 308:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1778, 1779); }
                   break;
-               case 309:
                case 310:
+               case 311:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(310, 311); }
+                     { jjCheckNAddTwoStates(311, 312); }
                   break;
-               case 316:
+               case 317:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1780, 1781); }
                   break;
-               case 318:
                case 319:
+               case 320:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(319, 320); }
+                     { jjCheckNAddTwoStates(320, 321); }
                   break;
-               case 327:
-               case 333:
+               case 328:
+               case 334:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjCheckNAddStates(897, 899); }
                   break;
-               case 342:
-               case 347:
+               case 343:
+               case 348:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(342, 343); }
+                  { jjCheckNAddTwoStates(343, 344); }
                   break;
-               case 357:
-               case 363:
+               case 358:
+               case 364:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjCheckNAddStates(976, 978); }
                   break;
-               case 372:
-               case 377:
+               case 373:
+               case 378:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 35)
                      kind = 35;
-                  { jjCheckNAddTwoStates(372, 373); }
+                  { jjCheckNAddTwoStates(373, 374); }
                   break;
-               case 387:
                case 388:
-               case 390:
+               case 389:
+               case 391:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 36)
                      kind = 36;
-                  { jjCheckNAddTwoStates(388, 389); }
+                  { jjCheckNAddTwoStates(389, 390); }
                   break;
-               case 400:
                case 401:
-               case 404:
+               case 402:
+               case 405:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjCheckNAddStates(1090, 1092); }
                   break;
-               case 433:
                case 434:
-               case 436:
+               case 435:
+               case 437:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 37)
                      kind = 37;
-                  { jjCheckNAddTwoStates(434, 435); }
+                  { jjCheckNAddTwoStates(435, 436); }
                   break;
-               case 454:
-               case 456:
+               case 455:
+               case 457:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 38)
                      kind = 38;
-                  { jjCheckNAddTwoStates(454, 455); }
+                  { jjCheckNAddTwoStates(455, 456); }
                   break;
-               case 469:
-               case 485:
+               case 470:
+               case 486:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjCheckNAddStates(1321, 1323); }
                   break;
-               case 473:
+               case 474:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1800, 1801); }
                   break;
-               case 475:
                case 476:
+               case 477:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(476, 477); }
+                     { jjCheckNAddTwoStates(477, 478); }
                   break;
-               case 495:
-               case 501:
+               case 496:
+               case 502:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjCheckNAddStates(1374, 1376); }
                   break;
-               case 510:
-               case 512:
+               case 511:
+               case 513:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjCheckNAddStates(1418, 1421); }
                   break;
-               case 524:
+               case 525:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1812, 1813); }
                   break;
-               case 526:
                case 527:
+               case 528:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(527, 528); }
+                     { jjCheckNAddTwoStates(528, 529); }
                   break;
-               case 670:
                case 671:
-               case 673:
+               case 672:
+               case 674:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 65)
                      kind = 65;
-                  { jjCheckNAddTwoStates(671, 672); }
+                  { jjCheckNAddTwoStates(672, 673); }
                   break;
-               case 695:
                case 696:
-               case 698:
+               case 697:
+               case 699:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 98)
                      kind = 98;
-                  { jjCheckNAddTwoStates(696, 697); }
+                  { jjCheckNAddTwoStates(697, 698); }
                   break;
-               case 719:
+               case 720:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1817, 1818); }
                   break;
-               case 721:
                case 722:
+               case 723:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(722, 723); }
+                     { jjCheckNAddTwoStates(723, 724); }
                   break;
-               case 737:
+               case 738:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                      { jjAddStates(1819, 1820); }
                   break;
-               case 739:
                case 740:
+               case 741:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(740, 741); }
+                     { jjCheckNAddTwoStates(741, 742); }
                   break;
                default : if (i1 == 0 || l1 == 0 || i2 == 0 ||  l2 == 0) break; else break;
             }
@@ -6312,7 +6330,7 @@ private int jjMoveNfa_0(int startState, int curPos)
          kind = 0x7fffffff;
       }
       ++curPos;
-      if ((i = jjnewStateCnt) == (startsAt = 824 - (jjnewStateCnt = startsAt)))
+      if ((i = jjnewStateCnt) == (startsAt = 825 - (jjnewStateCnt = startsAt)))
          break;
       try { curChar = input_stream.readChar(); }
       catch(java.io.IOException e) { break; }
@@ -6348,7 +6366,7 @@ null, null, null, "\175", "\136\75", "\44\75", "\52\75", "\75", "\73", "\57",
 null, null, null, null, null, null, null, null, null, null, "\72\72", null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
-null, null, null, null, null, "\174", "\45", };
+null, null, null, null, null, null, "\174", "\45", };
 protected Token jjFillToken()
 {
    final Token t;
@@ -6373,17 +6391,17 @@ protected Token jjFillToken()
    return t;
 }
 static final int[] jjnextStates = {
-   749, 750, 751, 582, 752, 753, 754, 585, 755, 756, 757, 588, 758, 759, 760, 591, 
-   761, 762, 763, 594, 764, 765, 766, 597, 767, 768, 769, 602, 770, 771, 772, 607, 
-   773, 774, 775, 610, 776, 777, 778, 612, 779, 780, 781, 614, 782, 783, 784, 617, 
-   785, 786, 787, 620, 788, 789, 790, 623, 791, 792, 793, 626, 794, 795, 796, 629, 
-   797, 798, 799, 633, 637, 639, 643, 800, 801, 802, 646, 803, 804, 805, 649, 806, 
-   807, 808, 652, 653, 809, 810, 811, 656, 658, 812, 813, 814, 815, 816, 817, 670, 
-   818, 819, 820, 692, 821, 822, 823, 683, 660, 266, 267, 275, 276, 277, 286, 287, 
-   8, 295, 296, 9, 304, 305, 10, 313, 314, 11, 322, 323, 324, 717, 734, 735, 
-   746, 580, 583, 586, 589, 592, 595, 598, 603, 608, 611, 613, 615, 618, 621, 624, 
-   627, 630, 644, 647, 650, 654, 659, 669, 691, 693, 694, 695, 708, 432, 433, 454, 
-   455, 446, 387, 400, 414, 422, 357, 358, 372, 373, 359, 327, 328, 342, 343, 329, 
+   750, 751, 752, 583, 753, 754, 755, 586, 756, 757, 758, 589, 759, 760, 761, 592, 
+   762, 763, 764, 595, 765, 766, 767, 598, 768, 769, 770, 603, 771, 772, 773, 608, 
+   774, 775, 776, 611, 777, 778, 779, 613, 780, 781, 782, 615, 783, 784, 785, 618, 
+   786, 787, 788, 621, 789, 790, 791, 624, 792, 793, 794, 627, 795, 796, 797, 630, 
+   798, 799, 800, 634, 638, 640, 644, 801, 802, 803, 647, 804, 805, 806, 650, 807, 
+   808, 809, 653, 654, 810, 811, 812, 657, 659, 813, 814, 815, 816, 817, 818, 671, 
+   819, 820, 821, 693, 822, 823, 824, 684, 661, 267, 268, 276, 277, 278, 287, 288, 
+   8, 296, 297, 9, 305, 306, 10, 314, 315, 11, 323, 324, 325, 581, 584, 587, 
+   590, 593, 596, 599, 604, 609, 612, 614, 616, 619, 622, 625, 628, 631, 645, 648, 
+   651, 655, 660, 670, 692, 694, 695, 696, 709, 433, 434, 455, 456, 447, 388, 401, 
+   415, 423, 358, 359, 373, 374, 360, 328, 329, 343, 344, 330, 718, 735, 736, 747, 
    214, 81, 90, 91, 200, 2, 3, 6, 3, 5, 6, 21, 22, 58, 71, 59, 
    64, 65, 60, 66, 59, 67, 64, 65, 60, 68, 69, 70, 59, 64, 65, 60, 
    59, 67, 64, 65, 60, 59, 67, 64, 65, 60, 68, 59, 67, 64, 65, 60, 
@@ -6425,68 +6443,68 @@ static final int[] jjnextStates = {
    237, 238, 243, 246, 227, 245, 242, 237, 238, 243, 246, 247, 251, 227, 237, 238, 
    243, 252, 253, 251, 227, 237, 238, 243, 254, 255, 256, 251, 227, 237, 238, 243, 
    253, 251, 227, 237, 238, 243, 253, 251, 227, 237, 238, 243, 254, 253, 251, 227, 
-   237, 238, 243, 254, 255, 261, 262, 265, 262, 264, 265, 270, 271, 274, 271, 273, 
-   274, 275, 276, 277, 281, 282, 285, 282, 284, 285, 286, 287, 8, 290, 291, 294, 
-   291, 293, 294, 295, 296, 9, 299, 300, 303, 300, 302, 303, 304, 305, 10, 308, 
-   309, 312, 309, 311, 312, 313, 314, 11, 317, 318, 321, 318, 320, 321, 322, 323, 
-   324, 327, 328, 329, 327, 335, 336, 328, 329, 337, 327, 338, 335, 336, 328, 329, 
-   339, 340, 341, 327, 335, 336, 328, 329, 327, 338, 335, 336, 328, 329, 327, 338, 
-   335, 336, 328, 329, 339, 327, 338, 335, 336, 328, 329, 339, 340, 342, 349, 350, 
-   343, 351, 342, 352, 349, 350, 343, 353, 354, 355, 342, 349, 350, 343, 342, 352, 
-   349, 350, 343, 342, 352, 349, 350, 343, 353, 342, 352, 349, 350, 343, 353, 354, 
-   357, 358, 359, 357, 365, 366, 358, 359, 367, 357, 368, 365, 366, 358, 359, 369, 
-   370, 371, 357, 365, 366, 358, 359, 357, 368, 365, 366, 358, 359, 357, 368, 365, 
-   366, 358, 359, 369, 357, 368, 365, 366, 358, 359, 369, 370, 372, 379, 380, 373, 
-   381, 372, 382, 379, 380, 373, 383, 384, 385, 372, 379, 380, 373, 372, 382, 379, 
-   380, 373, 372, 382, 379, 380, 373, 383, 372, 382, 379, 380, 373, 383, 384, 388, 
-   393, 394, 389, 395, 388, 396, 393, 394, 389, 397, 398, 399, 388, 393, 394, 389, 
-   388, 396, 393, 394, 389, 388, 396, 393, 394, 389, 397, 388, 396, 393, 394, 389, 
-   397, 398, 401, 402, 403, 401, 407, 408, 402, 403, 409, 401, 410, 407, 408, 402, 
-   403, 411, 412, 413, 401, 407, 408, 402, 403, 401, 410, 407, 408, 402, 403, 401, 
-   410, 407, 408, 402, 403, 411, 401, 410, 407, 408, 402, 403, 411, 412, 416, 408, 
-   401, 402, 403, 417, 418, 416, 408, 401, 402, 403, 419, 420, 421, 416, 408, 401, 
-   402, 403, 418, 416, 408, 401, 402, 403, 418, 416, 408, 401, 402, 403, 419, 418, 
-   416, 408, 401, 402, 403, 419, 420, 424, 394, 388, 389, 425, 426, 424, 394, 388, 
-   389, 427, 428, 429, 424, 394, 388, 389, 426, 424, 394, 388, 389, 426, 424, 394, 
-   388, 389, 427, 426, 424, 394, 388, 389, 427, 428, 434, 439, 440, 435, 441, 434, 
-   442, 439, 440, 435, 443, 444, 445, 434, 439, 440, 435, 434, 442, 439, 440, 435, 
-   434, 442, 439, 440, 435, 443, 434, 442, 439, 440, 435, 443, 444, 448, 440, 434, 
-   435, 449, 450, 448, 440, 434, 435, 451, 452, 453, 448, 440, 434, 435, 450, 448, 
-   440, 434, 435, 450, 448, 440, 434, 435, 451, 450, 448, 440, 434, 435, 451, 452, 
-   454, 459, 460, 455, 461, 454, 462, 459, 460, 455, 463, 464, 465, 454, 459, 460, 
-   455, 454, 462, 459, 460, 455, 454, 462, 459, 460, 455, 463, 454, 462, 459, 460, 
-   455, 463, 464, 468, 494, 510, 480, 511, 522, 469, 470, 481, 479, 480, 471, 474, 
-   475, 478, 475, 477, 478, 469, 487, 488, 470, 481, 489, 469, 490, 487, 488, 470, 
-   481, 491, 492, 493, 469, 487, 488, 470, 481, 469, 490, 487, 488, 470, 481, 469, 
-   490, 487, 488, 470, 481, 491, 469, 490, 487, 488, 470, 481, 491, 492, 495, 496, 
-   497, 495, 503, 504, 496, 497, 505, 495, 506, 503, 504, 496, 497, 507, 508, 509, 
-   495, 503, 504, 496, 497, 495, 506, 503, 504, 496, 497, 495, 506, 503, 504, 496, 
-   497, 507, 495, 506, 503, 504, 496, 497, 507, 508, 510, 471, 480, 511, 510, 515, 
-   480, 511, 516, 517, 510, 471, 479, 480, 471, 511, 510, 518, 515, 480, 511, 516, 
-   519, 520, 521, 510, 515, 480, 511, 516, 510, 518, 515, 480, 511, 516, 510, 518, 
-   515, 480, 511, 516, 519, 510, 518, 515, 480, 511, 516, 519, 520, 530, 468, 494, 
-   510, 479, 480, 471, 511, 522, 525, 526, 529, 526, 528, 529, 530, 468, 494, 510, 
-   480, 511, 522, 534, 540, 536, 537, 538, 539, 536, 537, 538, 541, 546, 550, 554, 
-   558, 562, 536, 560, 561, 536, 563, 564, 565, 536, 563, 564, 545, 571, 572, 573, 
-   545, 571, 572, 575, 568, 576, 577, 578, 575, 568, 576, 575, 568, 576, 577, 630, 
-   633, 637, 639, 643, 650, 652, 653, 654, 656, 658, 669, 670, 683, 671, 676, 677, 
-   672, 678, 671, 679, 676, 677, 672, 680, 681, 682, 671, 676, 677, 672, 671, 679, 
-   676, 677, 672, 671, 679, 676, 677, 672, 680, 671, 679, 676, 677, 672, 680, 681, 
-   685, 677, 671, 672, 686, 687, 685, 677, 671, 672, 688, 689, 690, 685, 677, 671, 
-   672, 687, 685, 677, 671, 672, 687, 685, 677, 671, 672, 688, 687, 685, 677, 671, 
-   672, 688, 689, 696, 701, 702, 697, 703, 696, 704, 701, 702, 697, 705, 706, 707, 
-   696, 701, 702, 697, 696, 704, 701, 702, 697, 696, 704, 701, 702, 697, 705, 696, 
-   704, 701, 702, 697, 705, 706, 710, 702, 696, 697, 711, 712, 710, 702, 696, 697, 
-   713, 714, 715, 710, 702, 696, 697, 712, 710, 702, 696, 697, 712, 710, 702, 696, 
-   697, 713, 712, 710, 702, 696, 697, 713, 714, 725, 734, 717, 720, 721, 724, 721, 
-   723, 724, 743, 746, 735, 738, 739, 742, 739, 741, 742, 797, 633, 637, 639, 643, 
-   806, 652, 653, 809, 656, 658, 815, 670, 683, 388, 401, 402, 403, 389, 390, 423, 
-   404, 415, 57, 58, 71, 532, 533, 566, 1, 2, 81, 90, 91, 200, 83, 84, 
+   237, 238, 243, 254, 255, 262, 263, 266, 263, 265, 266, 271, 272, 275, 272, 274, 
+   275, 276, 277, 278, 282, 283, 286, 283, 285, 286, 287, 288, 8, 291, 292, 295, 
+   292, 294, 295, 296, 297, 9, 300, 301, 304, 301, 303, 304, 305, 306, 10, 309, 
+   310, 313, 310, 312, 313, 314, 315, 11, 318, 319, 322, 319, 321, 322, 323, 324, 
+   325, 328, 329, 330, 328, 336, 337, 329, 330, 338, 328, 339, 336, 337, 329, 330, 
+   340, 341, 342, 328, 336, 337, 329, 330, 328, 339, 336, 337, 329, 330, 328, 339, 
+   336, 337, 329, 330, 340, 328, 339, 336, 337, 329, 330, 340, 341, 343, 350, 351, 
+   344, 352, 343, 353, 350, 351, 344, 354, 355, 356, 343, 350, 351, 344, 343, 353, 
+   350, 351, 344, 343, 353, 350, 351, 344, 354, 343, 353, 350, 351, 344, 354, 355, 
+   358, 359, 360, 358, 366, 367, 359, 360, 368, 358, 369, 366, 367, 359, 360, 370, 
+   371, 372, 358, 366, 367, 359, 360, 358, 369, 366, 367, 359, 360, 358, 369, 366, 
+   367, 359, 360, 370, 358, 369, 366, 367, 359, 360, 370, 371, 373, 380, 381, 374, 
+   382, 373, 383, 380, 381, 374, 384, 385, 386, 373, 380, 381, 374, 373, 383, 380, 
+   381, 374, 373, 383, 380, 381, 374, 384, 373, 383, 380, 381, 374, 384, 385, 389, 
+   394, 395, 390, 396, 389, 397, 394, 395, 390, 398, 399, 400, 389, 394, 395, 390, 
+   389, 397, 394, 395, 390, 389, 397, 394, 395, 390, 398, 389, 397, 394, 395, 390, 
+   398, 399, 402, 403, 404, 402, 408, 409, 403, 404, 410, 402, 411, 408, 409, 403, 
+   404, 412, 413, 414, 402, 408, 409, 403, 404, 402, 411, 408, 409, 403, 404, 402, 
+   411, 408, 409, 403, 404, 412, 402, 411, 408, 409, 403, 404, 412, 413, 417, 409, 
+   402, 403, 404, 418, 419, 417, 409, 402, 403, 404, 420, 421, 422, 417, 409, 402, 
+   403, 404, 419, 417, 409, 402, 403, 404, 419, 417, 409, 402, 403, 404, 420, 419, 
+   417, 409, 402, 403, 404, 420, 421, 425, 395, 389, 390, 426, 427, 425, 395, 389, 
+   390, 428, 429, 430, 425, 395, 389, 390, 427, 425, 395, 389, 390, 427, 425, 395, 
+   389, 390, 428, 427, 425, 395, 389, 390, 428, 429, 435, 440, 441, 436, 442, 435, 
+   443, 440, 441, 436, 444, 445, 446, 435, 440, 441, 436, 435, 443, 440, 441, 436, 
+   435, 443, 440, 441, 436, 444, 435, 443, 440, 441, 436, 444, 445, 449, 441, 435, 
+   436, 450, 451, 449, 441, 435, 436, 452, 453, 454, 449, 441, 435, 436, 451, 449, 
+   441, 435, 436, 451, 449, 441, 435, 436, 452, 451, 449, 441, 435, 436, 452, 453, 
+   455, 460, 461, 456, 462, 455, 463, 460, 461, 456, 464, 465, 466, 455, 460, 461, 
+   456, 455, 463, 460, 461, 456, 455, 463, 460, 461, 456, 464, 455, 463, 460, 461, 
+   456, 464, 465, 469, 495, 511, 481, 512, 523, 470, 471, 482, 480, 481, 472, 475, 
+   476, 479, 476, 478, 479, 470, 488, 489, 471, 482, 490, 470, 491, 488, 489, 471, 
+   482, 492, 493, 494, 470, 488, 489, 471, 482, 470, 491, 488, 489, 471, 482, 470, 
+   491, 488, 489, 471, 482, 492, 470, 491, 488, 489, 471, 482, 492, 493, 496, 497, 
+   498, 496, 504, 505, 497, 498, 506, 496, 507, 504, 505, 497, 498, 508, 509, 510, 
+   496, 504, 505, 497, 498, 496, 507, 504, 505, 497, 498, 496, 507, 504, 505, 497, 
+   498, 508, 496, 507, 504, 505, 497, 498, 508, 509, 511, 472, 481, 512, 511, 516, 
+   481, 512, 517, 518, 511, 472, 480, 481, 472, 512, 511, 519, 516, 481, 512, 517, 
+   520, 521, 522, 511, 516, 481, 512, 517, 511, 519, 516, 481, 512, 517, 511, 519, 
+   516, 481, 512, 517, 520, 511, 519, 516, 481, 512, 517, 520, 521, 531, 469, 495, 
+   511, 480, 481, 472, 512, 523, 526, 527, 530, 527, 529, 530, 531, 469, 495, 511, 
+   481, 512, 523, 535, 541, 537, 538, 539, 540, 537, 538, 539, 542, 547, 551, 555, 
+   559, 563, 537, 561, 562, 537, 564, 565, 566, 537, 564, 565, 546, 572, 573, 574, 
+   546, 572, 573, 576, 569, 577, 578, 579, 576, 569, 577, 576, 569, 577, 578, 631, 
+   634, 638, 640, 644, 651, 653, 654, 655, 657, 659, 670, 671, 684, 672, 677, 678, 
+   673, 679, 672, 680, 677, 678, 673, 681, 682, 683, 672, 677, 678, 673, 672, 680, 
+   677, 678, 673, 672, 680, 677, 678, 673, 681, 672, 680, 677, 678, 673, 681, 682, 
+   686, 678, 672, 673, 687, 688, 686, 678, 672, 673, 689, 690, 691, 686, 678, 672, 
+   673, 688, 686, 678, 672, 673, 688, 686, 678, 672, 673, 689, 688, 686, 678, 672, 
+   673, 689, 690, 697, 702, 703, 698, 704, 697, 705, 702, 703, 698, 706, 707, 708, 
+   697, 702, 703, 698, 697, 705, 702, 703, 698, 697, 705, 702, 703, 698, 706, 697, 
+   705, 702, 703, 698, 706, 707, 711, 703, 697, 698, 712, 713, 711, 703, 697, 698, 
+   714, 715, 716, 711, 703, 697, 698, 713, 711, 703, 697, 698, 713, 711, 703, 697, 
+   698, 714, 713, 711, 703, 697, 698, 714, 715, 726, 735, 718, 721, 722, 725, 722, 
+   724, 725, 744, 747, 736, 739, 740, 743, 740, 742, 743, 798, 634, 638, 640, 644, 
+   807, 653, 654, 810, 657, 659, 816, 671, 684, 389, 402, 403, 404, 390, 391, 424, 
+   405, 416, 57, 58, 71, 533, 534, 567, 1, 2, 81, 90, 91, 200, 83, 84, 
    95, 96, 111, 112, 120, 131, 139, 140, 161, 163, 164, 165, 177, 179, 180, 181, 
-   190, 191, 120, 131, 218, 219, 230, 231, 260, 261, 269, 270, 280, 281, 289, 290, 
-   298, 299, 307, 308, 316, 317, 330, 332, 333, 334, 344, 346, 347, 348, 360, 362, 
-   363, 364, 374, 376, 377, 378, 456, 457, 473, 474, 482, 484, 485, 486, 498, 500, 
-   501, 502, 512, 513, 524, 525, 662, 665, 668, 719, 720, 737, 738, 
+   190, 191, 120, 131, 218, 219, 230, 231, 261, 262, 270, 271, 281, 282, 290, 291, 
+   299, 300, 308, 309, 317, 318, 331, 333, 334, 335, 345, 347, 348, 349, 361, 363, 
+   364, 365, 375, 377, 378, 379, 457, 458, 474, 475, 483, 485, 486, 487, 499, 501, 
+   502, 503, 513, 514, 525, 526, 663, 666, 669, 720, 721, 738, 739, 
 };
 private static final boolean jjCanMove_0(int hiByte, int i1, int i2, long l1, long l2)
 {
@@ -6668,7 +6686,7 @@ private void jjCheckNAddStates(int start, int end)
   {
     int i;
     jjround = 0x80000001;
-    for (i = 824; i-- > 0;)
+    for (i = 825; i-- > 0;)
       jjrounds[i] = 0x80000000;
   }
 
@@ -6701,10 +6719,10 @@ public static final int[] jjnewLexState = {
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
-   -1, -1, -1, -1, -1, -1, -1, -1, 
+   -1, -1, -1, -1, -1, -1, -1, -1, -1, 
 };
 static final long[] jjtoToken = {
-   0xffffffffffe00001L, 0xffe00ffffffL, 
+   0xffffffffffe00001L, 0x1ffe00ffffffL, 
 };
 static final long[] jjtoSkip = {
    0x2L, 0x0L, 
@@ -6717,8 +6735,8 @@ static final long[] jjtoMore = {
 };
     protected SimpleCharStream  input_stream;
 
-    private final int[] jjrounds = new int[824];
-    private final int[] jjstateSet = new int[2 * 824];
+    private final int[] jjrounds = new int[825];
+    private final int[] jjstateSet = new int[2 * 825];
     private final StringBuilder jjimage = new StringBuilder();
     private StringBuilder image = jjimage;
     private int jjimageLen;


### PR DESCRIPTION
This comes in two part, the first commit is about parsing the first character before a possible ident, the second one is ignoring the declaration after a warning was generated (otherwise, the stripped property  name could be validated).