### PR TITLE
FontFamily.convertString() double-escapes already escaped strings

### DIFF
--- a/org/w3c/css/properties/css2/font/FontFamily.java
+++ b/org/w3c/css/properties/css2/font/FontFamily.java
@@ -143,13 +143,23 @@ public class FontFamily extends FontProperty implements CssOperator {
     }
 
     String convertString(String value) {
-        if (value.indexOf('"') != -1) {
-            return '\'' + value + '\'';
-        } else if (value.indexOf('\'') != -1) {
-            return '"' + value + '"';
-        } else {
-            return value;
-        }
+    	char cfirst = value.charAt(0);
+    	char clast  = value.charAt(value.length()-1);
+    	
+    	if (cfirst == clast
+    			&& (cfirst == '\'' || cfirst=='"')
+    	){
+    		// is already well escaped
+    		return value;
+    	}
+    	
+    	if (value.indexOf('"') != -1) {
+    		return '\'' + value + '\'';
+    	} else if (value.indexOf('\'') != -1) {
+    		return '"' + value + '"';
+    	} else {
+    		return value;
+    	}
     }
 
     /**


### PR DESCRIPTION
When a font-family includes spaces, it needs to be enclosed in quotes - e.g. `font-family: 'Open Sans'`.
This pull request removes adding another pair of quotes to already quoted strings.

Example: https://jigsaw.w3.org/css-validator/validator?uri=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DOpen%2BSans&profile=css3svg&usermedium=all&warning=1&vextwarning=&lang=de

Input: 
```css
@font-face {
    font-family: 'Open Sans';
    ...
}
```

Output (notice the additional double quotes at `'Open Sans'`):
```css
@font-face {
    font-family : "'Open Sans'";
    ...
} 
```