### PR TITLE
Allow nested at-rules

### DIFF
--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -1075,6 +1075,15 @@ String media = getAtRule().toString();
         case RESOLUTION:
         case DIMEN:
         case PSEUDOELEMENT_SYM:
+        case MEDIA_SYM:
+        case PAGE_SYM:
+        case FONT_FACE_SYM:
+        case KEYFRAMES_SYM:
+        case PREF_SYM:
+        case COLOR_PROFILE:
+        case COUNTER_STYLE_SYM:
+        case PHONETIC_ALPHABET_SYM:
+        case ATKEYWORD:
         case CLASS:
         case FUNCTIONNOT:
         case 108:{
@@ -1085,7 +1094,69 @@ String media = getAtRule().toString();
           jj_la1[26] = jj_gen;
           break label_20;
         }
-        ruleSet();
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case IDENT:
+        case HASHIDENT:
+        case HASH:
+        case LBRACKET:
+        case ANY:
+        case COLON:
+        case RELFONTLENGTH:
+        case RELVIEWLENGTH:
+        case ABSOLUTLENGTH:
+        case ANGLE:
+        case TIME:
+        case FREQ:
+        case RESOLUTION:
+        case DIMEN:
+        case PSEUDOELEMENT_SYM:
+        case CLASS:
+        case FUNCTIONNOT:
+        case 108:{
+          ruleSet();
+          break;
+          }
+        case MEDIA_SYM:{
+          media();
+          break;
+          }
+        case PAGE_SYM:{
+          page();
+          break;
+          }
+        case FONT_FACE_SYM:{
+          fontFace();
+          break;
+          }
+        case KEYFRAMES_SYM:{
+          keyframes();
+          break;
+          }
+        case PREF_SYM:{
+          preference();
+          break;
+          }
+        case COLOR_PROFILE:{
+          colorprofile();
+          break;
+          }
+        case COUNTER_STYLE_SYM:{
+          counterstyle();
+          break;
+          }
+        case PHONETIC_ALPHABET_SYM:{
+          phoneticAlphabet();
+          break;
+          }
+        case ATKEYWORD:{
+          atRuleDeclaration();
+          break;
+          }
+        default:
+          jj_la1[27] = jj_gen;
+          jj_consume_token(-1);
+          throw new ParseException();
+        }
       }
       jj_consume_token(RBRACE);
       label_21:
@@ -1096,7 +1167,7 @@ String media = getAtRule().toString();
           break;
           }
         default:
-          jj_la1[27] = jj_gen;
+          jj_la1[28] = jj_gen;
           break label_21;
         }
         jj_consume_token(S);
@@ -1126,7 +1197,7 @@ setAtRule(old);
         break;
         }
       default:
-        jj_la1[28] = jj_gen;
+        jj_la1[29] = jj_gen;
         break label_22;
       }
       jj_consume_token(S);
@@ -1140,7 +1211,7 @@ setAtRule(old);
         break;
         }
       default:
-        jj_la1[29] = jj_gen;
+        jj_la1[30] = jj_gen;
         break label_23;
       }
       jj_consume_token(S);
@@ -1163,7 +1234,7 @@ StringBuilder sb = new StringBuilder();
         break;
         }
       default:
-        jj_la1[30] = jj_gen;
+        jj_la1[31] = jj_gen;
         break label_24;
       }
       jj_consume_token(COMMA);
@@ -1175,7 +1246,7 @@ StringBuilder sb = new StringBuilder();
           break;
           }
         default:
-          jj_la1[31] = jj_gen;
+          jj_la1[32] = jj_gen;
           break label_25;
         }
         jj_consume_token(S);
@@ -1204,14 +1275,14 @@ mediarestrictor = convertIdent(n.image);
             break;
             }
           default:
-            jj_la1[32] = jj_gen;
+            jj_la1[33] = jj_gen;
             break label_26;
           }
         }
         break;
         }
       default:
-        jj_la1[33] = jj_gen;
+        jj_la1[34] = jj_gen;
         ;
       }
       n = jj_consume_token(IDENT);
@@ -1224,7 +1295,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
           break;
           }
         default:
-          jj_la1[34] = jj_gen;
+          jj_la1[35] = jj_gen;
           break label_27;
         }
         jj_consume_token(S);
@@ -1237,7 +1308,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
           break;
           }
         default:
-          jj_la1[35] = jj_gen;
+          jj_la1[36] = jj_gen;
           break label_28;
         }
         jj_consume_token(AND);
@@ -1250,7 +1321,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
             break;
             }
           default:
-            jj_la1[36] = jj_gen;
+            jj_la1[37] = jj_gen;
             break label_29;
           }
         }
@@ -1268,7 +1339,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
           break;
           }
         default:
-          jj_la1[37] = jj_gen;
+          jj_la1[38] = jj_gen;
           break label_30;
         }
         jj_consume_token(AND);
@@ -1281,7 +1352,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
             break;
             }
           default:
-            jj_la1[38] = jj_gen;
+            jj_la1[39] = jj_gen;
             break label_31;
           }
         }
@@ -1290,7 +1361,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
       break;
       }
     default:
-      jj_la1[39] = jj_gen;
+      jj_la1[40] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1311,7 +1382,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
         break;
         }
       default:
-        jj_la1[40] = jj_gen;
+        jj_la1[41] = jj_gen;
         break label_32;
       }
       jj_consume_token(S);
@@ -1330,7 +1401,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
         break;
         }
       default:
-        jj_la1[41] = jj_gen;
+        jj_la1[42] = jj_gen;
         break label_33;
       }
       jj_consume_token(S);
@@ -1346,7 +1417,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
           break;
           }
         default:
-          jj_la1[42] = jj_gen;
+          jj_la1[43] = jj_gen;
           break label_34;
         }
         jj_consume_token(S);
@@ -1355,7 +1426,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
       break;
       }
     default:
-      jj_la1[43] = jj_gen;
+      jj_la1[44] = jj_gen;
       ;
     }
     jj_consume_token(LPARAN);
@@ -1367,7 +1438,7 @@ mediaRule.addMedia(mediarestrictor, convertIdent(n.image), ac);
         break;
         }
       default:
-        jj_la1[44] = jj_gen;
+        jj_la1[45] = jj_gen;
         break label_35;
       }
       jj_consume_token(S);
@@ -1388,7 +1459,7 @@ MediaFeature mf = handleMediaFeature(mediaRule, mediaFeatureName, val);
         break;
         }
       default:
-        jj_la1[45] = jj_gen;
+        jj_la1[46] = jj_gen;
         break label_36;
       }
       jj_consume_token(S);
@@ -1408,7 +1479,7 @@ MediaFeature mf = handleMediaFeature(mediaRule, mediaFeatureName, val);
         break;
         }
       default:
-        jj_la1[46] = jj_gen;
+        jj_la1[47] = jj_gen;
         break label_37;
       }
       jj_consume_token(S);
@@ -1440,7 +1511,7 @@ MediaFeature mf = handleMediaFeature(mediaRule, mediaFeatureName, val);
           break;
           }
         default:
-          jj_la1[47] = jj_gen;
+          jj_la1[48] = jj_gen;
           break label_38;
         }
         jj_consume_token(S);
@@ -1457,7 +1528,7 @@ newRule.setIdent(convertIdent(n.image));
             break;
             }
           default:
-            jj_la1[48] = jj_gen;
+            jj_la1[49] = jj_gen;
             break label_39;
           }
           jj_consume_token(S);
@@ -1465,7 +1536,7 @@ newRule.setIdent(convertIdent(n.image));
         break;
         }
       default:
-        jj_la1[49] = jj_gen;
+        jj_la1[50] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -1474,7 +1545,7 @@ newRule.setIdent(convertIdent(n.image));
         break;
         }
       default:
-        jj_la1[50] = jj_gen;
+        jj_la1[51] = jj_gen;
         ;
       }
       jj_consume_token(LBRACE);
@@ -1486,7 +1557,7 @@ newRule.setIdent(convertIdent(n.image));
           break;
           }
         default:
-          jj_la1[51] = jj_gen;
+          jj_la1[52] = jj_gen;
           break label_40;
         }
         jj_consume_token(S);
@@ -1502,7 +1573,7 @@ collectv = v;
           break;
           }
         default:
-          jj_la1[52] = jj_gen;
+          jj_la1[53] = jj_gen;
           break label_41;
         }
         jj_consume_token(S);
@@ -1549,7 +1620,7 @@ setAtRule(old);
       break;
       }
     default:
-      jj_la1[53] = jj_gen;
+      jj_la1[54] = jj_gen;
       v = declarations();
 {if ("" != null) return v;}
     }
@@ -1577,7 +1648,7 @@ setAtRule(old);
         break;
         }
       default:
-        jj_la1[54] = jj_gen;
+        jj_la1[55] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1589,7 +1660,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[55] = jj_gen;
+          jj_la1[56] = jj_gen;
           break label_42;
         }
         jj_consume_token(S);
@@ -1603,7 +1674,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[56] = jj_gen;
+          jj_la1[57] = jj_gen;
           break label_43;
         }
         jj_consume_token(S);
@@ -1618,7 +1689,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[57] = jj_gen;
+          jj_la1[58] = jj_gen;
           break label_44;
         }
         jj_consume_token(S);
@@ -1641,7 +1712,7 @@ addError(e, skipStatement());
         break;
         }
       default:
-        jj_la1[58] = jj_gen;
+        jj_la1[59] = jj_gen;
         break label_45;
       }
       jj_consume_token(S);
@@ -1688,14 +1759,14 @@ CssIdent ident = new CssIdent();
             break;
             }
           default:
-            jj_la1[59] = jj_gen;
+            jj_la1[60] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
           break;
           }
         default:
-          jj_la1[60] = jj_gen;
+          jj_la1[61] = jj_gen;
           ;
         }
         n = jj_consume_token(PERCENTAGE);
@@ -1710,7 +1781,7 @@ CssPercentage p = new CssPercentage();
         break;
         }
       default:
-        jj_la1[61] = jj_gen;
+        jj_la1[62] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1722,7 +1793,7 @@ CssPercentage p = new CssPercentage();
           break;
           }
         default:
-          jj_la1[62] = jj_gen;
+          jj_la1[63] = jj_gen;
           break label_46;
         }
         jj_consume_token(S);
@@ -1783,7 +1854,7 @@ ac.getFrame()
           break;
           }
         default:
-          jj_la1[63] = jj_gen;
+          jj_la1[64] = jj_gen;
           break label_47;
         }
       }
@@ -1796,7 +1867,7 @@ ac.getFrame()
           break;
           }
         default:
-          jj_la1[64] = jj_gen;
+          jj_la1[65] = jj_gen;
           break label_48;
         }
         jj_consume_token(S);
@@ -1818,7 +1889,7 @@ krule.setName(convertIdent(n.image));
           break;
           }
         default:
-          jj_la1[65] = jj_gen;
+          jj_la1[66] = jj_gen;
           break label_49;
         }
         jj_consume_token(S);
@@ -1834,7 +1905,7 @@ krule.setName(convertIdent(n.image));
           break;
           }
         default:
-          jj_la1[66] = jj_gen;
+          jj_la1[67] = jj_gen;
           break label_50;
         }
         s = keyframe_selector(null);
@@ -1851,7 +1922,7 @@ sl = new ArrayList<CssSelectors>();
             break;
             }
           default:
-            jj_la1[67] = jj_gen;
+            jj_la1[68] = jj_gen;
             break label_51;
           }
           jj_consume_token(COMMA);
@@ -1863,7 +1934,7 @@ sl = new ArrayList<CssSelectors>();
               break;
               }
             default:
-              jj_la1[68] = jj_gen;
+              jj_la1[69] = jj_gen;
               break label_52;
             }
             jj_consume_token(S);
@@ -1883,7 +1954,7 @@ if (s != null) {
             break;
             }
           default:
-            jj_la1[69] = jj_gen;
+            jj_la1[70] = jj_gen;
             break label_53;
           }
           jj_consume_token(S);
@@ -1898,7 +1969,7 @@ if (s != null) {
             break;
             }
           default:
-            jj_la1[70] = jj_gen;
+            jj_la1[71] = jj_gen;
             break label_54;
           }
           jj_consume_token(S);
@@ -1935,7 +2006,7 @@ validSelector = (sl.size() != 0);
           break;
           }
         default:
-          jj_la1[71] = jj_gen;
+          jj_la1[72] = jj_gen;
           break label_55;
         }
         jj_consume_token(S);
@@ -1964,7 +2035,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[72] = jj_gen;
+          jj_la1[73] = jj_gen;
           break label_56;
         }
         jj_consume_token(S);
@@ -1985,7 +2056,7 @@ if (isCss1) {
           break;
           }
         default:
-          jj_la1[73] = jj_gen;
+          jj_la1[74] = jj_gen;
           break label_57;
         }
         jj_consume_token(S);
@@ -2000,7 +2071,7 @@ if (isCss1) {
           break;
           }
         default:
-          jj_la1[74] = jj_gen;
+          jj_la1[75] = jj_gen;
           break label_58;
         }
         jj_consume_token(S);
@@ -2043,7 +2114,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[75] = jj_gen;
+          jj_la1[76] = jj_gen;
           break label_59;
         }
         jj_consume_token(S);
@@ -2064,7 +2135,7 @@ if (!isSVG) {
           break;
           }
         default:
-          jj_la1[76] = jj_gen;
+          jj_la1[77] = jj_gen;
           break label_60;
         }
         jj_consume_token(S);
@@ -2079,7 +2150,7 @@ if (!isSVG) {
           break;
           }
         default:
-          jj_la1[77] = jj_gen;
+          jj_la1[78] = jj_gen;
           break label_61;
         }
         jj_consume_token(S);
@@ -2122,7 +2193,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[78] = jj_gen;
+          jj_la1[79] = jj_gen;
           break label_62;
         }
       }
@@ -2135,7 +2206,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[79] = jj_gen;
+          jj_la1[80] = jj_gen;
           break label_63;
         }
         jj_consume_token(S);
@@ -2157,7 +2228,7 @@ csrule.setName(convertIdent(n.image));
           break;
           }
         default:
-          jj_la1[80] = jj_gen;
+          jj_la1[81] = jj_gen;
           break label_64;
         }
         jj_consume_token(S);
@@ -2172,7 +2243,7 @@ csrule.setName(convertIdent(n.image));
           break;
           }
         default:
-          jj_la1[81] = jj_gen;
+          jj_la1[82] = jj_gen;
           break label_65;
         }
         jj_consume_token(S);
@@ -2210,7 +2281,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[82] = jj_gen;
+          jj_la1[83] = jj_gen;
           break label_66;
         }
         jj_consume_token(S);
@@ -2231,7 +2302,7 @@ if (isCSS1) {
           break;
           }
         default:
-          jj_la1[83] = jj_gen;
+          jj_la1[84] = jj_gen;
           break label_67;
         }
         jj_consume_token(S);
@@ -2246,7 +2317,7 @@ if (isCSS1) {
           break;
           }
         default:
-          jj_la1[84] = jj_gen;
+          jj_la1[85] = jj_gen;
           break label_68;
         }
         jj_consume_token(S);
@@ -2286,7 +2357,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[85] = jj_gen;
+          jj_la1[86] = jj_gen;
           break label_69;
         }
         jj_consume_token(S);
@@ -2300,7 +2371,7 @@ setAtRule(old);
           break;
           }
         default:
-          jj_la1[86] = jj_gen;
+          jj_la1[87] = jj_gen;
           break label_70;
         }
         jj_consume_token(S);
@@ -2369,7 +2440,7 @@ if (expr.getCount() > 0) expr.setOperator(',');
           break;
           }
         default:
-          jj_la1[87] = jj_gen;
+          jj_la1[88] = jj_gen;
           break label_71;
         }
         jj_consume_token(S);
@@ -2377,7 +2448,7 @@ if (expr.getCount() > 0) expr.setOperator(',');
       break;
       }
     default:
-      jj_la1[88] = jj_gen;
+      jj_la1[89] = jj_gen;
       ;
     }
   }
@@ -2407,7 +2478,7 @@ connector = '~' ;
         break;
         }
       default:
-        jj_la1[89] = jj_gen;
+        jj_la1[90] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2419,7 +2490,7 @@ connector = '~' ;
           break;
           }
         default:
-          jj_la1[90] = jj_gen;
+          jj_la1[91] = jj_gen;
           break label_72;
         }
         jj_consume_token(S);
@@ -2436,7 +2507,7 @@ connector = '~' ;
           break;
           }
         default:
-          jj_la1[91] = jj_gen;
+          jj_la1[92] = jj_gen;
           break label_73;
         }
       }
@@ -2444,7 +2515,7 @@ connector = ' ' ;
       break;
       }
     default:
-      jj_la1[92] = jj_gen;
+      jj_la1[93] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2468,7 +2539,7 @@ connector = ' ' ;
       break;
       }
     default:
-      jj_la1[93] = jj_gen;
+      jj_la1[94] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2563,14 +2634,14 @@ connector = ' ' ;
           break;
           }
         default:
-          jj_la1[94] = jj_gen;
+          jj_la1[95] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
         }
       default:
-        jj_la1[95] = jj_gen;
+        jj_la1[96] = jj_gen;
         ;
       }
       n = jj_consume_token(IDENT);
@@ -2582,7 +2653,7 @@ connector = ' ' ;
           break;
           }
         default:
-          jj_la1[96] = jj_gen;
+          jj_la1[97] = jj_gen;
           break label_74;
         }
         jj_consume_token(S);
@@ -2617,7 +2688,7 @@ currentProperty = convertIdent(n.image);
         break;
         }
       default:
-        jj_la1[97] = jj_gen;
+        jj_la1[98] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2636,7 +2707,7 @@ if (ac.getTreatCssHacksAsWarnings()) {
           break;
           }
         default:
-          jj_la1[98] = jj_gen;
+          jj_la1[99] = jj_gen;
           break label_75;
         }
         jj_consume_token(S);
@@ -2644,7 +2715,7 @@ if (ac.getTreatCssHacksAsWarnings()) {
       break;
       }
     default:
-      jj_la1[99] = jj_gen;
+      jj_la1[100] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2671,7 +2742,7 @@ if (contextual != null) {
           break;
           }
         default:
-          jj_la1[100] = jj_gen;
+          jj_la1[101] = jj_gen;
           break label_76;
         }
         jj_consume_token(COMMA);
@@ -2683,7 +2754,7 @@ if (contextual != null) {
             break;
             }
           default:
-            jj_la1[101] = jj_gen;
+            jj_la1[102] = jj_gen;
             break label_77;
           }
           jj_consume_token(S);
@@ -2703,7 +2774,7 @@ validSelector = (context_set.size() > 0);
           break;
           }
         default:
-          jj_la1[102] = jj_gen;
+          jj_la1[103] = jj_gen;
           break label_78;
         }
         jj_consume_token(S);
@@ -2718,7 +2789,7 @@ validSelector = (context_set.size() > 0);
           break;
           }
         default:
-          jj_la1[103] = jj_gen;
+          jj_la1[104] = jj_gen;
           break label_79;
         }
         jj_consume_token(S);
@@ -2797,7 +2868,7 @@ if (values != null) {
       break;
       }
     default:
-      jj_la1[104] = jj_gen;
+      jj_la1[105] = jj_gen;
       ;
     }
     label_80:
@@ -2808,7 +2879,7 @@ if (values != null) {
         break;
         }
       default:
-        jj_la1[105] = jj_gen;
+        jj_la1[106] = jj_gen;
         break label_80;
       }
       jj_consume_token(SEMICOLON);
@@ -2820,7 +2891,7 @@ if (values != null) {
           break;
           }
         default:
-          jj_la1[106] = jj_gen;
+          jj_la1[107] = jj_gen;
           break label_81;
         }
         jj_consume_token(S);
@@ -2854,7 +2925,7 @@ if (values != null) {
         break;
         }
       default:
-        jj_la1[107] = jj_gen;
+        jj_la1[108] = jj_gen;
         ;
       }
     }
@@ -2880,7 +2951,7 @@ if (!wrong_value) {
           break;
           }
         default:
-          jj_la1[108] = jj_gen;
+          jj_la1[109] = jj_gen;
           break label_82;
         }
         jj_consume_token(S);
@@ -2911,7 +2982,7 @@ if (!wrong_value) {
           break;
           }
         default:
-          jj_la1[109] = jj_gen;
+          jj_la1[110] = jj_gen;
           break label_83;
         }
         comb = combinator();
@@ -3006,7 +3077,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
         break;
         }
       default:
-        jj_la1[110] = jj_gen;
+        jj_la1[111] = jj_gen;
         break label_84;
       }
       label_85:
@@ -3018,7 +3089,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[111] = jj_gen;
+          jj_la1[112] = jj_gen;
           break label_85;
         }
       }
@@ -3062,7 +3133,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[112] = jj_gen;
+          jj_la1[113] = jj_gen;
           break label_86;
         }
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -3097,7 +3168,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[113] = jj_gen;
+          jj_la1[114] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -3154,7 +3225,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[114] = jj_gen;
+          jj_la1[115] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -3178,7 +3249,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
           break;
           }
         default:
-          jj_la1[115] = jj_gen;
+          jj_la1[116] = jj_gen;
           break label_87;
         }
       }
@@ -3186,7 +3257,7 @@ if ((ac.getCssProfile() == CssProfile.MOBILE) ||
       break;
       }
     default:
-      jj_la1[116] = jj_gen;
+      jj_la1[117] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3282,7 +3353,7 @@ if (n.image.charAt(0) == '.') {
       break;
       }
     default:
-      jj_la1[117] = jj_gen;
+      jj_la1[118] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3323,7 +3394,7 @@ if (n.image.charAt(0) == '.') {
       break;
       }
     default:
-      jj_la1[118] = jj_gen;
+      jj_la1[119] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3351,14 +3422,14 @@ if (n.image.charAt(0) == '.') {
           break;
           }
         default:
-          jj_la1[119] = jj_gen;
+          jj_la1[120] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
         }
       default:
-        jj_la1[120] = jj_gen;
+        jj_la1[121] = jj_gen;
         ;
       }
       p = jj_consume_token(108);
@@ -3414,7 +3485,7 @@ if (ac.getCssVersion() != CssVersion.CSS1) {
       break;
       }
     default:
-      jj_la1[121] = jj_gen;
+      jj_la1[122] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3435,7 +3506,7 @@ if (ac.getCssVersion() != CssVersion.CSS1) {
         break;
         }
       default:
-        jj_la1[122] = jj_gen;
+        jj_la1[123] = jj_gen;
         break label_88;
       }
       jj_consume_token(S);
@@ -3449,7 +3520,7 @@ if (ac.getCssVersion() != CssVersion.CSS1) {
         break;
         }
       default:
-        jj_la1[123] = jj_gen;
+        jj_la1[124] = jj_gen;
         break label_89;
       }
       jj_consume_token(S);
@@ -3493,7 +3564,7 @@ selectorType = CssSelectors.ATTRIBUTE_SUBSTR;
         break;
         }
       default:
-        jj_la1[124] = jj_gen;
+        jj_la1[125] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -3505,7 +3576,7 @@ selectorType = CssSelectors.ATTRIBUTE_SUBSTR;
           break;
           }
         default:
-          jj_la1[125] = jj_gen;
+          jj_la1[126] = jj_gen;
           break label_90;
         }
         jj_consume_token(S);
@@ -3522,7 +3593,7 @@ val.image = convertStringIndex(val.image, 1, val.image.length() -1, false);
         break;
         }
       default:
-        jj_la1[126] = jj_gen;
+        jj_la1[127] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -3534,7 +3605,7 @@ val.image = convertStringIndex(val.image, 1, val.image.length() -1, false);
           break;
           }
         default:
-          jj_la1[127] = jj_gen;
+          jj_la1[128] = jj_gen;
           break label_91;
         }
         jj_consume_token(S);
@@ -3542,7 +3613,7 @@ val.image = convertStringIndex(val.image, 1, val.image.length() -1, false);
       break;
       }
     default:
-      jj_la1[128] = jj_gen;
+      jj_la1[129] = jj_gen;
       ;
     }
     jj_consume_token(RBRACKET);
@@ -3632,7 +3703,7 @@ if (ac.getCssVersion() == CssVersion.CSS1) {
         break;
         }
       default:
-        jj_la1[129] = jj_gen;
+        jj_la1[130] = jj_gen;
         break label_92;
       }
       jj_consume_token(S);
@@ -3671,7 +3742,7 @@ if (ac.getCssVersion() == CssVersion.CSS1) {
       break;
       }
     default:
-      jj_la1[130] = jj_gen;
+      jj_la1[131] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3683,7 +3754,7 @@ if (ac.getCssVersion() == CssVersion.CSS1) {
         break;
         }
       default:
-        jj_la1[131] = jj_gen;
+        jj_la1[132] = jj_gen;
         break label_93;
       }
       jj_consume_token(S);
@@ -3747,7 +3818,7 @@ try {
               break;
               }
             default:
-              jj_la1[132] = jj_gen;
+              jj_la1[133] = jj_gen;
               break label_94;
             }
             jj_consume_token(S);
@@ -3766,7 +3837,7 @@ try {
             break;
             }
           default:
-            jj_la1[133] = jj_gen;
+            jj_la1[134] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -3778,7 +3849,7 @@ try {
               break;
               }
             default:
-              jj_la1[134] = jj_gen;
+              jj_la1[135] = jj_gen;
               break label_95;
             }
             jj_consume_token(S);
@@ -3805,7 +3876,7 @@ try {
               break;
               }
             default:
-              jj_la1[135] = jj_gen;
+              jj_la1[136] = jj_gen;
               break label_96;
             }
             jj_consume_token(S);
@@ -3825,7 +3896,7 @@ try {
           break;
           }
         default:
-          jj_la1[136] = jj_gen;
+          jj_la1[137] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -3833,14 +3904,14 @@ try {
         break;
         }
       default:
-        jj_la1[137] = jj_gen;
+        jj_la1[138] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[138] = jj_gen;
+      jj_la1[139] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3921,7 +3992,7 @@ n.image = n.image.substring(1);
       break;
       }
     default:
-      jj_la1[139] = jj_gen;
+      jj_la1[140] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3947,7 +4018,7 @@ n.image = n.image.substring(1);
             break;
             }
           default:
-            jj_la1[140] = jj_gen;
+            jj_la1[141] = jj_gen;
             break label_97;
           }
           jj_consume_token(S);
@@ -3959,13 +4030,13 @@ n.image = n.image.substring(1);
           break;
           }
         default:
-          jj_la1[141] = jj_gen;
+          jj_la1[142] = jj_gen;
           ;
         }
         break;
         }
       default:
-        jj_la1[142] = jj_gen;
+        jj_la1[143] = jj_gen;
         ;
       }
 try {
@@ -4019,7 +4090,7 @@ setMediaDeclaration(false);
           break;
           }
         default:
-          jj_la1[143] = jj_gen;
+          jj_la1[144] = jj_gen;
           break label_98;
         }
         jj_consume_token(S);
@@ -4031,7 +4102,7 @@ setMediaDeclaration(false);
         break;
         }
       default:
-        jj_la1[144] = jj_gen;
+        jj_la1[145] = jj_gen;
         ;
       }
 try {
@@ -4099,7 +4170,7 @@ skipAfterExpression(e);
         break;
         }
       default:
-        jj_la1[145] = jj_gen;
+        jj_la1[146] = jj_gen;
         break label_99;
       }
       jj_consume_token(S);
@@ -4150,7 +4221,7 @@ setValue(new CssIdent(), exp, operator, n, IDENT);
         break;
         }
       default:
-        jj_la1[146] = jj_gen;
+        jj_la1[147] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4162,7 +4233,7 @@ setValue(new CssIdent(), exp, operator, n, IDENT);
           break;
           }
         default:
-          jj_la1[147] = jj_gen;
+          jj_la1[148] = jj_gen;
           break label_101;
         }
         jj_consume_token(S);
@@ -4179,7 +4250,7 @@ setValue(new CssIdent(), exp, operator, n, IDENT);
         break;
         }
       default:
-        jj_la1[148] = jj_gen;
+        jj_la1[149] = jj_gen;
         break label_100;
       }
     }
@@ -4231,7 +4302,7 @@ setValue(new CssIdent(), exp, operator, n, IDENT);
           break;
           }
         default:
-          jj_la1[149] = jj_gen;
+          jj_la1[150] = jj_gen;
           break label_102;
         }
         operator(values);
@@ -4281,7 +4352,7 @@ ac.getFrame().addWarning(e.getMessage(), e.getMessageArgs());
         break;
         }
       default:
-        jj_la1[150] = jj_gen;
+        jj_la1[151] = jj_gen;
         break label_103;
       }
       operator(values);
@@ -4323,7 +4394,7 @@ ac.getFrame().addWarning(e.getMessage(), e.getMessageArgs());
         break;
         }
       default:
-        jj_la1[151] = jj_gen;
+        jj_la1[152] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4429,7 +4500,7 @@ if (ac.getTreatCssHacksAsWarnings()) {
         break;
         }
       default:
-        jj_la1[152] = jj_gen;
+        jj_la1[153] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4485,7 +4556,7 @@ setValue(new CssSwitch(), exp, operator, n, DIV);
           break;
           }
         default:
-          jj_la1[153] = jj_gen;
+          jj_la1[154] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -4535,14 +4606,14 @@ setValue(new CssUnicodeRange(), exp, operator, n, UNICODERANGE);
         break;
         }
       default:
-        jj_la1[154] = jj_gen;
+        jj_la1[155] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[155] = jj_gen;
+      jj_la1[156] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -4554,7 +4625,7 @@ setValue(new CssUnicodeRange(), exp, operator, n, UNICODERANGE);
         break;
         }
       default:
-        jj_la1[156] = jj_gen;
+        jj_la1[157] = jj_gen;
         break label_104;
       }
       jj_consume_token(S);
@@ -4593,7 +4664,7 @@ setValue(new CssUnicodeRange(), exp, operator, n, UNICODERANGE);
         break;
         }
       default:
-        jj_la1[157] = jj_gen;
+        jj_la1[158] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4608,7 +4679,7 @@ setValue(new CssNumber(), exp, operator, n, NUMBER);
             break;
             }
           default:
-            jj_la1[158] = jj_gen;
+            jj_la1[159] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -4708,7 +4779,7 @@ setValue(func, exp, operator, null, FUNCTION);
         break;
         }
       default:
-        jj_la1[159] = jj_gen;
+        jj_la1[160] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4720,7 +4791,7 @@ setValue(func, exp, operator, null, FUNCTION);
           break;
           }
         default:
-          jj_la1[160] = jj_gen;
+          jj_la1[161] = jj_gen;
           break label_105;
         }
         jj_consume_token(S);
@@ -4783,7 +4854,7 @@ setValue(new CssUnicodeRange(), exp, operator, n,
         break;
         }
       default:
-        jj_la1[161] = jj_gen;
+        jj_la1[162] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4795,7 +4866,7 @@ setValue(new CssUnicodeRange(), exp, operator, n,
           break;
           }
         default:
-          jj_la1[162] = jj_gen;
+          jj_la1[163] = jj_gen;
           break label_106;
         }
         jj_consume_token(S);
@@ -4803,7 +4874,7 @@ setValue(new CssUnicodeRange(), exp, operator, n,
       break;
       }
     default:
-      jj_la1[163] = jj_gen;
+      jj_la1[164] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -4820,7 +4891,7 @@ CssCalc c;
         break;
         }
       default:
-        jj_la1[164] = jj_gen;
+        jj_la1[165] = jj_gen;
         break label_107;
       }
       jj_consume_token(S);
@@ -4834,7 +4905,7 @@ CssCalc c;
         break;
         }
       default:
-        jj_la1[165] = jj_gen;
+        jj_la1[166] = jj_gen;
         break label_108;
       }
       jj_consume_token(S);
@@ -4881,7 +4952,7 @@ c = new CssCalc(ac, v1);
             break;
             }
           default:
-            jj_la1[166] = jj_gen;
+            jj_la1[167] = jj_gen;
             break label_110;
           }
           jj_consume_token(S);
@@ -4891,7 +4962,7 @@ nb_pre_sp++;
         break;
         }
       default:
-        jj_la1[167] = jj_gen;
+        jj_la1[168] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4907,7 +4978,7 @@ if (o.image.length() < 2 && nb_pre_sp == 0) {
           break;
           }
         default:
-          jj_la1[168] = jj_gen;
+          jj_la1[169] = jj_gen;
           break label_111;
         }
       }
@@ -4949,7 +5020,7 @@ c = new CssCalc(ac, v1);
           break;
           }
         default:
-          jj_la1[169] = jj_gen;
+          jj_la1[170] = jj_gen;
           break label_113;
         }
         jj_consume_token(S);
@@ -4965,7 +5036,7 @@ c = new CssCalc(ac, v1);
             break;
             }
           default:
-            jj_la1[170] = jj_gen;
+            jj_la1[171] = jj_gen;
             break label_114;
           }
           jj_consume_token(S);
@@ -4983,7 +5054,7 @@ c = new CssCalc(ac, v1);
             break;
             }
           default:
-            jj_la1[171] = jj_gen;
+            jj_la1[172] = jj_gen;
             break label_115;
           }
           jj_consume_token(S);
@@ -4995,7 +5066,7 @@ c = new CssCalc(ac, v1);
           break;
           }
         default:
-          jj_la1[172] = jj_gen;
+          jj_la1[173] = jj_gen;
           ;
         }
         n = jj_consume_token(NUMBER);
@@ -5003,7 +5074,7 @@ v2 = new CssNumber(); v2.set(addOperator(operator, n.image), ac);
         break;
         }
       default:
-        jj_la1[173] = jj_gen;
+        jj_la1[174] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5042,7 +5113,7 @@ char operator = ' ';
         break;
         }
       default:
-        jj_la1[174] = jj_gen;
+        jj_la1[175] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -5092,7 +5163,7 @@ v= new CssFrequency(); v.set(addOperator(operator, n.image), ac);
         break;
         }
       default:
-        jj_la1[175] = jj_gen;
+        jj_la1[176] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5108,7 +5179,7 @@ v= new CssFrequency(); v.set(addOperator(operator, n.image), ac);
           break;
           }
         default:
-          jj_la1[176] = jj_gen;
+          jj_la1[177] = jj_gen;
           break label_116;
         }
         jj_consume_token(S);
@@ -5122,7 +5193,7 @@ v= new CssFrequency(); v.set(addOperator(operator, n.image), ac);
           break;
           }
         default:
-          jj_la1[177] = jj_gen;
+          jj_la1[178] = jj_gen;
           break label_117;
         }
         jj_consume_token(S);
@@ -5140,7 +5211,7 @@ v= new CssFrequency(); v.set(addOperator(operator, n.image), ac);
       break;
       }
     default:
-      jj_la1[178] = jj_gen;
+      jj_la1[179] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5160,7 +5231,7 @@ CssExpression exp = null;
         break;
         }
       default:
-        jj_la1[179] = jj_gen;
+        jj_la1[180] = jj_gen;
         break label_118;
       }
       jj_consume_token(S);
@@ -5174,7 +5245,7 @@ CssExpression exp = null;
         break;
         }
       default:
-        jj_la1[180] = jj_gen;
+        jj_la1[181] = jj_gen;
         break label_119;
       }
       jj_consume_token(S);
@@ -5194,7 +5265,7 @@ exp = new CssExpression();
         break;
         }
       default:
-        jj_la1[181] = jj_gen;
+        jj_la1[182] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5207,7 +5278,7 @@ setValue(new CssIdent(), exp, ' ', n, IDENT);
           break;
           }
         default:
-          jj_la1[182] = jj_gen;
+          jj_la1[183] = jj_gen;
           break label_120;
         }
         jj_consume_token(S);
@@ -5215,7 +5286,7 @@ setValue(new CssIdent(), exp, ' ', n, IDENT);
       break;
       }
     default:
-      jj_la1[183] = jj_gen;
+      jj_la1[184] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -5230,7 +5301,7 @@ exp.setOperator(',');
           break;
           }
         default:
-          jj_la1[184] = jj_gen;
+          jj_la1[185] = jj_gen;
           break label_121;
         }
         jj_consume_token(S);
@@ -5239,7 +5310,7 @@ exp.setOperator(',');
       break;
       }
     default:
-      jj_la1[185] = jj_gen;
+      jj_la1[186] = jj_gen;
       ;
     }
     jj_consume_token(LPARAN);
@@ -5264,7 +5335,7 @@ v = new CssAttr();
         break;
         }
       default:
-        jj_la1[186] = jj_gen;
+        jj_la1[187] = jj_gen;
         break label_122;
       }
       jj_consume_token(S);
@@ -5332,7 +5403,7 @@ String funcname = n.image.toLowerCase();
         break;
         }
       default:
-        jj_la1[187] = jj_gen;
+        jj_la1[188] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5364,7 +5435,7 @@ String funcname = n.image.toLowerCase();
       break;
       }
     default:
-      jj_la1[188] = jj_gen;
+      jj_la1[189] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5658,23 +5729,6 @@ n.image = Util.strip(n.image);
     try { return (!jj_3_5()); }
     catch(LookaheadSuccess ls) { return true; }
     finally { jj_save(4, xla); }
-  }
-
-  private boolean jj_3R_177()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(48)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(47)) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_176()
- {
-    if (jj_scan_token(DIV)) return true;
-    return false;
   }
 
   private boolean jj_3R_175()
@@ -6122,6 +6176,13 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3R_132()
+ {
+    if (jj_3R_140()) return true;
+    if (jj_3R_131()) return true;
+    return false;
+  }
+
   private boolean jj_3R_135()
  {
     if (jj_3R_151()) return true;
@@ -6134,13 +6195,6 @@ n.image = Util.strip(n.image);
     xsp = jj_scanpos;
     if (jj_3R_123()) jj_scanpos = xsp;
     if (jj_scan_token(108)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_132()
- {
-    if (jj_3R_140()) return true;
-    if (jj_3R_131()) return true;
     return false;
   }
 
@@ -6304,6 +6358,23 @@ n.image = Util.strip(n.image);
     return false;
   }
 
+  private boolean jj_3R_177()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(48)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(47)) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_176()
+ {
+    if (jj_scan_token(DIV)) return true;
+    return false;
+  }
+
   /** Generated Token Manager. */
   public CssParserTokenManager token_source;
   SimpleCharStream jj_input_stream;
@@ -6315,7 +6386,7 @@ n.image = Util.strip(n.image);
   private Token jj_scanpos, jj_lastpos;
   private int jj_la;
   private int jj_gen;
-  final private int[] jj_la1 = new int[189];
+  final private int[] jj_la1 = new int[190];
   static private int[] jj_la1_0;
   static private int[] jj_la1_1;
   static private int[] jj_la1_2;
@@ -6327,16 +6398,16 @@ n.image = Util.strip(n.image);
 	   jj_la1_init_3();
 	}
 	private static void jj_la1_init_0() {
-	   jj_la1_0 = new int[] {0x0,0x0,0x0,0xe00000,0xe00000,0x0,0x0,0x200000,0x200000,0x0,0xc00000,0xc00000,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x200000,0x200000,0x40000000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x0,0x200000,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x200000,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x200000,0x200000,0x18000000,0x18000000,0x18000000,0x200000,0x200000,0x200000,0x200000,0x18000000,0x40000000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x40000000,0xa8000000,0x200000,0x200000,0xa8200000,0x18000000,0xe8000000,0xe8000000,0x200000,0x0,0x200000,0xe8000000,0x40000000,0x200000,0x200000,0x200000,0xe8000000,0x0,0x200000,0xe8000000,0x200000,0xa8200000,0x200000,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200000,0x200000,0x3000000,0x200000,0x0,0x200000,0x3000000,0x200000,0x0,0x200000,0x200000,0x0,0x200000,0x200000,0x0,0x0,0x0,0x0,0x200000,0x0,0x0,0x200000,0x0,0x200000,0x18000000,0x200000,0x18000000,0x58000000,0x58000000,0x18000000,0x0,0x0,0x0,0x18000000,0x200000,0x18000000,0x0,0x0,0x200000,0x0,0x200000,0x18000000,0x200000,0x200000,0x200000,0x18200000,0x200000,0x200000,0x200000,0x200000,0x18000000,0x0,0x18000000,0x0,0x200000,0x200000,0x18000000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x40000000,0x200000,0x0,0x0,};
+	   jj_la1_0 = new int[] {0x0,0x0,0x0,0xe00000,0xe00000,0x0,0x0,0x200000,0x200000,0x0,0xc00000,0xc00000,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x200000,0x40000000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x0,0x200000,0x0,0x200000,0x200000,0x200000,0x0,0x200000,0x200000,0x200000,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x0,0x0,0x200000,0x200000,0x200000,0x200000,0x18000000,0x18000000,0x18000000,0x200000,0x200000,0x200000,0x200000,0x18000000,0x40000000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x200000,0x40000000,0xa8000000,0x200000,0x200000,0xa8200000,0x18000000,0xe8000000,0xe8000000,0x200000,0x0,0x200000,0xe8000000,0x40000000,0x200000,0x200000,0x200000,0xe8000000,0x0,0x200000,0xe8000000,0x200000,0xa8200000,0x200000,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200000,0x200000,0x3000000,0x200000,0x0,0x200000,0x3000000,0x200000,0x0,0x200000,0x200000,0x0,0x200000,0x200000,0x0,0x0,0x0,0x0,0x200000,0x0,0x0,0x200000,0x0,0x200000,0x18000000,0x200000,0x18000000,0x58000000,0x58000000,0x18000000,0x0,0x0,0x0,0x18000000,0x200000,0x18000000,0x0,0x0,0x200000,0x0,0x200000,0x18000000,0x200000,0x200000,0x200000,0x18200000,0x200000,0x200000,0x200000,0x200000,0x18000000,0x0,0x18000000,0x0,0x200000,0x200000,0x18000000,0x200000,0x200000,0x0,0x200000,0x0,0x200000,0x40000000,0x200000,0x0,0x0,};
 	}
 	private static void jj_la1_init_1() {
-	   jj_la1_1 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xcba28070,0x0,0x0,0x0,0x0,0x0,0x10,0x400004,0x0,0x0,0x0,0x400004,0x0,0x100012,0x0,0x0,0x0,0xcba28070,0x0,0x0,0x0,0x0,0x0,0x0,0x2,0x0,0x1,0x0,0x1,0x0,0x100012,0x0,0x0,0x0,0x200000,0x0,0x0,0x0,0x0,0x0,0x10,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3bd000,0x3bd000,0x0,0x20,0x0,0x3bd030,0x0,0x0,0x0,0x0,0x3bd030,0x2000,0x0,0x3bd030,0x0,0x0,0x0,0x0,0xcba08060,0xcba08060,0xcba08060,0xcba08060,0xcba28070,0xcb800000,0xcb800000,0x20010,0x20010,0x20010,0x0,0x0,0x1e00,0x0,0x14,0x0,0x1e00,0x0,0xcba28070,0x0,0x0,0x14,0x0,0x0,0x0,0x10,0x200000,0x60,0x0,0x0,0x200000,0x0,0x0,0x0,0x14,0x0,0x14,0xffc1c0f4,0xffc00074,0x0,0xff800080,0x18000,0x41c074,0xffc1c0f4,0x0,0x0,0x0,0xff800000,0x0,0x400074,0x0,0xffc00074,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x24000,0x0,0xcf800000,0x0,0x0,0xcf900000,0x0,0x0,0x10,0x0,0x10,0x0,0x0,0x0,0x10,0x60,};
+	   jj_la1_1 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xcba28070,0x0,0x0,0x0,0x0,0x0,0x10,0x400004,0x0,0x0,0x0,0x400004,0x0,0x100012,0x0,0x0,0x0,0xcba28070,0xcba28070,0x0,0x0,0x0,0x0,0x0,0x0,0x2,0x0,0x1,0x0,0x1,0x0,0x100012,0x0,0x0,0x0,0x200000,0x0,0x0,0x0,0x0,0x0,0x10,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3bd000,0x3bd000,0x0,0x20,0x0,0x3bd030,0x0,0x0,0x0,0x0,0x3bd030,0x2000,0x0,0x3bd030,0x0,0x0,0x0,0x0,0xcba08060,0xcba08060,0xcba08060,0xcba08060,0xcba28070,0xcb800000,0xcb800000,0x20010,0x20010,0x20010,0x0,0x0,0x1e00,0x0,0x14,0x0,0x1e00,0x0,0xcba28070,0x0,0x0,0x14,0x0,0x0,0x0,0x10,0x200000,0x60,0x0,0x0,0x200000,0x0,0x0,0x0,0x14,0x0,0x14,0xffc1c0f4,0xffc00074,0x0,0xff800080,0x18000,0x41c074,0xffc1c0f4,0x0,0x0,0x0,0xff800000,0x0,0x400074,0x0,0xffc00074,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x24000,0x0,0xcf800000,0x0,0x0,0xcf900000,0x0,0x0,0x10,0x0,0x10,0x0,0x0,0x0,0x10,0x60,};
 	}
 	private static void jj_la1_init_2() {
-	   jj_la1_2 = new int[] {0x0,0x0,0x100,0x0,0x0,0x200,0x400,0x0,0x0,0x1c1f885,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x85,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1e0000,0x1e0000,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x0,0x0,0x0,0x0,0x8,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000000,0x0,0x1000000,0x0,0x0,0x0,0x0,0x1000000,0x0,0x0,0x1000000,0x0,0x0,0x0,0x0,0x85,0x85,0x85,0x85,0x85,0x5,0x5,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x85,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x80,0x0,0x0,0x20,0x0,0x0,0x20,0x0,0x1c,0x0,0x1c,0x5f,0x5f,0x0,0x5f,0x0,0x0,0x5f,0x0,0x0,0x10,0x5f,0x0,0x0,0x0,0x5f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x18,0x0,0x0,0x18,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_2 = new int[] {0x0,0x0,0x100,0x0,0x0,0x200,0x400,0x0,0x0,0x1c1f885,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1c1f885,0x1c1f885,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1e0000,0x1e0000,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x0,0x0,0x0,0x0,0x8,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000000,0x0,0x1000000,0x0,0x0,0x0,0x0,0x1000000,0x0,0x0,0x1000000,0x0,0x0,0x0,0x0,0x85,0x85,0x85,0x85,0x85,0x5,0x5,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x85,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x80,0x0,0x0,0x20,0x0,0x0,0x20,0x0,0x1c,0x0,0x1c,0x5f,0x5f,0x0,0x5f,0x0,0x0,0x5f,0x0,0x0,0x10,0x5f,0x0,0x0,0x0,0x5f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x18,0x0,0x0,0x18,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_3() {
-	   jj_la1_3 = new int[] {0x600,0x600,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1028,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1028,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x800,0x800,0x0,0x8,0x0,0x808,0x0,0x0,0x0,0x0,0x808,0x0,0x0,0x808,0x0,0x0,0x0,0x0,0x28,0x28,0x28,0x28,0x1028,0x8,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1008,0x0,0x0,0x0,0x0,0x0,0x110,0x110,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1c4,0x104,0x0,0x0,0x0,0x1c4,0x1c4,0x0,0x0,0x0,0x100,0x0,0x4,0x0,0x104,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xc0,0x0,0x0,0x2000,0x0,0x2000,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_3 = new int[] {0x600,0x600,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1028,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1028,0x1028,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x800,0x800,0x0,0x8,0x0,0x808,0x0,0x0,0x0,0x0,0x808,0x0,0x0,0x808,0x0,0x0,0x0,0x0,0x28,0x28,0x28,0x28,0x1028,0x8,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1008,0x0,0x0,0x0,0x0,0x0,0x110,0x110,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1c4,0x104,0x0,0x0,0x0,0x1c4,0x1c4,0x0,0x0,0x0,0x100,0x0,0x4,0x0,0x104,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xc0,0x0,0x0,0x2000,0x0,0x2000,0x0,0x0,0x0,0x0,0x0,};
 	}
   final private JJCalls[] jj_2_rtns = new JJCalls[5];
   private boolean jj_rescan = false;
@@ -6353,7 +6424,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 189; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 190; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6368,7 +6439,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 189; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 190; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6379,7 +6450,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 189; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 190; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6398,7 +6469,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 189; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 190; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6408,7 +6479,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 189; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 190; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6418,7 +6489,7 @@ n.image = Util.strip(n.image);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 189; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 190; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -6549,7 +6620,7 @@ n.image = Util.strip(n.image);
 	   la1tokens[jj_kind] = true;
 	   jj_kind = -1;
 	 }
-	 for (int i = 0; i < 189; i++) {
+	 for (int i = 0; i < 190; i++) {
 	   if (jj_la1[i] == jj_gen) {
 		 for (int j = 0; j < 32; j++) {
 		   if ((jj_la1_0[i] & (1<<j)) != 0) {

--- a/org/w3c/css/parser/analyzer/CssParser.jj
+++ b/org/w3c/css/parser/analyzer/CssParser.jj
@@ -979,7 +979,9 @@ AtRuleMedia media() :
 		        newAtRule(getAtRule());
 		    }
 	    }
-	<LBRACE> ( <S> )* ( ruleSet() )* <RBRACE> ( <S> )*
+	<LBRACE> ( <S> )* ( ruleSet()  | media() | page() | fontFace() |
+	     keyframes() | preference() | colorprofile() | counterstyle() |
+	     phoneticAlphabet() | atRuleDeclaration() )* <RBRACE> ( <S> )*
 	     {
 		     if (!isCss1) {
 		         endOfAtRule();


### PR DESCRIPTION
This change causes at-rules nested within other at-rules to be handled without
causing unexpected errors.

Fixes https://github.com/w3c/css-validator/issues/44
Fixes https://github.com/w3c/css-validator/issues/72