### PR TITLE
Allow @supports and @viewport (without checking)

### DIFF
--- a/org/w3c/css/parser/analyzer/CssParser.java
+++ b/org/w3c/css/parser/analyzer/CssParser.java
@@ -2412,7 +2412,10 @@ if (n.toString().charAt(1) == '-') {
                                 addAtRuleError();
                         }
                 } else {
-                        addAtRuleError();
+                        if (!n.toString().startsWith("@supports")
+                                && !n.toString().startsWith("@viewport")) {
+                                addAtRuleError();
+                        }
                 }
             skipStatement();
   }
@@ -5743,37 +5746,6 @@ n.image = Util.strip(n.image);
     finally { jj_save(4, xla); }
   }
 
-  private boolean jj_3R_175()
- {
-    if (jj_scan_token(STRING)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_154()
- {
-    if (jj_scan_token(PLUS)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_174()
- {
-    if (jj_3R_183()) return true;
-    return false;
-  }
-
-  private boolean jj_3_5()
- {
-    if (jj_3R_127()) return true;
-    if (jj_scan_token(LPARAN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_173()
- {
-    if (jj_3R_152()) return true;
-    return false;
-  }
-
   private boolean jj_3R_172()
  {
     if (jj_3R_151()) return true;
@@ -6384,6 +6356,37 @@ n.image = Util.strip(n.image);
   private boolean jj_3R_176()
  {
     if (jj_scan_token(DIV)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_175()
+ {
+    if (jj_scan_token(STRING)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_154()
+ {
+    if (jj_scan_token(PLUS)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_174()
+ {
+    if (jj_3R_183()) return true;
+    return false;
+  }
+
+  private boolean jj_3_5()
+ {
+    if (jj_3R_127()) return true;
+    if (jj_scan_token(LPARAN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_173()
+ {
+    if (jj_3R_152()) return true;
     return false;
   }
 

--- a/org/w3c/css/parser/analyzer/CssParser.jj
+++ b/org/w3c/css/parser/analyzer/CssParser.jj
@@ -1553,7 +1553,10 @@ void atRuleDeclaration() :
 				addAtRuleError();
 			}
 		} else {
-			addAtRuleError();
+			if (!n.toString().startsWith("@supports")
+				&& !n.toString().startsWith("@viewport")) {
+				addAtRuleError();
+			}
 		}
 	    skipStatement();
 	}


### PR DESCRIPTION
This change is a temporary workaround that adds an interim/initial/partial level
of support for allowing the @supports and @viewport at-rules. The intent is that
we’ll add full support for them later, and then at that time back this change
out (because adding real, full support will make it unnecessary).

This change simply causes no errors to be reported for stylesheets that use
@supports and @viewport. Beyond that, it doesn’t add any checking to report an
error if the content of a particular @supports at-rule or @viewport at-rule
doesn’t conform to the requirements in the relevant CSS specs.

Addresses https://github.com/w3c/css-validator/issues/71