### PR TITLE
Deal with IE/Edge lack of reportValidity support

### DIFF
--- a/scripts/w3c-validator.js
+++ b/scripts/w3c-validator.js
@@ -47,10 +47,13 @@ var W3C = {
 			var span = new Element('span').set('text', value).inject(link);
 			link.injectAfter(submit).addEvent('click', function(event){
 				new Event(event).stop();
-				if (W3C.Forms[i].reportValidity()) {
+				if ('reportValidity' in document.createElement('form')) {
+					if (W3C.Forms[i].reportValidity()) {
+						W3C.Forms[i].submit();
+					}
+				} else {
 					W3C.Forms[i].submit();
 				}
-
 			});
 		});
 		


### PR DESCRIPTION
This change refines the client-side form-validation code added in
27ccde0 to add feature-detection for .reportValidity() and to not use it
in browsers that don’t support it (IE and Edge prior to Edge 17).

Fixes https://github.com/w3c/css-validator/issues/162 Thanks @IanC311