### PR TITLE
Download velocity-tools from Maven Central

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -44,7 +44,7 @@
         <available file="lib/tagsoup-1.2.1.jar"/>
         <available file="lib/servlet-api-2.5-6.0.1.jar"/>
         <available file="lib/htmlparser-1.4.9.jar"/>
-        <available file="lib/velocity-tools-generic-2.0.jar"/>
+        <available file="lib/velocity-tools-2.0.jar"/>
       </and>
     </condition>
   </target>
@@ -62,7 +62,7 @@
     <get dest="tmp/commons-text-1.3.jar" src="https://repo1.maven.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3.jar" usetimestamp="true"/>
     <get dest="tmp/commons-logging-1.1.3.jar" src="https://repo1.maven.org/maven2/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3.jar" usetimestamp="true"/>
     <get dest="tmp/velocity-1.7.jar" src="https://repo1.maven.org/maven2/org/apache/velocity/velocity/1.7/velocity-1.7.jar" usetimestamp="true"/>
-    <get dest="tmp/velocity-tools-generic-2.0.jar" src="http://www.apache.org/dist/velocity/tools/2.0/velocity-tools-generic-2.0.jar" usetimestamp="true"/>
+    <get dest="tmp/velocity-tools-2.0.jar" src="https://repo1.maven.org/maven2/org/apache/velocity/velocity-tools/2.0/velocity-tools-2.0.jar" usetimestamp="true"/>
     <get dest="tmp/xercesImpl-2.11.0.jar" src="https://repo1.maven.org/maven2/xerces/xercesImpl/2.11.0/xercesImpl-2.11.0.jar" usetimestamp="true"/>
     <get dest="tmp/xml-apis-1.4.01.jar" src="https://repo1.maven.org/maven2/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01.jar" usetimestamp="true"/>
     <get dest="tmp/tagsoup-1.2.1.jar" src="http://central.maven.org/maven2/org/ccil/cowan/tagsoup/tagsoup/1.2.1/tagsoup-1.2.1.jar" usetimestamp="true"/>
@@ -79,7 +79,7 @@
     <copy file="tmp/commons-text-1.3.jar" tofile="lib/commons-text-1.3.jar"/>
     <copy file="tmp/commons-logging-1.1.3.jar" tofile="lib/commons-logging-1.1.3.jar"/>
     <copy file="tmp/velocity-1.7.jar" tofile="lib/velocity-1.7.jar"/>
-    <copy file="tmp/velocity-tools-generic-2.0.jar" tofile="lib/velocity-tools-generic-2.0.jar"/>
+    <copy file="tmp/velocity-tools-2.0.jar" tofile="lib/velocity-tools-2.0.jar"/>
     <copy file="tmp/xercesImpl-2.11.0.jar" tofile="lib/xercesImpl-2.11.0.jar"/>
     <copy file="tmp/xml-apis-1.4.01.jar" tofile="lib/xml-apis-1.4.01.jar"/>
     <copy file="tmp/tagsoup-1.2.1.jar" tofile="lib/tagsoup-1.2.1.jar"/>


### PR DESCRIPTION
This change causes the velocity-tools jar file to be downloaded from the Central Repository (aka Maven Central) rather than from the www.apache.org site — because trying to download from the www.apache.org site results in frequent failures, particularly in Travis CI.

Note that this also causes the velocity-tools-2.0.jar file to be downloaded instead of the velocity-tools-generic-2.0.jar file — because the velocity-tools-generic-2.0.jar file isn’t available from Maven Central, and the velocity-tools-2.0.jar file has a superset of the classes in the velocity-tools-generic-2.0.jar file.