### PR TITLE
CSSUrl, remove quotes from the URL kept in .value

### DIFF
--- a/org/w3c/css/values/CssURL.java
+++ b/org/w3c/css/values/CssURL.java
@@ -88,6 +88,18 @@ public class CssURL extends CssValue {
         String urlname = s.substring(4, s.length() - 1).trim();
         this.base = base;
 
+        urlname = urlname.trim();
+        if (urlname.isEmpty()){
+        	// okay, no further modifications needed
+        }else if (urlname.charAt(0)=='"' || urlname.charAt(0)=='\''){
+        	final int l = urlname.length()-1;
+        	if (urlname.charAt(0)==urlname.charAt(l)){
+        		urlname = urlname.substring(1, l);
+        	}else{
+                throw new InvalidParamException("url", s, ac);
+        	}
+        }
+        
         value = filterURLData(urlname);
         full = null;
         if (!urlHeading.startsWith("url"))


### PR DESCRIPTION
Previously, `CSSUrl.value` was stored verbatim, including any quotes around the actual value in `url( ... )`.
As `.value` is also used in `getURL()`, the resulting resolved URL included those quotes, which is wrong.

Example:
```css
* {background: url("file.png");
```
With a base of `http://www.example.org`, the result from `getURL()` was `http://www.example.org/"file.png"`.

This pull request modifies `CSSUrl` to remove balanced quotes from the input value before it is stored.
Admittedly, it has the side effect of removing the quotes also from the output of `toString()`, but they are optional and not needed anyways.