### PR TITLE
Allow the text-size-adjust property & check it

### DIFF
--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -125,6 +125,7 @@ text-emphasis:                          org.w3c.css.properties.css3.CssTextEmpha
 text-emphasis-color:                    org.w3c.css.properties.css3.CssTextEmphasisColor
 text-emphasis-position:                 org.w3c.css.properties.css3.CssTextEmphasisPosition
 text-emphasis-style:                    org.w3c.css.properties.css3.CssTextEmphasisStyle
+text-size-adjust:                       org.w3c.css.properties.css3.CssTextSizeAdjust
 text-underline-position:                org.w3c.css.properties.css3.CssTextUnderlinePosition
 tab-size:                               org.w3c.css.properties.css3.CssTabSize
 hanging-punctuation:                    org.w3c.css.properties.css3.CssHangingPunctuation

--- a/org/w3c/css/properties/CSS3SVGProperties.properties
+++ b/org/w3c/css/properties/CSS3SVGProperties.properties
@@ -174,6 +174,7 @@ text-emphasis:                          org.w3c.css.properties.css3.CssTextEmpha
 text-emphasis-color:                    org.w3c.css.properties.css3.CssTextEmphasisColor
 text-emphasis-position:                 org.w3c.css.properties.css3.CssTextEmphasisPosition
 text-emphasis-style:                    org.w3c.css.properties.css3.CssTextEmphasisStyle
+text-size-adjust:                       org.w3c.css.properties.css3.CssTextSizeAdjust
 text-underline-position:                org.w3c.css.properties.css3.CssTextUnderlinePosition
 tab-size:                               org.w3c.css.properties.css3.CssTabSize
 hanging-punctuation:                    org.w3c.css.properties.css3.CssHangingPunctuation

--- a/org/w3c/css/properties/Media.properties
+++ b/org/w3c/css/properties/Media.properties
@@ -43,6 +43,7 @@ text-emphasis:                  handheld, print, projection, screen, tty, tv
 text-emphasis-color:            handheld, print, projection, screen, tty, tv
 text-emphasis-position:         handheld, print, projection, screen, tty, tv
 text-emphasis-style:            handheld, print, projection, screen, tty, tv
+text-size-adjust:               handheld, print, projection, screen, tty, tv
 line-height:                    handheld, print, projection, screen, tty, tv
 margin-top:                     handheld, print, projection, screen, tty, tv
 margin-bottom:                  handheld, print, projection, screen, tty, tv

--- a/org/w3c/css/properties/css/CssTextSizeAdjust.java
+++ b/org/w3c/css/properties/css/CssTextSizeAdjust.java
@@ -1,0 +1,112 @@
+// (c) COPYRIGHT MIT, ERCIM, Keio and Beihang, 2018.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssTextSizeAdjust extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssTextSizeAdjust
+     */
+    public CssTextSizeAdjust() {
+    }
+
+    /**
+     * Creates a new CssTextSizeAdjust
+     *
+     * @param expression The expression for this property
+     * @throws org.w3c.css.util.InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssTextSizeAdjust(ApplContext ac, CssExpression expression, //
+                         boolean check) throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssTextSizeAdjust(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "text-size-adjust";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return value.equals(inherit);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssTextSizeAdjust != null) {
+            style.addRedefinitionWarning(ac, this);
+        }
+        s.cssTextSizeAdjust = this;
+    }
+
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssTextSizeAdjust &&
+                value.equals(((CssTextSizeAdjust) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getTextSizeAdjust();
+        } else {
+            return ((Css3Style) style).cssTextSizeAdjust;
+        }
+    }
+}

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -174,6 +174,7 @@ import org.w3c.css.properties.css.CssTextEmphasisPosition;
 import org.w3c.css.properties.css.CssTextEmphasisStyle;
 import org.w3c.css.properties.css.CssTextJustify;
 import org.w3c.css.properties.css.CssTextOverflow;
+import org.w3c.css.properties.css.CssTextSizeAdjust;
 import org.w3c.css.properties.css.CssTextUnderlinePosition;
 import org.w3c.css.properties.css.CssTouchAction;
 import org.w3c.css.properties.css.CssTransform;
@@ -353,6 +354,7 @@ public class Css3Style extends ATSCStyle {
     public CssTextEmphasisColor cssTextEmphasisColor;
     public CssTextEmphasisPosition cssTextEmphasisPosition;
     public CssTextEmphasisStyle cssTextEmphasisStyle;
+    public CssTextSizeAdjust cssTextSizeAdjust;
     public CssTextUnderlinePosition cssTextUnderlinePosition;
     public CssHangingPunctuation cssHangingPunctuation;
     public CssTabSize cssTabSize;
@@ -1688,6 +1690,15 @@ public class Css3Style extends ATSCStyle {
                             new CssTextEmphasisStyle(), style, selector);
         }
         return cssTextEmphasisStyle;
+    }
+
+    public CssTextSizeAdjust getTextSizeAdjust() {
+        if (cssTextSizeAdjust == null) {
+            cssTextSizeAdjust =
+                    (CssTextSizeAdjust) style.CascadingOrder(
+                            new CssTextSizeAdjust(), style, selector);
+        }
+        return cssTextSizeAdjust;
     }
 
     public CssTextUnderlinePosition getTextUnderlinePosition() {

--- a/org/w3c/css/properties/css3/CssTextSizeAdjust.java
+++ b/org/w3c/css/properties/css3/CssTextSizeAdjust.java
@@ -54,7 +54,7 @@ public class CssTextSizeAdjust extends org.w3c.css.properties.css.CssTextSizeAdj
      * @throws InvalidParamException Incorrect value
      */
     public CssTextSizeAdjust(ApplContext ac, CssExpression expression,
-                         boolean check) throws InvalidParamException {
+                             boolean check) throws InvalidParamException {
 
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);
@@ -78,6 +78,8 @@ public class CssTextSizeAdjust extends org.w3c.css.properties.css.CssTextSizeAdj
                                 getPropertyName(), ac);
                     }
                 }
+            case CssTypes.CSS_NUMBER:
+                val.getCheckableValue().checkEqualsZero(ac, this);
             case CssTypes.CSS_PERCENTAGE:
                 value = val;
                 break;

--- a/org/w3c/css/properties/css3/CssTextSizeAdjust.java
+++ b/org/w3c/css/properties/css3/CssTextSizeAdjust.java
@@ -1,0 +1,99 @@
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2018.
+// Please first read the full copyright statement at:
+// https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssIdent;
+import org.w3c.css.values.CssTypes;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @spec https://github.com/w3c/csswg-drafts/blob/d644687e36b3290d62fe0117a94345addf3468af/css-size-adjust-1/Overview.bs
+ */
+
+public class CssTextSizeAdjust extends org.w3c.css.properties.css.CssTextSizeAdjust {
+
+    public static final CssIdent auto = CssIdent.getIdent("auto");
+
+    public static final CssIdent[] allowed_values;
+
+    static {
+        int i = 0;
+        String[] _allowed_values = {"auto", "none"};
+        allowed_values = new CssIdent[_allowed_values.length];
+        i = 0;
+        for (String s : _allowed_values) {
+            allowed_values[i++] = CssIdent.getIdent(s);
+        }
+    }
+
+    public static CssIdent getAllowedIdent(CssIdent ident) {
+        for (CssIdent id : allowed_values) {
+            if (id.equals(ident)) {
+                return id;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Create a new CssTextSizeAdjust
+     */
+    public CssTextSizeAdjust() {
+        value = initial;
+    }
+
+    /**
+     * Create a new CssTextSizeAdjust
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Incorrect value
+     */
+    public CssTextSizeAdjust(ApplContext ac, CssExpression expression,
+                         boolean check) throws InvalidParamException {
+
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+
+        setByUser();
+
+        CssValue val;
+
+        val = expression.getValue();
+
+        switch (val.getType()) {
+            case CssTypes.CSS_IDENT:
+                CssIdent id = (CssIdent) val;
+                if (inherit.equals(id)) {
+                    value = inherit;
+                } else {
+                    value = getAllowedIdent(id);
+                    if (value == null) {
+                        throw new InvalidParamException("value", val.toString(),
+                                getPropertyName(), ac);
+                    }
+                }
+            case CssTypes.CSS_PERCENTAGE:
+                value = val;
+                break;
+            default:
+                throw new InvalidParamException("value", val.toString(),
+                        getPropertyName(), ac);
+        }
+    }
+
+    public CssTextSizeAdjust(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    public boolean isDefault() {
+        return ((value == auto) || (value == initial));
+    }
+
+}


### PR DESCRIPTION
This change makes the CSS checker recognize & check the `text-size-adjust`
property.

The checking behavior conforms to the definition in the Mobile Text Size
Adjustment spec at https://drafts.csswg.org/css-size-adjust/