### PR TITLE
Fix typo that disallowed color-burn & color-dodge

### DIFF
--- a/org/w3c/css/properties/css3/CssMixBlendMode.java
+++ b/org/w3c/css/properties/css3/CssMixBlendMode.java
@@ -21,7 +21,7 @@ public class CssMixBlendMode extends org.w3c.css.properties.css.CssMixBlendMode 
 
     static {
         String[] _allowed_values = {"normal", "multiply", "screen", "overlay",
-                "darken", "lighten", "color-dodge |color-burn", "hard-light",
+                "darken", "lighten", "color-dodge", "color-burn", "hard-light",
                 "soft-light", "difference", "exclusion", "hue", "saturation",
                 "color", "luminosity"};
         allowed_values = new CssIdent[_allowed_values.length];


### PR DESCRIPTION
This change fixes a typo in the code that caused the `color-burn` and
`color-dodge` values for `background-blend-mode` and `mix-blend-mode` to
be disallowed.

Closes https://github.com/w3c/css-validator/issues/179 Thanks @ajhoddinott