### PR TITLE
Report bad prop in declaration w/ vendor/hack flag

### DIFF
--- a/org/w3c/css/parser/CssPropertyFactory.java
+++ b/org/w3c/css/parser/CssPropertyFactory.java
@@ -178,16 +178,8 @@ public class CssPropertyFactory implements Cloneable {
             if (isVendorExtension(property)) {
                 throw new WarningParamException("vendor-extension", property);
             }
-            if (expression.hasVendorExtensions()) {
-                throw new WarningParamException("vendor-extension", expression.toStringFromStart());
-            }
         }
 
-        if (ac.getTreatCssHacksAsWarnings()) {
-            if (expression.hasCssHack()) {
-                throw new WarningParamException("css-hack", expression.toStringFromStart());
-            }
-        }
         try {
             atRuleMedia = (AtRuleMedia) atRule;
             // TODO FIXME in fact, it should use a vector of media instead of extracting

--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -4137,7 +4137,14 @@ try {
                                          warningException.getMessageArgs());
             } else {
                 values.starts();
-                addError(e, (CssExpression) values);
+                if (values.hasCssHack() || values.hasVendorExtensions()) {
+                    if ("createProperty"
+                            .equals(e.getStackTrace()[0].getMethodName())) {
+                        addError(e, (CssExpression) values);
+                    }
+                } else {
+                    addError(e, (CssExpression) values);
+                }
             }
         }
         {if ("" != null) return null;}
@@ -5402,6 +5409,14 @@ String funcname = n.image.toLowerCase();
             f.set(n.image.substring(0, n.image.length() - 1), exp);
             if (funcname.charAt(0) == '-') {
                 exp.markVendorExtension();
+                if (ac.getTreatVendorExtensionsAsWarnings()) {
+                    ac.getFrame().addWarning("vendor-extension",
+                            funcname.substring(0, funcname.length() - 1));
+                } else {
+                    addError(new ParseException(ac.getMsg()
+                            .getString("warning.vendor-extension")),
+                        funcname);
+                }
             }
             {if ("" != null) return f;}
         }
@@ -5743,40 +5758,9 @@ n.image = Util.strip(n.image);
     finally { jj_save(4, xla); }
   }
 
-  private boolean jj_3R_175()
- {
-    if (jj_scan_token(STRING)) return true;
-    return false;
-  }
-
   private boolean jj_3R_154()
  {
     if (jj_scan_token(PLUS)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_174()
- {
-    if (jj_3R_183()) return true;
-    return false;
-  }
-
-  private boolean jj_3_5()
- {
-    if (jj_3R_127()) return true;
-    if (jj_scan_token(LPARAN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_173()
- {
-    if (jj_3R_152()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_172()
- {
-    if (jj_3R_151()) return true;
     return false;
   }
 
@@ -5793,47 +5777,6 @@ n.image = Util.strip(n.image);
     if (jj_3R_153()) {
     jj_scanpos = xsp;
     if (jj_3R_154()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_187()
- {
-    if (jj_3R_129()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_139()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_172()) {
-    jj_scanpos = xsp;
-    if (jj_3R_173()) {
-    jj_scanpos = xsp;
-    if (jj_3R_174()) {
-    jj_scanpos = xsp;
-    if (jj_3R_175()) {
-    jj_scanpos = xsp;
-    if (jj_3R_176()) {
-    jj_scanpos = xsp;
-    if (jj_3R_177()) {
-    jj_scanpos = xsp;
-    if (jj_3R_178()) {
-    jj_scanpos = xsp;
-    if (jj_3R_179()) {
-    jj_scanpos = xsp;
-    if (jj_3R_180()) {
-    jj_scanpos = xsp;
-    if (jj_3R_181()) return true;
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-    }
     }
     return false;
   }
@@ -5888,23 +5831,9 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_182()
- {
-    if (jj_scan_token(COMMA)) return true;
-    return false;
-  }
-
   private boolean jj_3R_185()
  {
     if (jj_3R_187()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_140()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_182()) jj_scanpos = xsp;
     return false;
   }
 
@@ -5938,6 +5867,23 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3R_184()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(37)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(38)) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_182()
+ {
+    if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
   private boolean jj_3R_166()
  {
     if (jj_scan_token(ST)) return true;
@@ -5953,6 +5899,14 @@ n.image = Util.strip(n.image);
   private boolean jj_3R_164()
  {
     if (jj_scan_token(FREQ)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_140()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_182()) jj_scanpos = xsp;
     return false;
   }
 
@@ -5983,17 +5937,6 @@ n.image = Util.strip(n.image);
   private boolean jj_3R_159()
  {
     if (jj_scan_token(RELVIEWLENGTH)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_184()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(38)) return true;
-    }
     return false;
   }
 
@@ -6051,6 +5994,12 @@ n.image = Util.strip(n.image);
   private boolean jj_3R_130()
  {
     if (jj_3R_137()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_186()
+ {
+    if (jj_scan_token(IDENT)) return true;
     return false;
   }
 
@@ -6124,17 +6073,6 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_123()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(36)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(49)) return true;
-    }
-    return false;
-  }
-
   private boolean jj_3R_136()
  {
     if (jj_3R_152()) return true;
@@ -6153,12 +6091,6 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3R_186()
- {
-    if (jj_scan_token(IDENT)) return true;
-    return false;
-  }
-
   private boolean jj_3R_181()
  {
     if (jj_scan_token(UNICODERANGE)) return true;
@@ -6174,6 +6106,17 @@ n.image = Util.strip(n.image);
   private boolean jj_3R_149()
  {
     if (jj_scan_token(TIME)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_123()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(36)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(49)) return true;
+    }
     return false;
   }
 
@@ -6284,15 +6227,6 @@ n.image = Util.strip(n.image);
     return false;
   }
 
-  private boolean jj_3_1()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_123()) jj_scanpos = xsp;
-    if (jj_scan_token(108)) return true;
-    return false;
-  }
-
   private boolean jj_3R_129()
  {
     Token xsp;
@@ -6333,6 +6267,15 @@ n.image = Util.strip(n.image);
       if (jj_scan_token(21)) { jj_scanpos = xsp; break; }
     }
     if (jj_3R_129()) return true;
+    return false;
+  }
+
+  private boolean jj_3_1()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_123()) jj_scanpos = xsp;
+    if (jj_scan_token(108)) return true;
     return false;
   }
 
@@ -6384,6 +6327,78 @@ n.image = Util.strip(n.image);
   private boolean jj_3R_176()
  {
     if (jj_scan_token(DIV)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_175()
+ {
+    if (jj_scan_token(STRING)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_174()
+ {
+    if (jj_3R_183()) return true;
+    return false;
+  }
+
+  private boolean jj_3_5()
+ {
+    if (jj_3R_127()) return true;
+    if (jj_scan_token(LPARAN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_173()
+ {
+    if (jj_3R_152()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_172()
+ {
+    if (jj_3R_151()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_187()
+ {
+    if (jj_3R_129()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_139()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_172()) {
+    jj_scanpos = xsp;
+    if (jj_3R_173()) {
+    jj_scanpos = xsp;
+    if (jj_3R_174()) {
+    jj_scanpos = xsp;
+    if (jj_3R_175()) {
+    jj_scanpos = xsp;
+    if (jj_3R_176()) {
+    jj_scanpos = xsp;
+    if (jj_3R_177()) {
+    jj_scanpos = xsp;
+    if (jj_3R_178()) {
+    jj_scanpos = xsp;
+    if (jj_3R_179()) {
+    jj_scanpos = xsp;
+    if (jj_3R_180()) {
+    jj_scanpos = xsp;
+    if (jj_3R_181()) return true;
+    }
+    }
+    }
+    }
+    }
+    }
+    }
+    }
+    }
     return false;
   }
 

--- a/org/w3c/css/parser/analyzer/CssParser.jj
+++ b/org/w3c/css/parser/analyzer/CssParser.jj
@@ -2415,7 +2415,14 @@ try {
                                          warningException.getMessageArgs());
             } else {
                 values.starts();
-                addError(e, (CssExpression) values);
+                if (values.hasCssHack() || values.hasVendorExtensions()) {
+                    if ("createProperty"
+                            .equals(e.getStackTrace()[0].getMethodName())) {
+                        addError(e, (CssExpression) values);
+                    }
+                } else {
+                    addError(e, (CssExpression) values);
+                }
             }
         }
         return null;
@@ -2864,6 +2871,14 @@ CssValue function() :
 	    f.set(n.image.substring(0, n.image.length() - 1), exp);
 	    if (funcname.charAt(0) == '-') {
 	        exp.markVendorExtension();
+	        if (ac.getTreatVendorExtensionsAsWarnings()) {
+	            ac.getFrame().addWarning("vendor-extension",
+	                    funcname.substring(0, funcname.length() - 1));
+	        } else {
+	            addError(new ParseException(ac.getMsg()
+	                    .getString("warning.vendor-extension")),
+	                funcname);
+	        }
 	    }
 	    return f;
 	}


### PR DESCRIPTION
This change causes errors to be reported for bad property names even in cases
where the declaration containing the property has an expression with values
that have been flagged as vendor extensions or CSS hacks.

Without this change, if an expression is flagged as containing a value that is a
vendor extension or CSS hack but the declaration it’s in has an invalid property
name (e.g., `background-image` misspelled as `backround-image` but with a value
of `-webkit-image-set(...)`), no error is emitted for the invalid property name.

This change works by 1) removing from the createProperty method in the
CssPropertyFactory code the warning-report handling for declarations that have
vendor extensions and CSS hacks, 2) moving that handling into the parser code,
where it now checks what method threw an InvalidParamException if one is thrown
when parsing a declaration, and 3) reporting an error if the method that threw
InvalidParamException in a vendor-extension/CSS-hack case is the createProperty
method (which means it was thrown for a bad property name) rather than other
code that throws it (which indicates that it’s a vendor-extension/CSS-hack
*value* rather than a bad property name).

(Incidentally, a potential alternative way of dealing with this problem would be
to not throw an InvalidParamException for bad property names in the
createProperty method to begin with, but to instead throw some different (new?)
exception that could be caught and handled separately.)

Note that this change also adds handling to emit a specific warning or error in
the case where a function name is a vendor extension (that is, the function name
starts with `-`) — because after the rest of this change is made to the code, no
error or warning would otherwise be reported in that case.