### PR TITLE
Fix CssPropertyFactory to properly consume "initial" token

### DIFF
--- a/org/w3c/css/parser/CssPropertyFactory.java
+++ b/org/w3c/css/parser/CssPropertyFactory.java
@@ -267,6 +267,7 @@ public class CssPropertyFactory implements Cloneable {
                 Class[] parametersType = {};
                 Constructor constructor = Class.forName(classname).getConstructor(parametersType);
                 Object[] parameters = {};
+                expression.next(); // consume token
                 // invoke the constructor
                 return (CssProperty) constructor.newInstance(parameters);
             } else {


### PR DESCRIPTION
A CSS of:
```css
.inlineCss{text-decoration-style: initial}
```
triggers the following exception at `CssParser` line 5225:
```java
                // Did the property recognize all values in the expression ?

                if (!values.end() && ac.getMedium() == null) {
                        addError(new InvalidParamException("unrecognize", "", ac),
                             values);
```

Interestingly, I can not reproduce this on the public Jigsaw service, but in a direct call to `StyleSheetParser`:

> org.w3c.css.parser.CssParseException: Zu viele Werte oder die Werte werden nicht erkannt
> 	at org.w3c.css.parser.analyzer.CssParser.addError(CssParser.java:439)
> 	at org.w3c.css.parser.analyzer.CssParser.declaration(CssParser.java:5225)
> 	at org.w3c.css.parser.analyzer.CssParser.declarations(CssParser.java:3925)
> 	at org.w3c.css.parser.analyzer.CssParser.ruleSet(CssParser.java:3836)
> 	at org.w3c.css.parser.analyzer.CssParser.afterImportDeclaration(CssParser.java:789)
> 	at org.w3c.css.parser.analyzer.CssParser.parserUnit(CssParser.java:580)
> 	at org.w3c.css.parser.CssFouffa.parseStyle(CssFouffa.java:378)
> 	at org.w3c.css.css.StyleSheetParser.parseStyleElement(StyleSheetParser.java:316)
> 

Anyways, the reason seems to be that `CssPropertyFactory` has a special detection for the `initial` token, but fails to mark it as consumed.