### PR TITLE
Allow the scroll-behavior property & check it

### DIFF
--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -55,6 +55,9 @@ background-blend-mode:                  org.w3c.css.properties.css3.CssBackgroun
 isolation:                              org.w3c.css.properties.css3.CssIsolation
 mix-blend-mode:                         org.w3c.css.properties.css3.CssMixBlendMode
 
+# scroll-behavior
+scroll-behavior:                        org.w3c.css.properties.css3.CssScrollBehavior
+
 # scroll-snap
 scroll-padding:                         org.w3c.css.properties.css3.CssScrollPadding
 scroll-padding-block:                   org.w3c.css.properties.css3.CssScrollPaddingBlock

--- a/org/w3c/css/properties/CSS3SVGProperties.properties
+++ b/org/w3c/css/properties/CSS3SVGProperties.properties
@@ -104,6 +104,9 @@ background-blend-mode:                  org.w3c.css.properties.css3.CssBackgroun
 isolation:                              org.w3c.css.properties.css3.CssIsolation
 mix-blend-mode:                         org.w3c.css.properties.css3.CssMixBlendMode
 
+# scroll-behavior
+scroll-behavior:                        org.w3c.css.properties.css3.CssScrollBehavior
+
 # scroll-snap
 scroll-padding:                         org.w3c.css.properties.css3.CssScrollPadding
 scroll-padding-block:                   org.w3c.css.properties.css3.CssScrollPaddingBlock

--- a/org/w3c/css/properties/Media.properties
+++ b/org/w3c/css/properties/Media.properties
@@ -370,6 +370,7 @@ lighting-color:                 handheld, print, projection, screen, tty, tv
 touch-action:                   handheld, print, projection, screen, tty, tv
 appearance:                     all
 user-select:                    handheld, print, projection, screen, tty, tv
+scroll-behavior:                handheld, print, projection, screen, tty, tv
 
 
 # properties not yet implemented

--- a/org/w3c/css/properties/css/CssScrollBehavior.java
+++ b/org/w3c/css/properties/css/CssScrollBehavior.java
@@ -1,0 +1,112 @@
+// (c) COPYRIGHT MIT, ERCIM, Keio and Beihang, 2018.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssScrollBehavior extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssScrollBehavior
+     */
+    public CssScrollBehavior() {
+    }
+
+    /**
+     * Creates a new CssScrollBehavior
+     *
+     * @param expression The expression for this property
+     * @throws org.w3c.css.util.InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssScrollBehavior(ApplContext ac, CssExpression expression, //
+                         boolean check) throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssScrollBehavior(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "scroll-behavior";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return value.equals(inherit);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssScrollBehavior != null) {
+            style.addRedefinitionWarning(ac, this);
+        }
+        s.cssScrollBehavior = this;
+    }
+
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssScrollBehavior &&
+                value.equals(((CssScrollBehavior) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getScrollBehavior();
+        } else {
+            return ((Css3Style) style).cssScrollBehavior;
+        }
+    }
+}

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -136,6 +136,7 @@ import org.w3c.css.properties.css.CssRestBefore;
 import org.w3c.css.properties.css.CssRubyAlign;
 import org.w3c.css.properties.css.CssRubyMerge;
 import org.w3c.css.properties.css.CssRubyPosition;
+import org.w3c.css.properties.css.CssScrollBehavior;
 import org.w3c.css.properties.css.CssScrollPadding;
 import org.w3c.css.properties.css.CssScrollPaddingBlock;
 import org.w3c.css.properties.css.CssScrollPaddingBlockEnd;
@@ -226,6 +227,7 @@ public class Css3Style extends ATSCStyle {
     public CssTouchAction cssTouchAction;
     public CssAppearance cssAppearance;
     public CssUserSelect cssUserSelect;
+    public CssScrollBehavior cssScrollBehavior;
 
     public CssScrollSnapMarginBlockStart cssScrollSnapMarginBlockStart;
     public CssScrollSnapMarginBlockEnd cssScrollSnapMarginBlockEnd;
@@ -465,6 +467,15 @@ public class Css3Style extends ATSCStyle {
                             style, selector);
         }
         return cssUserSelect;
+    }
+
+    public CssScrollBehavior getScrollBehavior() {
+        if (cssScrollBehavior == null) {
+            cssScrollBehavior =
+                    (CssScrollBehavior) style.CascadingOrder(new CssScrollBehavior(),
+                            style, selector);
+        }
+        return cssScrollBehavior;
     }
 
     public org.w3c.css.properties.css.counterstyle.CssSpeakAs getCounterStyleCssSpeakAs() {

--- a/org/w3c/css/properties/css3/CssScrollBehavior.java
+++ b/org/w3c/css/properties/css3/CssScrollBehavior.java
@@ -1,0 +1,96 @@
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2018.
+// Please first read the full copyright statement at:
+// https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssIdent;
+import org.w3c.css.values.CssTypes;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @spec https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#smooth-scrolling
+ */
+
+public class CssScrollBehavior extends org.w3c.css.properties.css.CssScrollBehavior {
+
+    public static final CssIdent auto = CssIdent.getIdent("auto");
+
+    public static final CssIdent[] allowed_values;
+
+    static {
+        int i = 0;
+        String[] _allowed_values = {"auto", "smooth"};
+        allowed_values = new CssIdent[_allowed_values.length];
+        i = 0;
+        for (String s : _allowed_values) {
+            allowed_values[i++] = CssIdent.getIdent(s);
+        }
+    }
+
+    public static CssIdent getAllowedIdent(CssIdent ident) {
+        for (CssIdent id : allowed_values) {
+            if (id.equals(ident)) {
+                return id;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Create a new CssScrollBehavior
+     */
+    public CssScrollBehavior() {
+        value = initial;
+    }
+
+    /**
+     * Create a new CssScrollBehavior
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Incorrect value
+     */
+    public CssScrollBehavior(ApplContext ac, CssExpression expression,
+                         boolean check) throws InvalidParamException {
+
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+
+        setByUser();
+
+        CssValue val;
+
+        val = expression.getValue();
+
+        if (val.getType() == CssTypes.CSS_IDENT) {
+            CssIdent id = (CssIdent) val;
+            if (inherit.equals(id)) {
+                value = inherit;
+            } else {
+                value = getAllowedIdent(id);
+                if (value == null) {
+                    throw new InvalidParamException("value", val.toString(),
+                            getPropertyName(), ac);
+                }
+            }
+        } else {
+            throw new InvalidParamException("value", val.toString(),
+                    getPropertyName(), ac);
+        }
+        expression.next();
+    }
+
+    public CssScrollBehavior(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    public boolean isDefault() {
+        return ((value == auto) || (value == initial));
+    }
+
+}


### PR DESCRIPTION
This change makes the checker recognize & check the `scroll-behavior`
property.

The checking behavior conforms to the definition in the CSSOM View spec:
https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#smooth-scrolling