### PR TITLE
Emit error for deprecated media features

### DIFF
--- a/org/w3c/css/atrules/css/media/MediaFeature.java
+++ b/org/w3c/css/atrules/css/media/MediaFeature.java
@@ -1,6 +1,10 @@
 package org.w3c.css.atrules.css.media;
 
 import org.w3c.css.css.StyleSheetOrigin;
+import org.w3c.css.parser.analyzer.ParseException;
+import org.w3c.css.parser.CssError;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssValue;
 
 public abstract class MediaFeature implements StyleSheetOrigin {
@@ -50,6 +54,18 @@ public abstract class MediaFeature implements StyleSheetOrigin {
      */
     public String getCombinator() {
         return combinator;
+    }
+
+    public void reportDeprecatedMediaFeature(ApplContext ac, String modifier) {
+        String feature;
+        if (modifier != null) {
+            feature = String.format("%s-%s", modifier, getFeatureName());
+        } else {
+            feature = getFeatureName();
+        }
+        ac.getFrame().addError(new CssError(new ParseException(
+                String.format(ac.getMsg().getString("deprecatedmediafeature"),
+                        feature))));
     }
 
     /**

--- a/org/w3c/css/atrules/css3/media/MediaDeviceAspectRatio.java
+++ b/org/w3c/css/atrules/css3/media/MediaDeviceAspectRatio.java
@@ -8,13 +8,12 @@ package org.w3c.css.atrules.css3.media;
 import org.w3c.css.atrules.css.media.MediaFeature;
 import org.w3c.css.atrules.css.media.MediaRangeFeature;
 import org.w3c.css.util.ApplContext;
-import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssExpression;
 import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#device-aspect-ratio
+ * @spec https://www.w3.org/TR/2017/CR-mediaqueries-4-20170905/#mf-deprecated
  */
 @Deprecated
 public class MediaDeviceAspectRatio extends MediaRangeFeature {
@@ -33,36 +32,12 @@ public class MediaDeviceAspectRatio extends MediaRangeFeature {
      *          Values are incorrect
      */
     public MediaDeviceAspectRatio(ApplContext ac, String modifier,
-                                  CssExpression expression, boolean check)
-            throws InvalidParamException {
-
-        if (expression != null) {
-            if (expression.getCount() > 1) {
-                throw new InvalidParamException("unrecognize", ac);
-            }
-            if (expression.getCount() == 0) {
-                throw new InvalidParamException("few-value", getFeatureName(), ac);
-            }
-            CssValue val = expression.getValue();
-
-            if (val.getType() == CssTypes.CSS_RATIO) {
-                value = val;
-                setModifier(ac, modifier);
-            } else {
-                throw new InvalidParamException("unrecognize", ac);
-            }
-            setModifier(ac, modifier);
-        } else {
-            if (modifier != null) {
-                throw new InvalidParamException("nomodifiershortmedia",
-                        getFeatureName(), ac);
-            }
-        }
-
+                                  CssExpression expression, boolean check) {
+        reportDeprecatedMediaFeature(ac, modifier);
     }
 
     public MediaDeviceAspectRatio(ApplContext ac, String modifier, CssExpression expression)
-            throws InvalidParamException {
+            {
         this(ac, modifier, expression, false);
     }
 

--- a/org/w3c/css/atrules/css3/media/MediaDeviceHeight.java
+++ b/org/w3c/css/atrules/css3/media/MediaDeviceHeight.java
@@ -8,13 +8,12 @@ package org.w3c.css.atrules.css3.media;
 import org.w3c.css.atrules.css.media.MediaFeature;
 import org.w3c.css.atrules.css.media.MediaRangeFeature;
 import org.w3c.css.util.ApplContext;
-import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssExpression;
 import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#device-height
+ * @spec https://www.w3.org/TR/2017/CR-mediaqueries-4-20170905/#mf-deprecated
  */
 @Deprecated
 public class MediaDeviceHeight extends MediaRangeFeature {
@@ -33,41 +32,12 @@ public class MediaDeviceHeight extends MediaRangeFeature {
      *          Values are incorrect
      */
     public MediaDeviceHeight(ApplContext ac, String modifier,
-                             CssExpression expression, boolean check)
-            throws InvalidParamException {
-
-        if (expression != null) {
-            if (expression.getCount() > 1) {
-                throw new InvalidParamException("unrecognize", ac);
-            }
-            if (expression.getCount() == 0) {
-                throw new InvalidParamException("few-value", getFeatureName(), ac);
-            }
-            CssValue val = expression.getValue();
-
-            switch (val.getType()) {
-                case CssTypes.CSS_NUMBER:
-                    // a bit stupid as the only value would be 0...
-                    val.getCheckableValue().checkEqualsZero(ac, this);
-                case CssTypes.CSS_LENGTH:
-                    value = val;
-                    expression.next();
-                    break;
-                default:
-                    throw new InvalidParamException("value", expression.getValue(),
-                            getFeatureName(), ac);
-            }
-            setModifier(ac, modifier);
-        } else {
-            if (modifier != null) {
-                throw new InvalidParamException("nomodifiershortmedia",
-                        getFeatureName(), ac);
-            }
-        }
+                             CssExpression expression, boolean check) {
+        reportDeprecatedMediaFeature(ac, modifier);
     }
 
     public MediaDeviceHeight(ApplContext ac, String modifier, CssExpression expression)
-            throws InvalidParamException {
+            {
         this(ac, modifier, expression, false);
     }
 

--- a/org/w3c/css/atrules/css3/media/MediaDeviceWidth.java
+++ b/org/w3c/css/atrules/css3/media/MediaDeviceWidth.java
@@ -8,13 +8,12 @@ package org.w3c.css.atrules.css3.media;
 import org.w3c.css.atrules.css.media.MediaFeature;
 import org.w3c.css.atrules.css.media.MediaRangeFeature;
 import org.w3c.css.util.ApplContext;
-import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssExpression;
 import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#device-width
+ * @spec https://www.w3.org/TR/2017/CR-mediaqueries-4-20170905/#mf-deprecated
  */
 @Deprecated
 public class MediaDeviceWidth extends MediaRangeFeature {
@@ -33,41 +32,12 @@ public class MediaDeviceWidth extends MediaRangeFeature {
      *          Values are incorrect
      */
     public MediaDeviceWidth(ApplContext ac, String modifier,
-                            CssExpression expression, boolean check)
-            throws InvalidParamException {
-
-        if (expression != null) {
-            if (expression.getCount() > 1) {
-                throw new InvalidParamException("unrecognize", ac);
-            }
-            if (expression.getCount() == 0) {
-                throw new InvalidParamException("few-value", getFeatureName(), ac);
-            }
-            CssValue val = expression.getValue();
-
-            switch (val.getType()) {
-                case CssTypes.CSS_NUMBER:
-                    // a bit stupid as the only value would be 0...
-                    val.getCheckableValue().checkEqualsZero(ac, this);
-                case CssTypes.CSS_LENGTH:
-                    value = val;
-                    expression.next();
-                    break;
-                default:
-                    throw new InvalidParamException("value", expression.getValue(),
-                            getFeatureName(), ac);
-            }
-            setModifier(ac, modifier);
-        } else {
-            if (modifier != null) {
-                throw new InvalidParamException("nomodifiershortmedia",
-                        getFeatureName(), ac);
-            }
-        }
+                            CssExpression expression, boolean check) {
+        reportDeprecatedMediaFeature(ac, modifier);
     }
 
     public MediaDeviceWidth(ApplContext ac, String modifier, CssExpression expression)
-            throws InvalidParamException {
+            {
         this(ac, modifier, expression, false);
     }
 

--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -424,6 +424,7 @@ parser.import_not_allowed: @import are not allowed after any valid statement oth
 error.bg_order: In the CSS3 background definition, \u201Cbg_position\u201D must occur before / \u201Cbg_size\u201D if both are present
 
 warning.deprecatedmedia: The media \u201C%s\u201D has been deprecated
+deprecatedmediafeature: Deprecated media feature \u201C%s\u201D. For guidance, see the Deprecated Media Features section in the current Media Queries specification.
 error.nomediarestrictor: Mediarestrictor not defined in this CSS level
 error.nomediafeature: Media features are not defined in this CSS level
 error.nomodifiershortmedia: No prefixes are allowed for media features with no value


### PR DESCRIPTION
When the CSS3 profile is selected, this change causes an error to be emitted for the following deprecated media features: device-aspect-ratio, device-height, device-width — as well as for their corresponding min- and max- prefixed versions.

https://www.w3.org/TR/2017/CR-mediaqueries-4-20170905/#mf-deprecated states:

> The following media features are deprecated. They kept for backward
> compatibility, but are not appropriate for newly written style sheets.
> Authors must not use them.

Otherwise, without this change, no messages (not even warnings) are reported for the (mis)use of those media features.