### PR TITLE
fix "break-word"

### DIFF
--- a/org/w3c/css/properties/css3/CssWordBreak.java
+++ b/org/w3c/css/properties/css3/CssWordBreak.java
@@ -20,7 +20,7 @@ public class CssWordBreak extends org.w3c.css.properties.css.CssWordBreak {
     public static final CssIdent[] allowed_values;
 
     static {
-        String[] _allowed_values = {"normal", "keep-all", "break-all"};
+        String[] _allowed_values = {"normal", "keep-all", "break-all", "break-word"};
         allowed_values = new CssIdent[_allowed_values.length];
         int i = 0;
         for (String s : _allowed_values) {


### PR DESCRIPTION
"break-word" added back, was removed in this commit: https://github.com/w3c/css-validator/commit/8db26be2cc6ccdfcbb7c849067317ee02c27d8af