### PR TITLE
Report a specific error for word-break: break-word

### DIFF
--- a/org/w3c/css/properties/css3/CssWordBreak.java
+++ b/org/w3c/css/properties/css3/CssWordBreak.java
@@ -5,8 +5,6 @@
 // Please first read the full copyright statement in file COPYRIGHT.html
 package org.w3c.css.properties.css3;
 
-import org.w3c.css.parser.analyzer.ParseException;
-import org.w3c.css.parser.CssError;
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssExpression;
@@ -20,6 +18,7 @@ import org.w3c.css.values.CssValue;
 public class CssWordBreak extends org.w3c.css.properties.css.CssWordBreak {
 
     public static final CssIdent[] allowed_values;
+    public static final CssIdent break_word;
 
     static {
         String[] _allowed_values = {"normal", "keep-all", "break-all",
@@ -29,6 +28,7 @@ public class CssWordBreak extends org.w3c.css.properties.css.CssWordBreak {
         for (String s : _allowed_values) {
             allowed_values[i++] = CssIdent.getIdent(s);
         }
+        break_word = CssIdent.getIdent("break-word");
     }
 
     public static final CssIdent getAllowedValue(CssIdent ident) {
@@ -65,12 +65,6 @@ public class CssWordBreak extends org.w3c.css.properties.css.CssWordBreak {
         char op;
 
         val = expression.getValue();
-        if ("break-word".equals(val.toString())) {
-            ac.getFrame().addError(new CssError(new ParseException(
-                            String.format(
-                                ac.getMsg().getString("warning.deprecated"),
-                                "break-word"))));
-        }
         op = expression.getOperator();
 
         if (val.getType() == CssTypes.CSS_IDENT) {
@@ -83,6 +77,10 @@ public class CssWordBreak extends org.w3c.css.properties.css.CssWordBreak {
                     throw new InvalidParamException("value",
                             val.toString(),
                             getPropertyName(), ac);
+                }
+                // break-word is deprecated
+                if (value == break_word) {
+                    ac.getFrame().addWarning("deprecated", value.toString());
                 }
             }
         } else {

--- a/org/w3c/css/properties/css3/CssWordBreak.java
+++ b/org/w3c/css/properties/css3/CssWordBreak.java
@@ -5,6 +5,8 @@
 // Please first read the full copyright statement in file COPYRIGHT.html
 package org.w3c.css.properties.css3;
 
+import org.w3c.css.parser.analyzer.ParseException;
+import org.w3c.css.parser.CssError;
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssExpression;
@@ -20,7 +22,8 @@ public class CssWordBreak extends org.w3c.css.properties.css.CssWordBreak {
     public static final CssIdent[] allowed_values;
 
     static {
-        String[] _allowed_values = {"normal", "keep-all", "break-all"};
+        String[] _allowed_values = {"normal", "keep-all", "break-all",
+            "break-word"};
         allowed_values = new CssIdent[_allowed_values.length];
         int i = 0;
         for (String s : _allowed_values) {
@@ -62,6 +65,12 @@ public class CssWordBreak extends org.w3c.css.properties.css.CssWordBreak {
         char op;
 
         val = expression.getValue();
+        if ("break-word".equals(val.toString())) {
+            ac.getFrame().addError(new CssError(new ParseException(
+                            String.format(
+                                ac.getMsg().getString("warning.deprecated"),
+                                "break-word"))));
+        }
         op = expression.getOperator();
 
         if (val.getType() == CssTypes.CSS_IDENT) {


### PR DESCRIPTION
This change causes a specific *“The value 'break-word' is deprecated”* message to be reported. That aligns with the fact that the current CSS Text 3 spec now defines `break-word` as recognized `word-break` value:

https://drafts.csswg.org/css-text-3/#word-break-property
> Value:     normal | keep-all | break-all | break-word

...however, the spec also states:

> For compatibility with legacy content, the word-break property also
> supports a deprecated break-word keyword. When specified, this has the
> same effect as word-break: normal and overflow-wrap: anywhere,
> regardless of the actual value of the overflow-wrap property. However,
> the break-word keyword is not appropriate for newly-written style
> sheets. Authors must not use it.