### PR TITLE
StyleSheet, reset "properties" at end of endOfRule()

### DIFF
--- a/org/w3c/css/css/StyleSheet.java
+++ b/org/w3c/css/css/StyleSheet.java
@@ -272,6 +272,7 @@ public class StyleSheet {
         }
         selectortext = "";
         doNotAddRule = false;
+        properties = new ArrayList<>();
     }
 
     public void removeThisRule() {


### PR DESCRIPTION
Proposed fix for #267 
Reset `properties` collection when parsing a block is completed.