### PR TITLE
Css logical 1

### DIFF
--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -53,6 +53,7 @@ padding-block:                          org.w3c.css.properties.css3.CssPaddingBl
 padding-block-start:                    org.w3c.css.properties.css3.CssPaddingBlockStart
 padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBlockEnd
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
+padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -56,6 +56,7 @@ padding-inline:                         org.w3c.css.properties.css3.CssPaddingIn
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
 border-block-start-style:               org.w3c.css.properties.css3.CssBorderBlockStartStyle
+border-block-end-style:                 org.w3c.css.properties.css3.CssBorderBlockEndStyle
 border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -39,6 +39,7 @@ min-inline-size:                        org.w3c.css.properties.css3.CssMinInline
 inset-block:                            org.w3c.css.properties.css3.CssInsetBlock
 inset-block-start:                      org.w3c.css.properties.css3.CssInsetBlockStart
 inset-block-end:                        org.w3c.css.properties.css3.CssInsetBlockEnd
+inset-inline-start:                     org.w3c.css.properties.css3.CssInsetInlineStart
 margin-block:                           org.w3c.css.properties.css3.CssMarginBlock
 margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
 margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlockEnd

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -74,6 +74,7 @@ border-inline-end-style:                org.w3c.css.properties.css3.CssBorderInl
 border-inline-width:                    org.w3c.css.properties.css3.CssBorderInlineWidth
 border-inline-start-width:              org.w3c.css.properties.css3.CssBorderInlineStartWidth
 border-inline-end-width:                org.w3c.css.properties.css3.CssBorderInlineEndWidth
+border-inline-start:                    org.w3c.css.properties.css3.CssBorderInlineStart
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -36,6 +36,7 @@ min-block-size                          org.w3c.css.properties.css3.CssMinBlockS
 inline-size:                            org.w3c.css.properties.css3.CssInlineSize
 max-inline-size:                        org.w3c.css.properties.css3.CssMaxInlineSize
 min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
+margin-block:                           org.w3c.css.properties.css3.CssMarginBlock
 margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
 margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlockEnd
 margin-inline-start:                    org.w3c.css.properties.css3.CssMarginInlineStart

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -65,6 +65,7 @@ border-block-width:                     org.w3c.css.properties.css3.CssBorderBlo
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
 border-block-start:                     org.w3c.css.properties.css3.CssBorderBlockStart
+border-block-end:                       org.w3c.css.properties.css3.CssBorderBlockEnd
 border-inline-color:                    org.w3c.css.properties.css3.CssBorderInlineColor
 border-inline-start-color:              org.w3c.css.properties.css3.CssBorderInlineStartColor
 border-inline-style:                    org.w3c.css.properties.css3.CssBorderInlineStyle

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -62,6 +62,7 @@ border-block-width:                     org.w3c.css.properties.css3.CssBorderBlo
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
 border-inline-start-style:              org.w3c.css.properties.css3.CssBorderInlineStartStyle
+border-inline-end-style:                org.w3c.css.properties.css3.CssBorderInlineEndStyle
 border-inline-width:                    org.w3c.css.properties.css3.CssBorderInlineWidth
 border-inline-start-width:              org.w3c.css.properties.css3.CssBorderInlineStartWidth
 border-inline-end-width:                org.w3c.css.properties.css3.CssBorderInlineEndWidth

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -56,6 +56,7 @@ padding-inline:                         org.w3c.css.properties.css3.CssPaddingIn
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
+border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -77,6 +77,7 @@ border-inline-start-width:              org.w3c.css.properties.css3.CssBorderInl
 border-inline-end-width:                org.w3c.css.properties.css3.CssBorderInlineEndWidth
 border-inline-start:                    org.w3c.css.properties.css3.CssBorderInlineStart
 border-inline-end:                      org.w3c.css.properties.css3.CssBorderInlineEnd
+border-inline:                          org.w3c.css.properties.css3.CssBorderInline
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -64,6 +64,7 @@ border-block-end-style:                 org.w3c.css.properties.css3.CssBorderBlo
 border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
+border-inline-color:                    org.w3c.css.properties.css3.CssBorderInlineColor
 border-inline-start-color:              org.w3c.css.properties.css3.CssBorderInlineStartColor
 border-inline-style:                    org.w3c.css.properties.css3.CssBorderInlineStyle
 border-inline-start-style:              org.w3c.css.properties.css3.CssBorderInlineStartStyle

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -55,6 +55,7 @@ padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBl
 padding-inline:                         org.w3c.css.properties.css3.CssPaddingInline
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
+border-block-start-color:               org.w3c.css.properties.css3.CssBorderBlockStartColor
 border-block-style:                     org.w3c.css.properties.css3.CssBorderBlockStyle
 border-block-start-style:               org.w3c.css.properties.css3.CssBorderBlockStartStyle
 border-block-end-style:                 org.w3c.css.properties.css3.CssBorderBlockEndStyle

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -38,6 +38,7 @@ max-inline-size:                        org.w3c.css.properties.css3.CssMaxInline
 min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
 margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
 margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlockEnd
+margin-inline-start:                    org.w3c.css.properties.css3.CssMarginInlineStart
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -39,6 +39,7 @@ min-inline-size:                        org.w3c.css.properties.css3.CssMinInline
 inset-block:                            org.w3c.css.properties.css3.CssInsetBlock
 inset-block-start:                      org.w3c.css.properties.css3.CssInsetBlockStart
 inset-block-end:                        org.w3c.css.properties.css3.CssInsetBlockEnd
+inset-inline:                           org.w3c.css.properties.css3.CssInsetInline
 inset-inline-start:                     org.w3c.css.properties.css3.CssInsetInlineStart
 inset-inline-end:                       org.w3c.css.properties.css3.CssInsetInlineEnd
 margin-block:                           org.w3c.css.properties.css3.CssMarginBlock

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -78,6 +78,7 @@ border-inline-end-width:                org.w3c.css.properties.css3.CssBorderInl
 border-inline-start:                    org.w3c.css.properties.css3.CssBorderInlineStart
 border-inline-end:                      org.w3c.css.properties.css3.CssBorderInlineEnd
 border-inline:                          org.w3c.css.properties.css3.CssBorderInline
+border-start-start-radius:              org.w3c.css.properties.css3.CssBorderStartStartRadius
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -58,6 +58,7 @@ padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingIn
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
 border-inline-start-width:              org.w3c.css.properties.css3.CssBorderInlineStartWidth
+border-inline-end-width:                org.w3c.css.properties.css3.CssBorderInlineEndWidth
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -31,7 +31,9 @@ marker-side:                            org.w3c.css.properties.css3.CssMarkerSid
 
 #logical
 block-size:                             org.w3c.css.properties.css3.CssBlockSize
+min-block-size                          org.w3c.css.properties.css3.CssMinBlockSize
 inline-size:                            org.w3c.css.properties.css3.CssInlineSize
+min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -55,6 +55,7 @@ padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBl
 padding-inline:                         org.w3c.css.properties.css3.CssPaddingInline
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
+border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
 border-inline-start-width:              org.w3c.css.properties.css3.CssBorderInlineStartWidth

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -50,6 +50,7 @@ margin-inline:                          org.w3c.css.properties.css3.CssMarginInl
 margin-inline-start:                    org.w3c.css.properties.css3.CssMarginInlineStart
 margin-inline-end:                      org.w3c.css.properties.css3.CssMarginInlineEnd
 padding-block-start:                    org.w3c.css.properties.css3.CssPaddingBlockStart
+padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBlockEnd
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -64,6 +64,7 @@ border-block-end-style:                 org.w3c.css.properties.css3.CssBorderBlo
 border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
+border-inline-start-color:              org.w3c.css.properties.css3.CssBorderInlineStartColor
 border-inline-style:                    org.w3c.css.properties.css3.CssBorderInlineStyle
 border-inline-start-style:              org.w3c.css.properties.css3.CssBorderInlineStartStyle
 border-inline-end-style:                org.w3c.css.properties.css3.CssBorderInlineEndStyle

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -52,6 +52,7 @@ margin-inline-end:                      org.w3c.css.properties.css3.CssMarginInl
 padding-block:                          org.w3c.css.properties.css3.CssPaddingBlock
 padding-block-start:                    org.w3c.css.properties.css3.CssPaddingBlockStart
 padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBlockEnd
+padding-inline:                         org.w3c.css.properties.css3.CssPaddingInline
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
 

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -57,6 +57,7 @@ padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingIn
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
+border-inline-start-width:              org.w3c.css.properties.css3.CssBorderInlineStartWidth
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -39,6 +39,7 @@ min-inline-size:                        org.w3c.css.properties.css3.CssMinInline
 margin-block:                           org.w3c.css.properties.css3.CssMarginBlock
 margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
 margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlockEnd
+margin-inline:                          org.w3c.css.properties.css3.CssMarginInline
 margin-inline-start:                    org.w3c.css.properties.css3.CssMarginInlineStart
 margin-inline-end:                      org.w3c.css.properties.css3.CssMarginInlineEnd
 

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -49,6 +49,7 @@ margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlo
 margin-inline:                          org.w3c.css.properties.css3.CssMarginInline
 margin-inline-start:                    org.w3c.css.properties.css3.CssMarginInlineStart
 margin-inline-end:                      org.w3c.css.properties.css3.CssMarginInlineEnd
+padding-block:                          org.w3c.css.properties.css3.CssPaddingBlock
 padding-block-start:                    org.w3c.css.properties.css3.CssPaddingBlockStart
 padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBlockEnd
 

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -37,6 +37,7 @@ inline-size:                            org.w3c.css.properties.css3.CssInlineSiz
 max-inline-size:                        org.w3c.css.properties.css3.CssMaxInlineSize
 min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
 inset-block-start:                      org.w3c.css.properties.css3.CssInsetBlockStart
+inset-block-end:                        org.w3c.css.properties.css3.CssInsetBlockEnd
 margin-block:                           org.w3c.css.properties.css3.CssMarginBlock
 margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
 margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlockEnd

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -55,6 +55,7 @@ padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBl
 padding-inline:                         org.w3c.css.properties.css3.CssPaddingInline
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
+border-block-color:                     org.w3c.css.properties.css3.CssBorderBlockColor
 border-block-start-color:               org.w3c.css.properties.css3.CssBorderBlockStartColor
 border-block-end-color:                 org.w3c.css.properties.css3.CssBorderBlockEndColor
 border-block-style:                     org.w3c.css.properties.css3.CssBorderBlockStyle

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -52,6 +52,7 @@ margin-inline-end:                      org.w3c.css.properties.css3.CssMarginInl
 padding-block:                          org.w3c.css.properties.css3.CssPaddingBlock
 padding-block-start:                    org.w3c.css.properties.css3.CssPaddingBlockStart
 padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBlockEnd
+padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -75,6 +75,7 @@ border-inline-width:                    org.w3c.css.properties.css3.CssBorderInl
 border-inline-start-width:              org.w3c.css.properties.css3.CssBorderInlineStartWidth
 border-inline-end-width:                org.w3c.css.properties.css3.CssBorderInlineEndWidth
 border-inline-start:                    org.w3c.css.properties.css3.CssBorderInlineStart
+border-inline-end:                      org.w3c.css.properties.css3.CssBorderInlineEnd
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -55,6 +55,7 @@ padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBl
 padding-inline:                         org.w3c.css.properties.css3.CssPaddingInline
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
+border-block-start-style:               org.w3c.css.properties.css3.CssBorderBlockStartStyle
 border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -40,6 +40,7 @@ inset-block:                            org.w3c.css.properties.css3.CssInsetBloc
 inset-block-start:                      org.w3c.css.properties.css3.CssInsetBlockStart
 inset-block-end:                        org.w3c.css.properties.css3.CssInsetBlockEnd
 inset-inline-start:                     org.w3c.css.properties.css3.CssInsetInlineStart
+inset-inline-end:                       org.w3c.css.properties.css3.CssInsetInlineEnd
 margin-block:                           org.w3c.css.properties.css3.CssMarginBlock
 margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
 margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlockEnd

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -58,6 +58,7 @@ padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingIn
 border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
+border-inline-width:                    org.w3c.css.properties.css3.CssBorderInlineWidth
 border-inline-start-width:              org.w3c.css.properties.css3.CssBorderInlineStartWidth
 border-inline-end-width:                org.w3c.css.properties.css3.CssBorderInlineEndWidth
 

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -61,6 +61,7 @@ border-block-end-style:                 org.w3c.css.properties.css3.CssBorderBlo
 border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
+border-inline-style:                    org.w3c.css.properties.css3.CssBorderInlineStyle
 border-inline-start-style:              org.w3c.css.properties.css3.CssBorderInlineStartStyle
 border-inline-end-style:                org.w3c.css.properties.css3.CssBorderInlineEndStyle
 border-inline-width:                    org.w3c.css.properties.css3.CssBorderInlineWidth

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -39,6 +39,7 @@ min-inline-size:                        org.w3c.css.properties.css3.CssMinInline
 margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
 margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlockEnd
 margin-inline-start:                    org.w3c.css.properties.css3.CssMarginInlineStart
+margin-inline-end:                      org.w3c.css.properties.css3.CssMarginInlineEnd
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -37,6 +37,7 @@ inline-size:                            org.w3c.css.properties.css3.CssInlineSiz
 max-inline-size:                        org.w3c.css.properties.css3.CssMaxInlineSize
 min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
 margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
+margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlockEnd
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -80,6 +80,7 @@ border-inline-end:                      org.w3c.css.properties.css3.CssBorderInl
 border-inline:                          org.w3c.css.properties.css3.CssBorderInline
 border-start-start-radius:              org.w3c.css.properties.css3.CssBorderStartStartRadius
 border-start-end-radius:                org.w3c.css.properties.css3.CssBorderStartEndRadius
+border-end-start-radius:                org.w3c.css.properties.css3.CssBorderEndStartRadius
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -55,6 +55,7 @@ padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBl
 padding-inline:                         org.w3c.css.properties.css3.CssPaddingInline
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
+border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -36,6 +36,7 @@ min-block-size                          org.w3c.css.properties.css3.CssMinBlockS
 inline-size:                            org.w3c.css.properties.css3.CssInlineSize
 max-inline-size:                        org.w3c.css.properties.css3.CssMaxInlineSize
 min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
+inset:                                  org.w3c.css.properties.css3.CssInset
 inset-block:                            org.w3c.css.properties.css3.CssInsetBlock
 inset-block-start:                      org.w3c.css.properties.css3.CssInsetBlockStart
 inset-block-end:                        org.w3c.css.properties.css3.CssInsetBlockEnd

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -66,6 +66,7 @@ border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlo
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
 border-block-start:                     org.w3c.css.properties.css3.CssBorderBlockStart
 border-block-end:                       org.w3c.css.properties.css3.CssBorderBlockEnd
+border-block:                           org.w3c.css.properties.css3.CssBorderBlock
 border-inline-color:                    org.w3c.css.properties.css3.CssBorderInlineColor
 border-inline-start-color:              org.w3c.css.properties.css3.CssBorderInlineStartColor
 border-inline-style:                    org.w3c.css.properties.css3.CssBorderInlineStyle

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -49,6 +49,7 @@ margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlo
 margin-inline:                          org.w3c.css.properties.css3.CssMarginInline
 margin-inline-start:                    org.w3c.css.properties.css3.CssMarginInlineStart
 margin-inline-end:                      org.w3c.css.properties.css3.CssMarginInlineEnd
+padding-block-start:                    org.w3c.css.properties.css3.CssPaddingBlockStart
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -61,6 +61,7 @@ border-block-end-style:                 org.w3c.css.properties.css3.CssBorderBlo
 border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
+border-inline-start-style:              org.w3c.css.properties.css3.CssBorderInlineStartStyle
 border-inline-width:                    org.w3c.css.properties.css3.CssBorderInlineWidth
 border-inline-start-width:              org.w3c.css.properties.css3.CssBorderInlineStartWidth
 border-inline-end-width:                org.w3c.css.properties.css3.CssBorderInlineEndWidth

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -79,6 +79,7 @@ border-inline-start:                    org.w3c.css.properties.css3.CssBorderInl
 border-inline-end:                      org.w3c.css.properties.css3.CssBorderInlineEnd
 border-inline:                          org.w3c.css.properties.css3.CssBorderInline
 border-start-start-radius:              org.w3c.css.properties.css3.CssBorderStartStartRadius
+border-start-end-radius:                org.w3c.css.properties.css3.CssBorderStartEndRadius
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -31,8 +31,10 @@ marker-side:                            org.w3c.css.properties.css3.CssMarkerSid
 
 #logical
 block-size:                             org.w3c.css.properties.css3.CssBlockSize
+max-block-size:                         org.w3c.css.properties.css3.CssMaxBlockSize
 min-block-size                          org.w3c.css.properties.css3.CssMinBlockSize
 inline-size:                            org.w3c.css.properties.css3.CssInlineSize
+max-inline-size:                        org.w3c.css.properties.css3.CssMaxInlineSize
 min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
 
 # counter-styles

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -36,6 +36,7 @@ min-block-size                          org.w3c.css.properties.css3.CssMinBlockS
 inline-size:                            org.w3c.css.properties.css3.CssInlineSize
 max-inline-size:                        org.w3c.css.properties.css3.CssMaxInlineSize
 min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
+margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -29,6 +29,10 @@ color-scheme:                           org.w3c.css.properties.css3.CssColorSche
 counter-set:                            org.w3c.css.properties.css3.CssCounterSet
 marker-side:                            org.w3c.css.properties.css3.CssMarkerSide
 
+#logical
+block-size:                             org.w3c.css.properties.css3.CssBlockSize
+inline-size:                            org.w3c.css.properties.css3.CssInlineSize
+
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols
 @counter-style.fallback                 org.w3c.css.properties.css3.counterstyle.CssFallback

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -36,6 +36,7 @@ min-block-size                          org.w3c.css.properties.css3.CssMinBlockS
 inline-size:                            org.w3c.css.properties.css3.CssInlineSize
 max-inline-size:                        org.w3c.css.properties.css3.CssMaxInlineSize
 min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
+inset-block-start:                      org.w3c.css.properties.css3.CssInsetBlockStart
 margin-block:                           org.w3c.css.properties.css3.CssMarginBlock
 margin-block-start:                     org.w3c.css.properties.css3.CssMarginBlockStart
 margin-block-end:                       org.w3c.css.properties.css3.CssMarginBlockEnd

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -81,6 +81,7 @@ border-inline:                          org.w3c.css.properties.css3.CssBorderInl
 border-start-start-radius:              org.w3c.css.properties.css3.CssBorderStartStartRadius
 border-start-end-radius:                org.w3c.css.properties.css3.CssBorderStartEndRadius
 border-end-start-radius:                org.w3c.css.properties.css3.CssBorderEndStartRadius
+border-end-end-radius:                  org.w3c.css.properties.css3.CssBorderEndEndRadius
 
 # counter-styles
 @counter-style.additive-symbols         org.w3c.css.properties.css3.counterstyle.CssAdditiveSymbols

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -56,6 +56,7 @@ padding-inline:                         org.w3c.css.properties.css3.CssPaddingIn
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
 border-block-start-color:               org.w3c.css.properties.css3.CssBorderBlockStartColor
+border-block-end-color:                 org.w3c.css.properties.css3.CssBorderBlockEndColor
 border-block-style:                     org.w3c.css.properties.css3.CssBorderBlockStyle
 border-block-start-style:               org.w3c.css.properties.css3.CssBorderBlockStartStyle
 border-block-end-style:                 org.w3c.css.properties.css3.CssBorderBlockEndStyle

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -36,6 +36,7 @@ min-block-size                          org.w3c.css.properties.css3.CssMinBlockS
 inline-size:                            org.w3c.css.properties.css3.CssInlineSize
 max-inline-size:                        org.w3c.css.properties.css3.CssMaxInlineSize
 min-inline-size:                        org.w3c.css.properties.css3.CssMinInlineSize
+inset-block:                            org.w3c.css.properties.css3.CssInsetBlock
 inset-block-start:                      org.w3c.css.properties.css3.CssInsetBlockStart
 inset-block-end:                        org.w3c.css.properties.css3.CssInsetBlockEnd
 margin-block:                           org.w3c.css.properties.css3.CssMarginBlock

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -55,6 +55,7 @@ padding-block-end:                      org.w3c.css.properties.css3.CssPaddingBl
 padding-inline:                         org.w3c.css.properties.css3.CssPaddingInline
 padding-inline-start:                   org.w3c.css.properties.css3.CssPaddingInlineStart
 padding-inline-end:                     org.w3c.css.properties.css3.CssPaddingInlineEnd
+border-block-style:                     org.w3c.css.properties.css3.CssBorderBlockStyle
 border-block-start-style:               org.w3c.css.properties.css3.CssBorderBlockStartStyle
 border-block-end-style:                 org.w3c.css.properties.css3.CssBorderBlockEndStyle
 border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -64,6 +64,7 @@ border-block-end-style:                 org.w3c.css.properties.css3.CssBorderBlo
 border-block-width:                     org.w3c.css.properties.css3.CssBorderBlockWidth
 border-block-start-width:               org.w3c.css.properties.css3.CssBorderBlockStartWidth
 border-block-end-width:                 org.w3c.css.properties.css3.CssBorderBlockEndWidth
+border-block-start:                     org.w3c.css.properties.css3.CssBorderBlockStart
 border-inline-color:                    org.w3c.css.properties.css3.CssBorderInlineColor
 border-inline-start-color:              org.w3c.css.properties.css3.CssBorderInlineStartColor
 border-inline-style:                    org.w3c.css.properties.css3.CssBorderInlineStyle

--- a/org/w3c/css/properties/css/CssBlockSize.java
+++ b/org/w3c/css/properties/css/CssBlockSize.java
@@ -1,0 +1,116 @@
+// $Id$
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBlockSize extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBlockSize
+     */
+    public CssBlockSize() {
+    }
+
+    /**
+     * Creates a new CssBlockSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBlockSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBlockSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "block-size";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return value.equals(inherit);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBlockSize != null) {
+            style.addRedefinitionWarning(ac, this);
+        }
+        s.cssBlockSize = this;
+    }
+
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBlockSize &&
+                value.equals(((CssBlockSize) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBlockSize();
+        } else {
+            return ((Css3Style) style).cssBlockSize;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlock.java
+++ b/org/w3c/css/properties/css/CssBorderBlock.java
@@ -1,0 +1,140 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlock extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlock
+     */
+    public CssBorderBlock() {
+    }
+
+    /**
+     * Creates a new CssBorderBlock
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlock(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlock(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderBlock != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderBlockStart != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockStart);
+            } else {
+                if (s.cssBorderBlockStartColor != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderBlockStartColor);
+                }
+                if (s.cssBorderBlockStartStyle != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderBlockStartStyle);
+                }
+                if (s.cssBorderBlockStartWidth != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderBlockStartWidth);
+                }
+            }
+            if (s.cssBorderBlockEnd != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockEnd); 
+            } else {
+                if (s.cssBorderBlockEndColor != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderBlockEndColor);
+                }
+                if (s.cssBorderBlockEndStyle != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderBlockEndStyle);
+                }
+                if (s.cssBorderBlockEndWidth != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderBlockEndWidth);
+                }
+            }
+        }
+        s.cssBorderBlock = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlock &&
+                value.equals(((CssBorderBlock) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlock();
+        } else {
+            return ((Css3Style) style).cssBorderBlock;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockColor.java
+++ b/org/w3c/css/properties/css/CssBorderBlockColor.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockColor extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockColor
+     */
+    public CssBorderBlockColor() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-color";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderBlockColor != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderBlockStartColor != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockStartColor);
+            }
+            if (s.cssBorderBlockEndColor != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockEndColor);
+            }
+        }
+        s.cssBorderBlockColor = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockColor &&
+                value.equals(((CssBorderBlockColor) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockColor();
+        } else {
+            return ((Css3Style) style).cssBorderBlockColor;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockEnd.java
+++ b/org/w3c/css/properties/css/CssBorderBlockEnd.java
@@ -1,0 +1,123 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockEnd extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockEnd
+     */
+    public CssBorderBlockEnd() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-end";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderBlockEnd != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderBlockEndColor != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockEndColor);
+            }
+            if (s.cssBorderBlockEndStyle != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockEndStyle);
+            }
+            if (s.cssBorderBlockEndWidth != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockEndWidth);
+            }
+        }
+        s.cssBorderBlockEnd = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockEnd &&
+                value.equals(((CssBorderBlockEnd) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockEnd();
+        } else {
+            return ((Css3Style) style).cssBorderBlockEnd;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockEndColor.java
+++ b/org/w3c/css/properties/css/CssBorderBlockEndColor.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockEndColor extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockEndColor
+     */
+    public CssBorderBlockEndColor() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockEndColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockEndColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockEndColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-end-color";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderBlockEndColor != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderBlockEndColor = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockEndColor &&
+                value.equals(((CssBorderBlockEndColor) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockEndColor();
+        } else {
+            return ((Css3Style) style).cssBorderBlockEndColor;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockEndStyle.java
+++ b/org/w3c/css/properties/css/CssBorderBlockEndStyle.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockEndStyle extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockEndStyle
+     */
+    public CssBorderBlockEndStyle() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockEndStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockEndStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockEndStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-end-style";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderBlockEndStyle != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderBlockEndStyle = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockEndStyle &&
+                value.equals(((CssBorderBlockEndStyle) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockEndStyle();
+        } else {
+            return ((Css3Style) style).cssBorderBlockEndStyle;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockEndWidth.java
+++ b/org/w3c/css/properties/css/CssBorderBlockEndWidth.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockEndWidth extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockEndWidth
+     */
+    public CssBorderBlockEndWidth() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockEndWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockEndWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockEndWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-end-width";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderBlockEndWidth != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderBlockEndWidth = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockEndWidth &&
+                value.equals(((CssBorderBlockEndWidth) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockEndWidth();
+        } else {
+            return ((Css3Style) style).cssBorderBlockEndWidth;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockStart.java
+++ b/org/w3c/css/properties/css/CssBorderBlockStart.java
@@ -1,0 +1,123 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockStart extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockStart
+     */
+    public CssBorderBlockStart() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-start";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderBlockStart != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderBlockStartColor != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockStartColor);
+            }
+            if (s.cssBorderBlockStartStyle != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockStartStyle);
+            }
+            if (s.cssBorderBlockStartWidth != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockStartWidth);
+            }
+        }
+        s.cssBorderBlockStart = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockStart &&
+                value.equals(((CssBorderBlockStart) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockStart();
+        } else {
+            return ((Css3Style) style).cssBorderBlockStart;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockStartColor.java
+++ b/org/w3c/css/properties/css/CssBorderBlockStartColor.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockStartColor extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockStartColor
+     */
+    public CssBorderBlockStartColor() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockStartColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockStartColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockStartColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-start-color";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderBlockStartColor != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderBlockStartColor = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockStartColor &&
+                value.equals(((CssBorderBlockStartColor) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockStartColor();
+        } else {
+            return ((Css3Style) style).cssBorderBlockStartColor;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockStartStyle.java
+++ b/org/w3c/css/properties/css/CssBorderBlockStartStyle.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockStartStyle extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockStartStyle
+     */
+    public CssBorderBlockStartStyle() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockStartStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockStartStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockStartStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-start-style";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderBlockStartStyle != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderBlockStartStyle = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockStartStyle &&
+                value.equals(((CssBorderBlockStartStyle) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockStartStyle();
+        } else {
+            return ((Css3Style) style).cssBorderBlockStartStyle;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockStartWidth.java
+++ b/org/w3c/css/properties/css/CssBorderBlockStartWidth.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockStartWidth extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockStartWidth
+     */
+    public CssBorderBlockStartWidth() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockStartWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockStartWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockStartWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-start-width";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderBlockStartWidth != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderBlockStartWidth = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockStartWidth &&
+                value.equals(((CssBorderBlockStartWidth) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockStartWidth();
+        } else {
+            return ((Css3Style) style).cssBorderBlockStartWidth;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockStyle.java
+++ b/org/w3c/css/properties/css/CssBorderBlockStyle.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockStyle extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockStyle
+     */
+    public CssBorderBlockStyle() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-style";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderBlockStyle != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderBlockStartStyle != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockStartStyle);
+            }
+            if (s.cssBorderBlockEndStyle != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockEndStyle);
+            }
+        }
+        s.cssBorderBlockStyle = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockStyle &&
+                value.equals(((CssBorderBlockStyle) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockStyle();
+        } else {
+            return ((Css3Style) style).cssBorderBlockStyle;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderBlockWidth.java
+++ b/org/w3c/css/properties/css/CssBorderBlockWidth.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderBlockWidth extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderBlockWidth
+     */
+    public CssBorderBlockWidth() {
+    }
+
+    /**
+     * Creates a new CssBorderBlockWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderBlockWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-block-width";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderBlockWidth != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderBlockStartWidth != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockStartWidth);
+            }
+            if (s.cssBorderBlockEndWidth != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderBlockEndWidth);
+            }
+        }
+        s.cssBorderBlockWidth = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderBlockWidth &&
+                value.equals(((CssBorderBlockWidth) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderBlockWidth();
+        } else {
+            return ((Css3Style) style).cssBorderBlockWidth;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderEndEndRadius.java
+++ b/org/w3c/css/properties/css/CssBorderEndEndRadius.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderEndEndRadius extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderEndEndRadius
+     */
+    public CssBorderEndEndRadius() {
+    }
+
+    /**
+     * Creates a new CssBorderEndEndRadius
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderEndEndRadius(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderEndEndRadius(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-end-end-radius";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderEndEndRadius != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderEndEndRadius = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderEndEndRadius &&
+                value.equals(((CssBorderEndEndRadius) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderEndEndRadius();
+        } else {
+            return ((Css3Style) style).cssBorderEndEndRadius;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderEndStartRadius.java
+++ b/org/w3c/css/properties/css/CssBorderEndStartRadius.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderEndStartRadius extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderEndStartRadius
+     */
+    public CssBorderEndStartRadius() {
+    }
+
+    /**
+     * Creates a new CssBorderEndStartRadius
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderEndStartRadius(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderEndStartRadius(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-end-start-radius";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderEndStartRadius != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderEndStartRadius = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderEndStartRadius &&
+                value.equals(((CssBorderEndStartRadius) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderEndStartRadius();
+        } else {
+            return ((Css3Style) style).cssBorderEndStartRadius;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInline.java
+++ b/org/w3c/css/properties/css/CssBorderInline.java
@@ -1,0 +1,140 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInline extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInline
+     */
+    public CssBorderInline() {
+    }
+
+    /**
+     * Creates a new CssBorderInline
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInline(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInline(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderInline != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderInlineStart != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineStart);
+            } else {
+                if (s.cssBorderInlineStartColor != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderInlineStartColor);
+                }
+                if (s.cssBorderInlineStartStyle != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderInlineStartStyle);
+                }
+                if (s.cssBorderInlineStartWidth != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderInlineStartWidth);
+                }
+            }
+            if (s.cssBorderInlineEnd != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineEnd); 
+            } else {
+                if (s.cssBorderInlineEndColor != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderInlineEndColor);
+                }
+                if (s.cssBorderInlineEndStyle != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderInlineEndStyle);
+                }
+                if (s.cssBorderInlineEndWidth != null) {
+                    style.addRedefinitionWarning(ac, s.cssBorderInlineEndWidth);
+                }
+            }
+        }
+        s.cssBorderInline = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInline &&
+                value.equals(((CssBorderInline) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInline();
+        } else {
+            return ((Css3Style) style).cssBorderInline;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineColor.java
+++ b/org/w3c/css/properties/css/CssBorderInlineColor.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineColor extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineColor
+     */
+    public CssBorderInlineColor() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-color";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderInlineColor != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderInlineStartColor != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineStartColor);
+            }
+            if (s.cssBorderInlineEndColor != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineEndColor);
+            }
+        }
+        s.cssBorderInlineColor = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineColor &&
+                value.equals(((CssBorderInlineColor) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineColor();
+        } else {
+            return ((Css3Style) style).cssBorderInlineColor;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineEnd.java
+++ b/org/w3c/css/properties/css/CssBorderInlineEnd.java
@@ -1,0 +1,123 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineEnd extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineEnd
+     */
+    public CssBorderInlineEnd() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-end";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderInlineEnd != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderInlineEndColor != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineEndColor);
+            }
+            if (s.cssBorderInlineEndStyle != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineEndStyle);
+            }
+            if (s.cssBorderInlineEndWidth != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineEndWidth);
+            }
+        }
+        s.cssBorderInlineEnd = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineEnd &&
+                value.equals(((CssBorderInlineEnd) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineEnd();
+        } else {
+            return ((Css3Style) style).cssBorderInlineEnd;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineEndColor.java
+++ b/org/w3c/css/properties/css/CssBorderInlineEndColor.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineEndColor extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineEndColor
+     */
+    public CssBorderInlineEndColor() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineEndColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineEndColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineEndColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-end-color";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderInlineEndColor != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderInlineEndColor = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineEndColor &&
+                value.equals(((CssBorderInlineEndColor) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineEndColor();
+        } else {
+            return ((Css3Style) style).cssBorderInlineEndColor;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineEndStyle.java
+++ b/org/w3c/css/properties/css/CssBorderInlineEndStyle.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineEndStyle extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineEndStyle
+     */
+    public CssBorderInlineEndStyle() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineEndStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineEndStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineEndStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-end-style";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderInlineEndStyle != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderInlineEndStyle = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineEndStyle &&
+                value.equals(((CssBorderInlineEndStyle) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineEndStyle();
+        } else {
+            return ((Css3Style) style).cssBorderInlineEndStyle;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineEndWidth.java
+++ b/org/w3c/css/properties/css/CssBorderInlineEndWidth.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineEndWidth extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineEndWidth
+     */
+    public CssBorderInlineEndWidth() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineEndWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineEndWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineEndWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-end-width";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderInlineEndWidth != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderInlineEndWidth = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineEndWidth &&
+                value.equals(((CssBorderInlineEndWidth) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineEndWidth();
+        } else {
+            return ((Css3Style) style).cssBorderInlineEndWidth;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineStart.java
+++ b/org/w3c/css/properties/css/CssBorderInlineStart.java
@@ -1,0 +1,123 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineStart extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineStart
+     */
+    public CssBorderInlineStart() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-start";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderInlineStart != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderInlineStartColor != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineStartColor);
+            }
+            if (s.cssBorderInlineStartStyle != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineStartStyle);
+            }
+            if (s.cssBorderInlineStartWidth != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineStartWidth);
+            }
+        }
+        s.cssBorderInlineStart = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineStart &&
+                value.equals(((CssBorderInlineStart) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineStart();
+        } else {
+            return ((Css3Style) style).cssBorderInlineStart;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineStartColor.java
+++ b/org/w3c/css/properties/css/CssBorderInlineStartColor.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineStartColor extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineStartColor
+     */
+    public CssBorderInlineStartColor() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineStartColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineStartColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineStartColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-start-color";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderInlineStartColor != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderInlineStartColor = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineStartColor &&
+                value.equals(((CssBorderInlineStartColor) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineStartColor();
+        } else {
+            return ((Css3Style) style).cssBorderInlineStartColor;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineStartStyle.java
+++ b/org/w3c/css/properties/css/CssBorderInlineStartStyle.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineStartStyle extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineStartStyle
+     */
+    public CssBorderInlineStartStyle() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineStartStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineStartStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineStartStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-start-style";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderInlineStartStyle != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderInlineStartStyle = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineStartStyle &&
+                value.equals(((CssBorderInlineStartStyle) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineStartStyle();
+        } else {
+            return ((Css3Style) style).cssBorderInlineStartStyle;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineStartWidth.java
+++ b/org/w3c/css/properties/css/CssBorderInlineStartWidth.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineStartWidth extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineStartWidth
+     */
+    public CssBorderInlineStartWidth() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineStartWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineStartWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineStartWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-start-width";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderInlineStartWidth != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderInlineStartWidth = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineStartWidth &&
+                value.equals(((CssBorderInlineStartWidth) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineStartWidth();
+        } else {
+            return ((Css3Style) style).cssBorderInlineStartWidth;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineStyle.java
+++ b/org/w3c/css/properties/css/CssBorderInlineStyle.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineStyle extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineStyle
+     */
+    public CssBorderInlineStyle() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-style";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderInlineStyle != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderInlineStartStyle != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineStartStyle);
+            }
+            if (s.cssBorderInlineEndStyle != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineEndStyle);
+            }
+        }
+        s.cssBorderInlineStyle = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineStyle &&
+                value.equals(((CssBorderInlineStyle) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineStyle();
+        } else {
+            return ((Css3Style) style).cssBorderInlineStyle;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderInlineWidth.java
+++ b/org/w3c/css/properties/css/CssBorderInlineWidth.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderInlineWidth extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderInlineWidth
+     */
+    public CssBorderInlineWidth() {
+    }
+
+    /**
+     * Creates a new CssBorderInlineWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderInlineWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-inline-width";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssBorderInlineWidth != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssBorderInlineStartWidth != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineStartWidth);
+            }
+            if (s.cssBorderInlineEndWidth != null) {
+                style.addRedefinitionWarning(ac, s.cssBorderInlineEndWidth);
+            }
+        }
+        s.cssBorderInlineWidth = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderInlineWidth &&
+                value.equals(((CssBorderInlineWidth) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderInlineWidth();
+        } else {
+            return ((Css3Style) style).cssBorderInlineWidth;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderStartEndRadius.java
+++ b/org/w3c/css/properties/css/CssBorderStartEndRadius.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderStartEndRadius extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderStartEndRadius
+     */
+    public CssBorderStartEndRadius() {
+    }
+
+    /**
+     * Creates a new CssBorderStartEndRadius
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderStartEndRadius(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderStartEndRadius(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-start-end-radius";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderStartEndRadius != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderStartEndRadius = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderStartEndRadius &&
+                value.equals(((CssBorderStartEndRadius) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderStartEndRadius();
+        } else {
+            return ((Css3Style) style).cssBorderStartEndRadius;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssBorderStartStartRadius.java
+++ b/org/w3c/css/properties/css/CssBorderStartStartRadius.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssBorderStartStartRadius extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssBorderStartStartRadius
+     */
+    public CssBorderStartStartRadius() {
+    }
+
+    /**
+     * Creates a new CssBorderStartStartRadius
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderStartStartRadius(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssBorderStartStartRadius(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "border-start-start-radius";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssBorderStartStartRadius != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssBorderStartStartRadius = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssBorderStartStartRadius &&
+                value.equals(((CssBorderStartStartRadius) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getBorderStartStartRadius();
+        } else {
+            return ((Css3Style) style).cssBorderStartStartRadius;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssInlineSize.java
+++ b/org/w3c/css/properties/css/CssInlineSize.java
@@ -1,0 +1,116 @@
+// $Id$
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssInlineSize extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssInlineSize
+     */
+    public CssInlineSize() {
+    }
+
+    /**
+     * Creates a new CssInlineSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssInlineSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssInlineSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "inline-size";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return value.equals(inherit);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssInlineSize != null) {
+            style.addRedefinitionWarning(ac, this);
+        }
+        s.cssInlineSize = this;
+    }
+
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssInlineSize &&
+                value.equals(((CssInlineSize) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getInlineSize();
+        } else {
+            return ((Css3Style) style).cssInlineSize;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssInset.java
+++ b/org/w3c/css/properties/css/CssInset.java
@@ -1,0 +1,134 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssInset extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssInset
+     */
+    public CssInset() {
+    }
+
+    /**
+     * Creates a new CssInset
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInset(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssInset(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "inset";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssInset != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssInsetBlock != null) {
+                style.addRedefinitionWarning(ac, s.cssInsetBlock);
+            } else {
+                if (s.cssInsetBlockStart != null) {
+                    style.addRedefinitionWarning(ac, s.cssInsetBlockStart); 
+                }
+                if (s.cssInsetBlockEnd != null) {
+                    style.addRedefinitionWarning(ac, s.cssInsetBlockEnd);
+                }
+            }
+            if (s.cssInsetInline != null) {
+                style.addRedefinitionWarning(ac, s.cssInsetInline);
+            } else {
+                if (s.cssInsetInlineStart != null) {
+                    style.addRedefinitionWarning(ac, s.cssInsetInlineStart);
+                }
+                if (s.cssInsetInlineEnd != null) {
+                    style.addRedefinitionWarning(ac, s.cssInsetInlineEnd);
+                }
+            }
+        }
+        s.cssInset = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssInset &&
+                value.equals(((CssInset) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getInset();
+        } else {
+            return ((Css3Style) style).cssInset;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssInsetBlock.java
+++ b/org/w3c/css/properties/css/CssInsetBlock.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssInsetBlock extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssInsetBlock
+     */
+    public CssInsetBlock() {
+    }
+
+    /**
+     * Creates a new CssInsetBlock
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInsetBlock(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssInsetBlock(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "inset-block";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssInsetBlock != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssInsetBlockStart != null) {
+                style.addRedefinitionWarning(ac, s.cssInsetBlockStart);
+            }
+            if (s.cssInsetBlockEnd != null) {
+                style.addRedefinitionWarning(ac, s.cssInsetBlockEnd);
+            }
+        }
+        s.cssInsetBlock = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssInsetBlock &&
+                value.equals(((CssInsetBlock) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getInsetBlock();
+        } else {
+            return ((Css3Style) style).cssInsetBlock;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssInsetBlockEnd.java
+++ b/org/w3c/css/properties/css/CssInsetBlockEnd.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssInsetBlockEnd extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssInsetBlockEnd
+     */
+    public CssInsetBlockEnd() {
+    }
+
+    /**
+     * Creates a new CssInsetBlockEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInsetBlockEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssInsetBlockEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "inset-block-end";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssInsetBlockEnd != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssInsetBlockEnd = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssInsetBlockEnd &&
+                value.equals(((CssInsetBlockEnd) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getInsetBlockEnd();
+        } else {
+            return ((Css3Style) style).cssInsetBlockEnd;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssInsetBlockStart.java
+++ b/org/w3c/css/properties/css/CssInsetBlockStart.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssInsetBlockStart extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssInsetBlockStart
+     */
+    public CssInsetBlockStart() {
+    }
+
+    /**
+     * Creates a new CssInsetBlockStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInsetBlockStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssInsetBlockStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "inset-block-start";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssInsetBlockStart != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssInsetBlockStart = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssInsetBlockStart &&
+                value.equals(((CssInsetBlockStart) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getInsetBlockStart();
+        } else {
+            return ((Css3Style) style).cssInsetBlockStart;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssInsetInline.java
+++ b/org/w3c/css/properties/css/CssInsetInline.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssInsetInline extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssInsetInline
+     */
+    public CssInsetInline() {
+    }
+
+    /**
+     * Creates a new CssInsetInline
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInsetInline(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssInsetInline(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "inset-inline";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssInsetInline != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssInsetInlineStart != null) {
+                style.addRedefinitionWarning(ac, s.cssInsetInlineStart);
+            }
+            if (s.cssInsetInlineEnd != null) {
+                style.addRedefinitionWarning(ac, s.cssInsetInlineEnd);
+            }
+        }
+        s.cssInsetInline = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssInsetInline &&
+                value.equals(((CssInsetInline) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getInsetInline();
+        } else {
+            return ((Css3Style) style).cssInsetInline;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssInsetInlineEnd.java
+++ b/org/w3c/css/properties/css/CssInsetInlineEnd.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssInsetInlineEnd extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssInsetInlineEnd
+     */
+    public CssInsetInlineEnd() {
+    }
+
+    /**
+     * Creates a new CssInsetInlineEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInsetInlineEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssInsetInlineEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "inset-inline-end";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssInsetInlineEnd != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssInsetInlineEnd = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssInsetInlineEnd &&
+                value.equals(((CssInsetInlineEnd) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getInsetInlineEnd();
+        } else {
+            return ((Css3Style) style).cssInsetInlineEnd;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssInsetInlineStart.java
+++ b/org/w3c/css/properties/css/CssInsetInlineStart.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssInsetInlineStart extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssInsetInlineStart
+     */
+    public CssInsetInlineStart() {
+    }
+
+    /**
+     * Creates a new CssInsetInlineStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInsetInlineStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssInsetInlineStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "inset-inline-start";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssInsetInlineStart != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssInsetInlineStart = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssInsetInlineStart &&
+                value.equals(((CssInsetInlineStart) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getInsetInlineStart();
+        } else {
+            return ((Css3Style) style).cssInsetInlineStart;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMarginBlock.java
+++ b/org/w3c/css/properties/css/CssMarginBlock.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMarginBlock extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssMarginBlock
+     */
+    public CssMarginBlock() {
+    }
+
+    /**
+     * Creates a new CssMarginBlock
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMarginBlock(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMarginBlock(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "margin-block";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssMarginBlock != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssMarginBlockStart != null) {
+                style.addRedefinitionWarning(ac, s.cssMarginBlockStart);
+            }
+            if (s.cssMarginBlockEnd != null) {
+                style.addRedefinitionWarning(ac, s.cssMarginBlockEnd);
+            }
+        }
+        s.cssMarginBlock = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMarginBlock &&
+                value.equals(((CssMarginBlock) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMarginBlock();
+        } else {
+            return ((Css3Style) style).cssMarginBlock;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMarginBlockEnd.java
+++ b/org/w3c/css/properties/css/CssMarginBlockEnd.java
@@ -55,7 +55,7 @@ public class CssMarginBlockEnd extends CssProperty {
      * Returns the name of this property
      */
     public final String getPropertyName() {
-        return "max-width";
+        return "margin-block-end";
     }
 
     /**

--- a/org/w3c/css/properties/css/CssMarginBlockEnd.java
+++ b/org/w3c/css/properties/css/CssMarginBlockEnd.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMarginBlockEnd extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssMarginBlockEnd
+     */
+    public CssMarginBlockEnd() {
+    }
+
+    /**
+     * Creates a new CssMarginBlockEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMarginBlockEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMarginBlockEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "max-width";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssMarginBlockEnd != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssMarginBlockEnd = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMarginBlockEnd &&
+                value.equals(((CssMarginBlockEnd) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMarginBlockEnd();
+        } else {
+            return ((Css3Style) style).cssMarginBlockEnd;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMarginBlockStart.java
+++ b/org/w3c/css/properties/css/CssMarginBlockStart.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMarginBlockStart extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssMarginBlockStart
+     */
+    public CssMarginBlockStart() {
+    }
+
+    /**
+     * Creates a new CssMarginBlockStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMarginBlockStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMarginBlockStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "max-width";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssMarginBlockStart != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssMarginBlockStart = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMarginBlockStart &&
+                value.equals(((CssMarginBlockStart) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMarginBlockStart();
+        } else {
+            return ((Css3Style) style).cssMarginBlockStart;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMarginBlockStart.java
+++ b/org/w3c/css/properties/css/CssMarginBlockStart.java
@@ -55,7 +55,7 @@ public class CssMarginBlockStart extends CssProperty {
      * Returns the name of this property
      */
     public final String getPropertyName() {
-        return "max-width";
+        return "margin-block-start";
     }
 
     /**

--- a/org/w3c/css/properties/css/CssMarginInline.java
+++ b/org/w3c/css/properties/css/CssMarginInline.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMarginInline extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssMarginInline
+     */
+    public CssMarginInline() {
+    }
+
+    /**
+     * Creates a new CssMarginInline
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMarginInline(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMarginInline(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "margin-inline";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssMarginInline != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssMarginInlineStart != null) {
+                style.addRedefinitionWarning(ac, s.cssMarginInlineStart);
+            }
+            if (s.cssMarginInlineEnd != null) {
+                style.addRedefinitionWarning(ac, s.cssMarginInlineEnd);
+            }
+        }
+        s.cssMarginInline = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMarginInline &&
+                value.equals(((CssMarginInline) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMarginInline();
+        } else {
+            return ((Css3Style) style).cssMarginInline;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMarginInlineEnd.java
+++ b/org/w3c/css/properties/css/CssMarginInlineEnd.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMarginInlineEnd extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssMarginInlineEnd
+     */
+    public CssMarginInlineEnd() {
+    }
+
+    /**
+     * Creates a new CssMarginInlineEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMarginInlineEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMarginInlineEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "margin-inline-end";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssMarginInlineEnd != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssMarginInlineEnd = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMarginInlineEnd &&
+                value.equals(((CssMarginInlineEnd) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMarginInlineEnd();
+        } else {
+            return ((Css3Style) style).cssMarginInlineEnd;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMarginInlineStart.java
+++ b/org/w3c/css/properties/css/CssMarginInlineStart.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMarginInlineStart extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssMarginInlineStart
+     */
+    public CssMarginInlineStart() {
+    }
+
+    /**
+     * Creates a new CssMarginInlineStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMarginInlineStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMarginInlineStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "margin-inline-start";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssMarginInlineStart != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssMarginInlineStart = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMarginInlineStart &&
+                value.equals(((CssMarginInlineStart) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMarginInlineStart();
+        } else {
+            return ((Css3Style) style).cssMarginInlineStart;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMaxBlockSize.java
+++ b/org/w3c/css/properties/css/CssMaxBlockSize.java
@@ -1,0 +1,116 @@
+// $Id$
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMaxBlockSize extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssMaxBlockSize
+     */
+    public CssMaxBlockSize() {
+    }
+
+    /**
+     * Creates a new CssMaxBlockSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssMaxBlockSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMaxBlockSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "max-block-size";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return value.equals(inherit);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssMaxBlockSize != null) {
+            style.addRedefinitionWarning(ac, this);
+        }
+        s.cssMaxBlockSize = this;
+    }
+
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMaxBlockSize &&
+                value.equals(((CssMaxBlockSize) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMaxBlockSize();
+        } else {
+            return ((Css3Style) style).cssMaxBlockSize;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMaxInlineSize.java
+++ b/org/w3c/css/properties/css/CssMaxInlineSize.java
@@ -1,0 +1,116 @@
+// $Id$
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMaxInlineSize extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssMaxInlineSize
+     */
+    public CssMaxInlineSize() {
+    }
+
+    /**
+     * Creates a new CssMaxInlineSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssMaxInlineSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMaxInlineSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "max-inline-size";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return value.equals(inherit);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssMaxInlineSize != null) {
+            style.addRedefinitionWarning(ac, this);
+        }
+        s.cssMaxInlineSize = this;
+    }
+
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMaxInlineSize &&
+                value.equals(((CssMaxInlineSize) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMaxInlineSize();
+        } else {
+            return ((Css3Style) style).cssMaxInlineSize;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMinBlockSize.java
+++ b/org/w3c/css/properties/css/CssMinBlockSize.java
@@ -1,0 +1,116 @@
+// $Id$
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMinBlockSize extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssMinBlockSize
+     */
+    public CssMinBlockSize() {
+    }
+
+    /**
+     * Creates a new CssMinBlockSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssMinBlockSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMinBlockSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "min-block-size";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return value.equals(inherit);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssMinBlockSize != null) {
+            style.addRedefinitionWarning(ac, this);
+        }
+        s.cssMinBlockSize = this;
+    }
+
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMinBlockSize &&
+                value.equals(((CssMinBlockSize) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMinBlockSize();
+        } else {
+            return ((Css3Style) style).cssMinBlockSize;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssMinInlineSize.java
+++ b/org/w3c/css/properties/css/CssMinInlineSize.java
@@ -1,0 +1,116 @@
+// $Id$
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssMinInlineSize extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssInlineSize
+     */
+    public CssMinInlineSize() {
+    }
+
+    /**
+     * Creates a new CssInlineSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssMinInlineSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssMinInlineSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "min-inline-size";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return value.equals(inherit);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssMinInlineSize != null) {
+            style.addRedefinitionWarning(ac, this);
+        }
+        s.cssMinInlineSize = this;
+    }
+
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssMinInlineSize &&
+                value.equals(((CssMinInlineSize) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getMinInlineSize();
+        } else {
+            return ((Css3Style) style).cssMinInlineSize;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssPaddingBlock.java
+++ b/org/w3c/css/properties/css/CssPaddingBlock.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssPaddingBlock extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssPaddingBlock
+     */
+    public CssPaddingBlock() {
+    }
+
+    /**
+     * Creates a new CssPaddingBlock
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssPaddingBlock(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssPaddingBlock(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "padding-block";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssPaddingBlock != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssPaddingBlockStart != null) {
+                style.addRedefinitionWarning(ac, s.cssPaddingBlockStart);
+            }
+            if (s.cssPaddingBlockEnd != null) {
+                style.addRedefinitionWarning(ac, s.cssPaddingBlockEnd);
+            }
+        }
+        s.cssPaddingBlock = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssPaddingBlock &&
+                value.equals(((CssPaddingBlock) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getPaddingBlock();
+        } else {
+            return ((Css3Style) style).cssPaddingBlock;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssPaddingBlockEnd.java
+++ b/org/w3c/css/properties/css/CssPaddingBlockEnd.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssPaddingBlockEnd extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssPaddingBlockEnd
+     */
+    public CssPaddingBlockEnd() {
+    }
+
+    /**
+     * Creates a new CssPaddingBlockEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssPaddingBlockEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssPaddingBlockEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "padding-block-end";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssPaddingBlockEnd != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssPaddingBlockEnd = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssPaddingBlockEnd &&
+                value.equals(((CssPaddingBlockEnd) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getPaddingBlockEnd();
+        } else {
+            return ((Css3Style) style).cssPaddingBlockEnd;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssPaddingBlockStart.java
+++ b/org/w3c/css/properties/css/CssPaddingBlockStart.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssPaddingBlockStart extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssPaddingBlockStart
+     */
+    public CssPaddingBlockStart() {
+    }
+
+    /**
+     * Creates a new CssPaddingBlockStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssPaddingBlockStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssPaddingBlockStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "padding-block-start";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssPaddingBlockStart != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssPaddingBlockStart = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssPaddingBlockStart &&
+                value.equals(((CssPaddingBlockStart) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getPaddingBlockStart();
+        } else {
+            return ((Css3Style) style).cssPaddingBlockStart;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssPaddingInline.java
+++ b/org/w3c/css/properties/css/CssPaddingInline.java
@@ -1,0 +1,120 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssPaddingInline extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssPaddingInline
+     */
+    public CssPaddingInline() {
+    }
+
+    /**
+     * Creates a new CssPaddingInline
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssPaddingInline(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssPaddingInline(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "padding-inline";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        Css3Style s = (Css3Style) style;
+        if (s.cssPaddingInline != null) {
+            style.addRedefinitionWarning(ac, this);
+        } else {
+            if (s.cssPaddingInlineStart != null) {
+                style.addRedefinitionWarning(ac, s.cssPaddingInlineStart);
+            }
+            if (s.cssPaddingInlineEnd != null) {
+                style.addRedefinitionWarning(ac, s.cssPaddingInlineEnd);
+            }
+        }
+        s.cssPaddingInline = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssPaddingInline &&
+                value.equals(((CssPaddingInline) property).value));
+    }
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getPaddingInline();
+        } else {
+            return ((Css3Style) style).cssPaddingInline;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssPaddingInlineEnd.java
+++ b/org/w3c/css/properties/css/CssPaddingInlineEnd.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssPaddingInlineEnd extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssPaddingInlineEnd
+     */
+    public CssPaddingInlineEnd() {
+    }
+
+    /**
+     * Creates a new CssPaddingInlineEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssPaddingInlineEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssPaddingInlineEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "padding-inline-end";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssPaddingInlineEnd != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssPaddingInlineEnd = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssPaddingInlineEnd &&
+                value.equals(((CssPaddingInlineEnd) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getPaddingInlineEnd();
+        } else {
+            return ((Css3Style) style).cssPaddingInlineEnd;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css/CssPaddingInlineStart.java
+++ b/org/w3c/css/properties/css/CssPaddingInlineStart.java
@@ -1,0 +1,112 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @since CSS3
+ */
+public class CssPaddingInlineStart extends CssProperty {
+
+    public CssValue value;
+
+    /**
+     * Create a new CssPaddingInlineStart
+     */
+    public CssPaddingInlineStart() {
+    }
+
+    /**
+     * Creates a new CssPaddingInlineStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssPaddingInlineStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssPaddingInlineStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "padding-inline-start";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssPaddingInlineStart != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssPaddingInlineStart = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssPaddingInlineStart &&
+                value.equals(((CssPaddingInlineStart) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getPaddingInlineStart();
+        } else {
+            return ((Css3Style) style).cssPaddingInlineStart;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -117,6 +117,7 @@ import org.w3c.css.properties.css.CssInlineSize;
 import org.w3c.css.properties.css.CssInsetBlock;
 import org.w3c.css.properties.css.CssInsetBlockEnd;
 import org.w3c.css.properties.css.CssInsetBlockStart;
+import org.w3c.css.properties.css.CssInsetInline;
 import org.w3c.css.properties.css.CssInsetInlineEnd;
 import org.w3c.css.properties.css.CssInsetInlineStart;
 import org.w3c.css.properties.css.CssIsolation;
@@ -531,7 +532,17 @@ public class Css3Style extends ATSCStyle {
     public CssInsetBlock cssInsetBlock;
     public CssInsetInlineStart cssInsetInlineStart;
     public CssInsetInlineEnd cssInsetInlineEnd;
-
+    public CssInsetInline   cssInsetInline;
+    
+    public CssInsetInline getInsetInline() {
+        if (cssInsetInline == null) {
+            cssInsetInline =
+                    (CssInsetInline) style.CascadingOrder(new CssInsetInline(),
+                            style, selector);
+        }
+        return cssInsetInline;
+    }
+    
     public CssInsetInlineEnd getInsetInlineEnd() {
         if (cssInsetInlineEnd == null) {
             cssInsetInlineEnd =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -123,6 +123,7 @@ import org.w3c.css.properties.css.CssLineBreak;
 import org.w3c.css.properties.css.CssMarginBlock;
 import org.w3c.css.properties.css.CssMarginBlockEnd;
 import org.w3c.css.properties.css.CssMarginBlockStart;
+import org.w3c.css.properties.css.CssMarginInline;
 import org.w3c.css.properties.css.CssMarginInlineEnd;
 import org.w3c.css.properties.css.CssMarginInlineStart;
 import org.w3c.css.properties.css.CssMarkerSide;
@@ -519,8 +520,17 @@ public class Css3Style extends ATSCStyle {
     public CssMarginBlock cssMarginBlock;
     public CssMarginInlineStart cssMarginInlineStart;
     public CssMarginInlineEnd cssMarginInlineEnd;
+    public CssMarginInline cssMarginInline;
 
-
+    public CssMarginInline getMarginInline() {
+        if (cssMarginInline == null) {
+            cssMarginInline =
+                    (CssMarginInline) style.CascadingOrder(new CssMarginInline(),
+                            style, selector);
+        }
+        return cssMarginInline;
+    }
+    
     public CssMarginInlineEnd getMarginInlineEnd() {
         if (cssMarginInlineEnd == null) {
             cssMarginInlineEnd =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -125,6 +125,8 @@ import org.w3c.css.properties.css.CssMarqueeDirection;
 import org.w3c.css.properties.css.CssMarqueePlayCount;
 import org.w3c.css.properties.css.CssMarqueeSpeed;
 import org.w3c.css.properties.css.CssMarqueeStyle;
+import org.w3c.css.properties.css.CssMinBlockSize;
+import org.w3c.css.properties.css.CssMinInlineSize;
 import org.w3c.css.properties.css.CssMixBlendMode;
 import org.w3c.css.properties.css.CssNavDown;
 import org.w3c.css.properties.css.CssNavLeft;
@@ -501,7 +503,27 @@ public class Css3Style extends ATSCStyle {
 
     public CssBlockSize cssBlockSize;
     public CssInlineSize cssInlineSize;
+    public CssMinBlockSize cssMinBlockSize;
+    public CssMinInlineSize cssMinInlineSize;
 
+    public CssMinInlineSize getMinInlineSize() {
+        if (cssMinInlineSize == null) {
+            cssMinInlineSize =
+                    (CssMinInlineSize) style.CascadingOrder(new CssMinInlineSize(),
+                            style, selector);
+        }
+        return cssMinInlineSize;
+    }
+    
+    public CssMinBlockSize getMinBlockSize() {
+        if (cssMinBlockSize == null) {
+            cssMinBlockSize =
+                    (CssMinBlockSize) style.CascadingOrder(new CssMinBlockSize(),
+                            style, selector);
+        }
+        return cssMinBlockSize;
+    }
+    
     public CssInlineSize getInlineSize() {
         if (cssInlineSize == null) {
             cssInlineSize =
@@ -510,6 +532,7 @@ public class Css3Style extends ATSCStyle {
         }
         return cssInlineSize;
     }
+    
     public CssBlockSize getBlockSize() {
         if (cssBlockSize == null) {
             cssBlockSize =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -59,6 +59,7 @@ import org.w3c.css.properties.css.CssBorderInlineStartStyle;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
 import org.w3c.css.properties.css.CssBorderInlineStyle;
 import org.w3c.css.properties.css.CssBorderInlineWidth;
+import org.w3c.css.properties.css.CssBorderStartStartRadius;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
 import org.w3c.css.properties.css.CssBoxShadow;
 import org.w3c.css.properties.css.CssBoxSizing;
@@ -595,7 +596,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineEnd   cssBorderInlineEnd;
     public CssBorderBlock   cssBorderBlock;
     public CssBorderInline  cssBorderInline;
+    public CssBorderStartStartRadius cssBorderStartStartRadius;
 
+    public CssBorderStartStartRadius getBorderStartStartRadius() {
+        if (cssBorderStartStartRadius == null) {
+            cssBorderStartStartRadius =
+                    (CssBorderStartStartRadius) style.CascadingOrder(new CssBorderStartStartRadius(),
+                            style, selector);
+        }
+        return cssBorderStartStartRadius;
+    }
+    
     public CssBorderInline getBorderInline() {
         if (cssBorderInline == null) {
             cssBorderInline =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -46,6 +46,7 @@ import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBorderInlineEndStyle;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
+import org.w3c.css.properties.css.CssBorderInlineStartColor;
 import org.w3c.css.properties.css.CssBorderInlineStartStyle;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
 import org.w3c.css.properties.css.CssBorderInlineStyle;
@@ -577,7 +578,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockStartColor cssBorderBlockStartColor;
     public CssBorderBlockEndColor cssBorderBlockEndColor;
     public CssBorderBlockColor cssBorderBlockColor;
+    public CssBorderInlineStartColor cssBorderInlineStartColor;
 
+    public CssBorderInlineStartColor getBorderInlineStartColor() {
+        if (cssBorderInlineStartColor == null) {
+            cssBorderInlineStartColor =
+                    (CssBorderInlineStartColor) style.CascadingOrder(new CssBorderInlineStartColor(),
+                            style, selector);
+        }
+        return cssBorderInlineStartColor;
+    }
+    
     public CssBorderBlockColor getBorderBlockColor() {
         if (cssBorderBlockColor == null) {
             cssBorderBlockColor =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -44,6 +44,7 @@ import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderBlockStyle;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
+import org.w3c.css.properties.css.CssBorderInlineEndColor;
 import org.w3c.css.properties.css.CssBorderInlineEndStyle;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
 import org.w3c.css.properties.css.CssBorderInlineStartColor;
@@ -579,7 +580,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockEndColor cssBorderBlockEndColor;
     public CssBorderBlockColor cssBorderBlockColor;
     public CssBorderInlineStartColor cssBorderInlineStartColor;
+    public CssBorderInlineEndColor cssBorderInlineEndColor;
 
+    public CssBorderInlineEndColor getBorderInlineEndColor() {
+        if (cssBorderInlineEndColor == null) {
+            cssBorderInlineEndColor =
+                    (CssBorderInlineEndColor) style.CascadingOrder(new CssBorderInlineEndColor(),
+                            style, selector);
+        }
+        return cssBorderInlineEndColor;
+    }
+    
     public CssBorderInlineStartColor getBorderInlineStartColor() {
         if (cssBorderInlineStartColor == null) {
             cssBorderInlineStartColor =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -120,6 +120,7 @@ import org.w3c.css.properties.css.CssJustifyItems;
 import org.w3c.css.properties.css.CssJustifySelf;
 import org.w3c.css.properties.css.CssLightingColor;
 import org.w3c.css.properties.css.CssLineBreak;
+import org.w3c.css.properties.css.CssMarginBlockStart;
 import org.w3c.css.properties.css.CssMarkerSide;
 import org.w3c.css.properties.css.CssMarqueeDirection;
 import org.w3c.css.properties.css.CssMarqueePlayCount;
@@ -509,6 +510,16 @@ public class Css3Style extends ATSCStyle {
     public CssMinInlineSize cssMinInlineSize;
     public CssMaxBlockSize cssMaxBlockSize;
     public CssMaxInlineSize cssMaxInlineSize;
+    public CssMarginBlockStart cssMarginBlockStart;
+
+    public CssMarginBlockStart getMarginBlockStart() {
+        if (cssMarginBlockStart == null) {
+            cssMarginBlockStart =
+                    (CssMarginBlockStart) style.CascadingOrder(new CssMarginBlockStart(),
+                            style, selector);
+        }
+        return cssMarginBlockStart;
+    }
     
     public CssMaxInlineSize getMaxInlineSize() {
         if (cssMaxInlineSize == null) {
@@ -518,6 +529,7 @@ public class Css3Style extends ATSCStyle {
         }
         return cssMaxInlineSize;
     }
+    
     public CssMaxBlockSize getMaxBlockSize() {
         if (cssMaxBlockSize == null) {
             cssMaxBlockSize =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -156,6 +156,7 @@ import org.w3c.css.properties.css.CssOverflowStyle;
 import org.w3c.css.properties.css.CssOverflowWrap;
 import org.w3c.css.properties.css.CssOverflowX;
 import org.w3c.css.properties.css.CssOverflowY;
+import org.w3c.css.properties.css.CssPaddingBlockStart;
 import org.w3c.css.properties.css.CssPerspective;
 import org.w3c.css.properties.css.CssPerspectiveOrigin;
 import org.w3c.css.properties.css.CssPlaceContent;
@@ -535,7 +536,18 @@ public class Css3Style extends ATSCStyle {
     public CssInsetInlineEnd cssInsetInlineEnd;
     public CssInsetInline   cssInsetInline;
     public CssInset cssInset;
+    public CssPaddingBlockStart cssPaddingBlockStart;
 
+
+    public CssPaddingBlockStart getPaddingBlockStart() {
+        if (cssPaddingBlockStart == null) {
+            cssPaddingBlockStart =
+                    (CssPaddingBlockStart) style.CascadingOrder(new CssPaddingBlockStart(),
+                            style, selector);
+        }
+        return cssPaddingBlockStart;
+    }
+    
     public CssInset getInset() {
         if (cssInset == null) {
             cssInset =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -44,6 +44,7 @@ import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderBlockStyle;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
+import org.w3c.css.properties.css.CssBorderInlineColor;
 import org.w3c.css.properties.css.CssBorderInlineEndColor;
 import org.w3c.css.properties.css.CssBorderInlineEndStyle;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
@@ -581,7 +582,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockColor cssBorderBlockColor;
     public CssBorderInlineStartColor cssBorderInlineStartColor;
     public CssBorderInlineEndColor cssBorderInlineEndColor;
+    public CssBorderInlineColor cssBorderInlineColor;
 
+    public CssBorderInlineColor getBorderInlineColor() {
+        if (cssBorderInlineColor == null) {
+            cssBorderInlineColor =
+                    (CssBorderInlineColor) style.CascadingOrder(new CssBorderInlineColor(),
+                            style, selector);
+        }
+        return cssBorderInlineColor;
+    }
+    
     public CssBorderInlineEndColor getBorderInlineEndColor() {
         if (cssBorderInlineEndColor == null) {
             cssBorderInlineEndColor =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -114,6 +114,7 @@ import org.w3c.css.properties.css.CssInitialLetter;
 import org.w3c.css.properties.css.CssInitialLetterAlign;
 import org.w3c.css.properties.css.CssInitialLetterWrap;
 import org.w3c.css.properties.css.CssInlineSize;
+import org.w3c.css.properties.css.CssInset;
 import org.w3c.css.properties.css.CssInsetBlock;
 import org.w3c.css.properties.css.CssInsetBlockEnd;
 import org.w3c.css.properties.css.CssInsetBlockStart;
@@ -533,6 +534,16 @@ public class Css3Style extends ATSCStyle {
     public CssInsetInlineStart cssInsetInlineStart;
     public CssInsetInlineEnd cssInsetInlineEnd;
     public CssInsetInline   cssInsetInline;
+    public CssInset cssInset;
+
+    public CssInset getInset() {
+        if (cssInset == null) {
+            cssInset =
+                    (CssInset) style.CascadingOrder(new CssInset(),
+                            style, selector);
+        }
+        return cssInset;
+    }
     
     public CssInsetInline getInsetInline() {
         if (cssInsetInline == null) {

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -42,6 +42,7 @@ import org.w3c.css.properties.css.CssBorderBlockStyle;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
+import org.w3c.css.properties.css.CssBorderInlineStartStyle;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
 import org.w3c.css.properties.css.CssBorderInlineWidth;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
@@ -565,7 +566,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockStartStyle cssBorderBlockStartStyle;
     public CssBorderBlockEndStyle cssBorderBlockEndStyle;
     public CssBorderBlockStyle  cssBorderBlockStyle;
+    public CssBorderInlineStartStyle cssBorderInlineStartStyle;
 
+    public CssBorderInlineStartStyle getBorderInlineStartStyle() {
+        if (cssBorderInlineStartStyle == null) {
+            cssBorderInlineStartStyle =
+                    (CssBorderInlineStartStyle) style.CascadingOrder(new CssBorderInlineStartStyle(),
+                            style, selector);
+        }
+        return cssBorderInlineStartStyle;
+    }
+    
     public CssBorderBlockStyle getBorderBlockStyle() {
         if (cssBorderBlockStyle == null) {
             cssBorderBlockStyle =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -35,6 +35,7 @@ import org.w3c.css.properties.css.CssBackgroundSize;
 import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
 import org.w3c.css.properties.css.CssBorderBlockColor;
+import org.w3c.css.properties.css.CssBorderBlockEnd;
 import org.w3c.css.properties.css.CssBorderBlockEndColor;
 import org.w3c.css.properties.css.CssBorderBlockEndStyle;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
@@ -585,7 +586,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineEndColor cssBorderInlineEndColor;
     public CssBorderInlineColor cssBorderInlineColor;
     public CssBorderBlockStart  cssBorderBlockStart;
+    public CssBorderBlockEnd  cssBorderBlockEnd;
 
+    public CssBorderBlockEnd getBorderBlockEnd() {
+        if (cssBorderBlockEnd == null) {
+            cssBorderBlockEnd =
+                    (CssBorderBlockEnd) style.CascadingOrder(new CssBorderBlockEnd(),
+                            style, selector);
+        }
+        return cssBorderBlockEnd;
+    }
+    
     public CssBorderBlockStart getBorderBlockStart() {
         if (cssBorderBlockStart == null) {
             cssBorderBlockStart =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -34,6 +34,7 @@ import org.w3c.css.properties.css.CssBackgroundPositionY;
 import org.w3c.css.properties.css.CssBackgroundSize;
 import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
+import org.w3c.css.properties.css.CssBorderBlockColor;
 import org.w3c.css.properties.css.CssBorderBlockEndColor;
 import org.w3c.css.properties.css.CssBorderBlockEndStyle;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
@@ -575,7 +576,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineStyle cssBorderInlineStyle;
     public CssBorderBlockStartColor cssBorderBlockStartColor;
     public CssBorderBlockEndColor cssBorderBlockEndColor;
+    public CssBorderBlockColor cssBorderBlockColor;
 
+    public CssBorderBlockColor getBorderBlockColor() {
+        if (cssBorderBlockColor == null) {
+            cssBorderBlockColor =
+                    (CssBorderBlockColor) style.CascadingOrder(new CssBorderBlockColor(),
+                            style, selector);
+        }
+        return cssBorderBlockColor;
+    }
+    
     public CssBorderBlockEndColor getBorderBlockEndColor() {
         if (cssBorderBlockEndColor == null) {
             cssBorderBlockEndColor =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -46,6 +46,7 @@ import org.w3c.css.properties.css.CssBorderBlockStartStyle;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderBlockStyle;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
+import org.w3c.css.properties.css.CssBorderEndEndRadius;
 import org.w3c.css.properties.css.CssBorderEndStartRadius;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBorderInline;
@@ -601,7 +602,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderStartStartRadius cssBorderStartStartRadius;
     public CssBorderStartEndRadius cssBorderStartEndRadius;
     public CssBorderEndStartRadius cssBorderEndStartRadius;
+    public CssBorderEndEndRadius cssBorderEndEndRadius;
 
+    public CssBorderEndEndRadius getBorderEndEndRadius() {
+        if (cssBorderEndEndRadius == null) {
+            cssBorderEndEndRadius =
+                    (CssBorderEndEndRadius) style.CascadingOrder(new CssBorderEndEndRadius(),
+                            style, selector);
+        }
+        return cssBorderEndEndRadius;
+    }
+    
     public CssBorderEndStartRadius getBorderEndStartRadius() {
         if (cssBorderEndStartRadius == null) {
             cssBorderEndStartRadius =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -117,6 +117,7 @@ import org.w3c.css.properties.css.CssInlineSize;
 import org.w3c.css.properties.css.CssInsetBlock;
 import org.w3c.css.properties.css.CssInsetBlockEnd;
 import org.w3c.css.properties.css.CssInsetBlockStart;
+import org.w3c.css.properties.css.CssInsetInlineEnd;
 import org.w3c.css.properties.css.CssInsetInlineStart;
 import org.w3c.css.properties.css.CssIsolation;
 import org.w3c.css.properties.css.CssJustifyContent;
@@ -529,7 +530,17 @@ public class Css3Style extends ATSCStyle {
     public CssInsetBlockEnd cssInsetBlockEnd;
     public CssInsetBlock cssInsetBlock;
     public CssInsetInlineStart cssInsetInlineStart;
+    public CssInsetInlineEnd cssInsetInlineEnd;
 
+    public CssInsetInlineEnd getInsetInlineEnd() {
+        if (cssInsetInlineEnd == null) {
+            cssInsetInlineEnd =
+                    (CssInsetInlineEnd) style.CascadingOrder(new CssInsetInlineEnd(),
+                            style, selector);
+        }
+        return cssInsetInlineEnd;
+    }
+    
     public CssInsetInlineStart getInsetInlineStart() {
         if (cssInsetInlineStart == null) {
             cssInsetInlineStart =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -40,6 +40,7 @@ import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
+import org.w3c.css.properties.css.CssBorderInlineWidth;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
 import org.w3c.css.properties.css.CssBoxShadow;
 import org.w3c.css.properties.css.CssBoxSizing;
@@ -557,6 +558,16 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineStartWidth cssBorderInlineStartWidth;
     public CssBorderInlineEndWidth cssBorderInlineEndWidth;
     public CssBorderBlockWidth cssBorderBlockWidth;
+    public CssBorderInlineWidth cssBorderInlineWidth;
+
+    public CssBorderInlineWidth getBorderInlineWidth() {
+        if (cssBorderInlineWidth == null) {
+            cssBorderInlineWidth =
+                    (CssBorderInlineWidth) style.CascadingOrder(new CssBorderInlineWidth(),
+                            style, selector);
+        }
+        return cssBorderInlineWidth;
+    }
     
     public CssBorderBlockWidth getBorderBlockWidth() {
         if (cssBorderBlockWidth == null) {

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -34,6 +34,7 @@ import org.w3c.css.properties.css.CssBackgroundPositionY;
 import org.w3c.css.properties.css.CssBackgroundSize;
 import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
+import org.w3c.css.properties.css.CssBorderBlockEndWidth;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
@@ -549,7 +550,17 @@ public class Css3Style extends ATSCStyle {
     public CssPaddingInlineEnd cssPaddingInlineEnd;
     public CssPaddingInline cssPaddingInline;
     public CssBorderBlockStartWidth cssBorderBlockStartWidth;
+    public CssBorderBlockEndWidth cssBorderBlockEndWidth;
 
+    public CssBorderBlockEndWidth getBorderBlockEndWidth() {
+        if (cssBorderBlockEndWidth == null) {
+            cssBorderBlockEndWidth =
+                    (CssBorderBlockEndWidth) style.CascadingOrder(new CssBorderBlockEndWidth(),
+                            style, selector);
+        }
+        return cssBorderBlockEndWidth;
+    }
+    
     public CssBorderBlockStartWidth getBorderBlockStartWidth() {
         if (cssBorderBlockStartWidth == null) {
             cssBorderBlockStartWidth =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -34,6 +34,7 @@ import org.w3c.css.properties.css.CssBackgroundPositionY;
 import org.w3c.css.properties.css.CssBackgroundSize;
 import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
+import org.w3c.css.properties.css.CssBorderBlockEndColor;
 import org.w3c.css.properties.css.CssBorderBlockEndStyle;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
 import org.w3c.css.properties.css.CssBorderBlockStartColor;
@@ -573,7 +574,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineEndStyle cssBorderInlineEndStyle;
     public CssBorderInlineStyle cssBorderInlineStyle;
     public CssBorderBlockStartColor cssBorderBlockStartColor;
+    public CssBorderBlockEndColor cssBorderBlockEndColor;
 
+    public CssBorderBlockEndColor getBorderBlockEndColor() {
+        if (cssBorderBlockEndColor == null) {
+            cssBorderBlockEndColor =
+                    (CssBorderBlockEndColor) style.CascadingOrder(new CssBorderBlockEndColor(),
+                            style, selector);
+        }
+        return cssBorderBlockEndColor;
+    }
+    
     public CssBorderBlockStartColor getBorderBlockStartColor() {
         if (cssBorderBlockStartColor == null) {
             cssBorderBlockStartColor =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -122,6 +122,7 @@ import org.w3c.css.properties.css.CssLightingColor;
 import org.w3c.css.properties.css.CssLineBreak;
 import org.w3c.css.properties.css.CssMarginBlockEnd;
 import org.w3c.css.properties.css.CssMarginBlockStart;
+import org.w3c.css.properties.css.CssMarginInlineStart;
 import org.w3c.css.properties.css.CssMarkerSide;
 import org.w3c.css.properties.css.CssMarqueeDirection;
 import org.w3c.css.properties.css.CssMarqueePlayCount;
@@ -513,6 +514,16 @@ public class Css3Style extends ATSCStyle {
     public CssMaxInlineSize cssMaxInlineSize;
     public CssMarginBlockStart cssMarginBlockStart;
     public CssMarginBlockEnd cssMarginBlockEnd;
+    public CssMarginInlineStart cssMarginInlineStart;
+
+    public CssMarginInlineStart getMarginInlineStart() {
+        if (cssMarginInlineStart == null) {
+            cssMarginInlineStart =
+                    (CssMarginInlineStart) style.CascadingOrder(new CssMarginInlineStart(),
+                            style, selector);
+        }
+        return cssMarginInlineStart;
+    }
     
     public CssMarginBlockEnd getMarginBlockEnd() {
         if (cssMarginBlockEnd == null) {

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -37,6 +37,7 @@ import org.w3c.css.properties.css.CssBlockSize;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
+import org.w3c.css.properties.css.CssBorderInlineStartWidth;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
 import org.w3c.css.properties.css.CssBoxShadow;
 import org.w3c.css.properties.css.CssBoxSizing;
@@ -551,7 +552,17 @@ public class Css3Style extends ATSCStyle {
     public CssPaddingInline cssPaddingInline;
     public CssBorderBlockStartWidth cssBorderBlockStartWidth;
     public CssBorderBlockEndWidth cssBorderBlockEndWidth;
+    public CssBorderInlineStartWidth cssBorderInlineStartWidth;
 
+    public CssBorderInlineStartWidth getBorderInlineStartWidth() {
+        if (cssBorderInlineStartWidth == null) {
+            cssBorderInlineStartWidth =
+                    (CssBorderInlineStartWidth) style.CascadingOrder(new CssBorderInlineStartWidth(),
+                            style, selector);
+        }
+        return cssBorderInlineStartWidth;
+    }
+    
     public CssBorderBlockEndWidth getBorderBlockEndWidth() {
         if (cssBorderBlockEndWidth == null) {
             cssBorderBlockEndWidth =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -37,6 +37,7 @@ import org.w3c.css.properties.css.CssBlockSize;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
+import org.w3c.css.properties.css.CssBorderInlineEndWidth;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
 import org.w3c.css.properties.css.CssBoxShadow;
@@ -553,7 +554,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockStartWidth cssBorderBlockStartWidth;
     public CssBorderBlockEndWidth cssBorderBlockEndWidth;
     public CssBorderInlineStartWidth cssBorderInlineStartWidth;
+    public CssBorderInlineEndWidth cssBorderInlineEndWidth;
 
+    public CssBorderInlineEndWidth getBorderInlineEndWidth() {
+        if (cssBorderInlineEndWidth == null) {
+            cssBorderInlineEndWidth =
+                    (CssBorderInlineEndWidth) style.CascadingOrder(new CssBorderInlineEndWidth(),
+                            style, selector);
+        }
+        return cssBorderInlineEndWidth;
+    }
+    
     public CssBorderInlineStartWidth getBorderInlineStartWidth() {
         if (cssBorderInlineStartWidth == null) {
             cssBorderInlineStartWidth =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -159,6 +159,7 @@ import org.w3c.css.properties.css.CssOverflowY;
 import org.w3c.css.properties.css.CssPaddingBlock;
 import org.w3c.css.properties.css.CssPaddingBlockEnd;
 import org.w3c.css.properties.css.CssPaddingBlockStart;
+import org.w3c.css.properties.css.CssPaddingInlineEnd;
 import org.w3c.css.properties.css.CssPaddingInlineStart;
 import org.w3c.css.properties.css.CssPerspective;
 import org.w3c.css.properties.css.CssPerspectiveOrigin;
@@ -543,7 +544,17 @@ public class Css3Style extends ATSCStyle {
     public CssPaddingBlockEnd cssPaddingBlockEnd;
     public CssPaddingBlock cssPaddingBlock;
     public CssPaddingInlineStart cssPaddingInlineStart;
+    public CssPaddingInlineEnd cssPaddingInlineEnd;
 
+    public CssPaddingInlineEnd getPaddingInlineEnd() {
+        if (cssPaddingInlineEnd == null) {
+            cssPaddingInlineEnd =
+                    (CssPaddingInlineEnd) style.CascadingOrder(new CssPaddingInlineEnd(),
+                            style, selector);
+        }
+        return cssPaddingInlineEnd;
+    }
+    
     public CssPaddingInlineStart getPaddingInlineStart() {
         if (cssPaddingInlineStart == null) {
             cssPaddingInlineStart =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -47,6 +47,7 @@ import org.w3c.css.properties.css.CssBorderBlockStyle;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBorderInlineColor;
+import org.w3c.css.properties.css.CssBorderInlineEnd;
 import org.w3c.css.properties.css.CssBorderInlineEndColor;
 import org.w3c.css.properties.css.CssBorderInlineEndStyle;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
@@ -589,7 +590,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockStart  cssBorderBlockStart;
     public CssBorderBlockEnd  cssBorderBlockEnd;
     public CssBorderInlineStart cssBorderInlineStart;
+    public CssBorderInlineEnd   cssBorderInlineEnd;
 
+    public CssBorderInlineEnd getBorderInlineEnd() {
+        if (cssBorderInlineEnd == null) {
+            cssBorderInlineEnd =
+                    (CssBorderInlineEnd) style.CascadingOrder(new CssBorderInlineEnd(),
+                            style, selector);
+        }
+        return cssBorderInlineEnd;
+    }
+    
     public CssBorderInlineStart getBorderInlineStart() {
         if (cssBorderInlineStart == null) {
             cssBorderInlineStart =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -159,6 +159,7 @@ import org.w3c.css.properties.css.CssOverflowY;
 import org.w3c.css.properties.css.CssPaddingBlock;
 import org.w3c.css.properties.css.CssPaddingBlockEnd;
 import org.w3c.css.properties.css.CssPaddingBlockStart;
+import org.w3c.css.properties.css.CssPaddingInlineStart;
 import org.w3c.css.properties.css.CssPerspective;
 import org.w3c.css.properties.css.CssPerspectiveOrigin;
 import org.w3c.css.properties.css.CssPlaceContent;
@@ -541,7 +542,17 @@ public class Css3Style extends ATSCStyle {
     public CssPaddingBlockStart cssPaddingBlockStart;
     public CssPaddingBlockEnd cssPaddingBlockEnd;
     public CssPaddingBlock cssPaddingBlock;
+    public CssPaddingInlineStart cssPaddingInlineStart;
 
+    public CssPaddingInlineStart getPaddingInlineStart() {
+        if (cssPaddingInlineStart == null) {
+            cssPaddingInlineStart =
+                    (CssPaddingInlineStart) style.CascadingOrder(new CssPaddingInlineStart(),
+                            style, selector);
+        }
+        return cssPaddingInlineStart;
+    }
+    
     public CssPaddingBlock getPaddingBlock() {
         if (cssPaddingBlock == null) {
             cssPaddingBlock =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -122,6 +122,7 @@ import org.w3c.css.properties.css.CssLightingColor;
 import org.w3c.css.properties.css.CssLineBreak;
 import org.w3c.css.properties.css.CssMarginBlockEnd;
 import org.w3c.css.properties.css.CssMarginBlockStart;
+import org.w3c.css.properties.css.CssMarginInlineEnd;
 import org.w3c.css.properties.css.CssMarginInlineStart;
 import org.w3c.css.properties.css.CssMarkerSide;
 import org.w3c.css.properties.css.CssMarqueeDirection;
@@ -515,7 +516,18 @@ public class Css3Style extends ATSCStyle {
     public CssMarginBlockStart cssMarginBlockStart;
     public CssMarginBlockEnd cssMarginBlockEnd;
     public CssMarginInlineStart cssMarginInlineStart;
+    public CssMarginInlineEnd cssMarginInlineEnd;
 
+
+    public CssMarginInlineEnd getMarginInlineEnd() {
+        if (cssMarginInlineEnd == null) {
+            cssMarginInlineEnd =
+                    (CssMarginInlineEnd) style.CascadingOrder(new CssMarginInlineEnd(),
+                            style, selector);
+        }
+        return cssMarginInlineEnd;
+    }
+    
     public CssMarginInlineStart getMarginInlineStart() {
         if (cssMarginInlineStart == null) {
             cssMarginInlineStart =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -35,6 +35,7 @@ import org.w3c.css.properties.css.CssBackgroundSize;
 import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
+import org.w3c.css.properties.css.CssBorderBlockStartStyle;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
@@ -559,7 +560,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineEndWidth cssBorderInlineEndWidth;
     public CssBorderBlockWidth cssBorderBlockWidth;
     public CssBorderInlineWidth cssBorderInlineWidth;
+    public CssBorderBlockStartStyle cssBorderBlockStartStyle;
 
+    public CssBorderBlockStartStyle getBorderBlockStartStyle() {
+        if (cssBorderBlockStartStyle == null) {
+            cssBorderBlockStartStyle =
+                    (CssBorderBlockStartStyle) style.CascadingOrder(new CssBorderBlockStartStyle(),
+                            style, selector);
+        }
+        return cssBorderBlockStartStyle;
+    }
+    
     public CssBorderInlineWidth getBorderInlineWidth() {
         if (cssBorderInlineWidth == null) {
             cssBorderInlineWidth =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -114,6 +114,7 @@ import org.w3c.css.properties.css.CssInitialLetter;
 import org.w3c.css.properties.css.CssInitialLetterAlign;
 import org.w3c.css.properties.css.CssInitialLetterWrap;
 import org.w3c.css.properties.css.CssInlineSize;
+import org.w3c.css.properties.css.CssInsetBlockEnd;
 import org.w3c.css.properties.css.CssInsetBlockStart;
 import org.w3c.css.properties.css.CssIsolation;
 import org.w3c.css.properties.css.CssJustifyContent;
@@ -523,7 +524,17 @@ public class Css3Style extends ATSCStyle {
     public CssMarginInlineEnd cssMarginInlineEnd;
     public CssMarginInline cssMarginInline;
     public CssInsetBlockStart cssInsetBlockStart;
+    public CssInsetBlockEnd cssInsetBlockEnd;
 
+    public CssInsetBlockEnd getInsetBlockEnd() {
+        if (cssInsetBlockEnd == null) {
+            cssInsetBlockEnd =
+                    (CssInsetBlockEnd) style.CascadingOrder(new CssInsetBlockEnd(),
+                            style, selector);
+        }
+        return cssInsetBlockEnd;
+    }
+    
     public CssInsetBlockStart getInsetBlockStart() {
         if (cssInsetBlockStart == null) {
             cssInsetBlockStart =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -34,6 +34,7 @@ import org.w3c.css.properties.css.CssBackgroundPositionY;
 import org.w3c.css.properties.css.CssBackgroundSize;
 import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
+import org.w3c.css.properties.css.CssBorderBlockEndStyle;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
 import org.w3c.css.properties.css.CssBorderBlockStartStyle;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
@@ -561,7 +562,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockWidth cssBorderBlockWidth;
     public CssBorderInlineWidth cssBorderInlineWidth;
     public CssBorderBlockStartStyle cssBorderBlockStartStyle;
+    public CssBorderBlockEndStyle cssBorderBlockEndStyle;
 
+    public CssBorderBlockEndStyle getBorderBlockEndStyle() {
+        if (cssBorderBlockEndStyle == null) {
+            cssBorderBlockEndStyle =
+                    (CssBorderBlockEndStyle) style.CascadingOrder(new CssBorderBlockEndStyle(),
+                            style, selector);
+        }
+        return cssBorderBlockEndStyle;
+    }
+    
     public CssBorderBlockStartStyle getBorderBlockStartStyle() {
         if (cssBorderBlockStartStyle == null) {
             cssBorderBlockStartStyle =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -45,6 +45,7 @@ import org.w3c.css.properties.css.CssBorderInlineEndStyle;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
 import org.w3c.css.properties.css.CssBorderInlineStartStyle;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
+import org.w3c.css.properties.css.CssBorderInlineStyle;
 import org.w3c.css.properties.css.CssBorderInlineWidth;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
 import org.w3c.css.properties.css.CssBoxShadow;
@@ -569,7 +570,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockStyle  cssBorderBlockStyle;
     public CssBorderInlineStartStyle cssBorderInlineStartStyle;
     public CssBorderInlineEndStyle cssBorderInlineEndStyle;
+    public CssBorderInlineStyle cssBorderInlineStyle;
 
+    public CssBorderInlineStyle getBorderInlineStyle() {
+        if (cssBorderInlineStyle == null) {
+            cssBorderInlineStyle =
+                    (CssBorderInlineStyle) style.CascadingOrder(new CssBorderInlineStyle(),
+                            style, selector);
+        }
+        return cssBorderInlineStyle;
+    }
+    
     public CssBorderInlineEndStyle getBorderInlineEndStyle() {
         if (cssBorderInlineEndStyle == null) {
             cssBorderInlineEndStyle =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -41,6 +41,7 @@ import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderBlockStyle;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
+import org.w3c.css.properties.css.CssBorderInlineEndStyle;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
 import org.w3c.css.properties.css.CssBorderInlineStartStyle;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
@@ -567,7 +568,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockEndStyle cssBorderBlockEndStyle;
     public CssBorderBlockStyle  cssBorderBlockStyle;
     public CssBorderInlineStartStyle cssBorderInlineStartStyle;
+    public CssBorderInlineEndStyle cssBorderInlineEndStyle;
 
+    public CssBorderInlineEndStyle getBorderInlineEndStyle() {
+        if (cssBorderInlineEndStyle == null) {
+            cssBorderInlineEndStyle =
+                    (CssBorderInlineEndStyle) style.CascadingOrder(new CssBorderInlineEndStyle(),
+                            style, selector);
+        }
+        return cssBorderInlineEndStyle;
+    }
+    
     public CssBorderInlineStartStyle getBorderInlineStartStyle() {
         if (cssBorderInlineStartStyle == null) {
             cssBorderInlineStartStyle =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -46,6 +46,7 @@ import org.w3c.css.properties.css.CssBorderBlockStartStyle;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderBlockStyle;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
+import org.w3c.css.properties.css.CssBorderEndStartRadius;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBorderInline;
 import org.w3c.css.properties.css.CssBorderInlineColor;
@@ -599,7 +600,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInline  cssBorderInline;
     public CssBorderStartStartRadius cssBorderStartStartRadius;
     public CssBorderStartEndRadius cssBorderStartEndRadius;
+    public CssBorderEndStartRadius cssBorderEndStartRadius;
 
+    public CssBorderEndStartRadius getBorderEndStartRadius() {
+        if (cssBorderEndStartRadius == null) {
+            cssBorderEndStartRadius =
+                    (CssBorderEndStartRadius) style.CascadingOrder(new CssBorderEndStartRadius(),
+                            style, selector);
+        }
+        return cssBorderEndStartRadius;
+    }
+    
     public CssBorderStartEndRadius getBorderStartEndRadius() {
         if (cssBorderStartEndRadius == null) {
             cssBorderStartEndRadius =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -36,6 +36,7 @@ import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
+import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
@@ -555,7 +556,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockEndWidth cssBorderBlockEndWidth;
     public CssBorderInlineStartWidth cssBorderInlineStartWidth;
     public CssBorderInlineEndWidth cssBorderInlineEndWidth;
-
+    public CssBorderBlockWidth cssBorderBlockWidth;
+    
+    public CssBorderBlockWidth getBorderBlockWidth() {
+        if (cssBorderBlockWidth == null) {
+            cssBorderBlockWidth =
+                    (CssBorderBlockWidth) style.CascadingOrder(new CssBorderBlockWidth(),
+                            style, selector);
+        }
+        return cssBorderBlockWidth;
+    }
+    
     public CssBorderInlineEndWidth getBorderInlineEndWidth() {
         if (cssBorderInlineEndWidth == null) {
             cssBorderInlineEndWidth =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -47,6 +47,7 @@ import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderBlockStyle;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
+import org.w3c.css.properties.css.CssBorderInline;
 import org.w3c.css.properties.css.CssBorderInlineColor;
 import org.w3c.css.properties.css.CssBorderInlineEnd;
 import org.w3c.css.properties.css.CssBorderInlineEndColor;
@@ -593,7 +594,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineStart cssBorderInlineStart;
     public CssBorderInlineEnd   cssBorderInlineEnd;
     public CssBorderBlock   cssBorderBlock;
+    public CssBorderInline  cssBorderInline;
 
+    public CssBorderInline getBorderInline() {
+        if (cssBorderInline == null) {
+            cssBorderInline =
+                    (CssBorderInline) style.CascadingOrder(new CssBorderInline(),
+                            style, selector);
+        }
+        return cssBorderInline;
+    }
+    
     public CssBorderBlock getBorderBlock() {
         if (cssBorderBlock == null) {
             cssBorderBlock =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -50,6 +50,7 @@ import org.w3c.css.properties.css.CssBorderInlineColor;
 import org.w3c.css.properties.css.CssBorderInlineEndColor;
 import org.w3c.css.properties.css.CssBorderInlineEndStyle;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
+import org.w3c.css.properties.css.CssBorderInlineStart;
 import org.w3c.css.properties.css.CssBorderInlineStartColor;
 import org.w3c.css.properties.css.CssBorderInlineStartStyle;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
@@ -587,7 +588,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineColor cssBorderInlineColor;
     public CssBorderBlockStart  cssBorderBlockStart;
     public CssBorderBlockEnd  cssBorderBlockEnd;
+    public CssBorderInlineStart cssBorderInlineStart;
 
+    public CssBorderInlineStart getBorderInlineStart() {
+        if (cssBorderInlineStart == null) {
+            cssBorderInlineStart =
+                    (CssBorderInlineStart) style.CascadingOrder(new CssBorderInlineStart(),
+                            style, selector);
+        }
+        return cssBorderInlineStart;
+    }
+    
     public CssBorderBlockEnd getBorderBlockEnd() {
         if (cssBorderBlockEnd == null) {
             cssBorderBlockEnd =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -36,6 +36,7 @@ import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
 import org.w3c.css.properties.css.CssBorderBlockEndStyle;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
+import org.w3c.css.properties.css.CssBorderBlockStartColor;
 import org.w3c.css.properties.css.CssBorderBlockStartStyle;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderBlockStyle;
@@ -571,7 +572,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineStartStyle cssBorderInlineStartStyle;
     public CssBorderInlineEndStyle cssBorderInlineEndStyle;
     public CssBorderInlineStyle cssBorderInlineStyle;
+    public CssBorderBlockStartColor cssBorderBlockStartColor;
 
+    public CssBorderBlockStartColor getBorderBlockStartColor() {
+        if (cssBorderBlockStartColor == null) {
+            cssBorderBlockStartColor =
+                    (CssBorderBlockStartColor) style.CascadingOrder(new CssBorderBlockStartColor(),
+                            style, selector);
+        }
+        return cssBorderBlockStartColor;
+    }
+    
     public CssBorderInlineStyle getBorderInlineStyle() {
         if (cssBorderInlineStyle == null) {
             cssBorderInlineStyle =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -156,6 +156,7 @@ import org.w3c.css.properties.css.CssOverflowStyle;
 import org.w3c.css.properties.css.CssOverflowWrap;
 import org.w3c.css.properties.css.CssOverflowX;
 import org.w3c.css.properties.css.CssOverflowY;
+import org.w3c.css.properties.css.CssPaddingBlock;
 import org.w3c.css.properties.css.CssPaddingBlockEnd;
 import org.w3c.css.properties.css.CssPaddingBlockStart;
 import org.w3c.css.properties.css.CssPerspective;
@@ -539,7 +540,17 @@ public class Css3Style extends ATSCStyle {
     public CssInset cssInset;
     public CssPaddingBlockStart cssPaddingBlockStart;
     public CssPaddingBlockEnd cssPaddingBlockEnd;
+    public CssPaddingBlock cssPaddingBlock;
 
+    public CssPaddingBlock getPaddingBlock() {
+        if (cssPaddingBlock == null) {
+            cssPaddingBlock =
+                    (CssPaddingBlock) style.CascadingOrder(new CssPaddingBlock(),
+                            style, selector);
+        }
+        return cssPaddingBlock;
+    }
+    
     public CssPaddingBlockEnd getPaddingBlockEnd() {
         if (cssPaddingBlockEnd == null) {
             cssPaddingBlockEnd =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -34,6 +34,7 @@ import org.w3c.css.properties.css.CssBackgroundPositionY;
 import org.w3c.css.properties.css.CssBackgroundSize;
 import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
+import org.w3c.css.properties.css.CssBorderBlock;
 import org.w3c.css.properties.css.CssBorderBlockColor;
 import org.w3c.css.properties.css.CssBorderBlockEnd;
 import org.w3c.css.properties.css.CssBorderBlockEndColor;
@@ -591,7 +592,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlockEnd  cssBorderBlockEnd;
     public CssBorderInlineStart cssBorderInlineStart;
     public CssBorderInlineEnd   cssBorderInlineEnd;
+    public CssBorderBlock   cssBorderBlock;
 
+    public CssBorderBlock getBorderBlock() {
+        if (cssBorderBlock == null) {
+            cssBorderBlock =
+                    (CssBorderBlock) style.CascadingOrder(new CssBorderBlock(),
+                            style, selector);
+        }
+        return cssBorderBlock;
+    }
+    
     public CssBorderInlineEnd getBorderInlineEnd() {
         if (cssBorderInlineEnd == null) {
             cssBorderInlineEnd =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -38,6 +38,7 @@ import org.w3c.css.properties.css.CssBorderBlockColor;
 import org.w3c.css.properties.css.CssBorderBlockEndColor;
 import org.w3c.css.properties.css.CssBorderBlockEndStyle;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
+import org.w3c.css.properties.css.CssBorderBlockStart;
 import org.w3c.css.properties.css.CssBorderBlockStartColor;
 import org.w3c.css.properties.css.CssBorderBlockStartStyle;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
@@ -583,7 +584,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineStartColor cssBorderInlineStartColor;
     public CssBorderInlineEndColor cssBorderInlineEndColor;
     public CssBorderInlineColor cssBorderInlineColor;
+    public CssBorderBlockStart  cssBorderBlockStart;
 
+    public CssBorderBlockStart getBorderBlockStart() {
+        if (cssBorderBlockStart == null) {
+            cssBorderBlockStart =
+                    (CssBorderBlockStart) style.CascadingOrder(new CssBorderBlockStart(),
+                            style, selector);
+        }
+        return cssBorderBlockStart;
+    }
+    
     public CssBorderInlineColor getBorderInlineColor() {
         if (cssBorderInlineColor == null) {
             cssBorderInlineColor =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -117,6 +117,7 @@ import org.w3c.css.properties.css.CssInlineSize;
 import org.w3c.css.properties.css.CssInsetBlock;
 import org.w3c.css.properties.css.CssInsetBlockEnd;
 import org.w3c.css.properties.css.CssInsetBlockStart;
+import org.w3c.css.properties.css.CssInsetInlineStart;
 import org.w3c.css.properties.css.CssIsolation;
 import org.w3c.css.properties.css.CssJustifyContent;
 import org.w3c.css.properties.css.CssJustifyItems;
@@ -527,7 +528,17 @@ public class Css3Style extends ATSCStyle {
     public CssInsetBlockStart cssInsetBlockStart;
     public CssInsetBlockEnd cssInsetBlockEnd;
     public CssInsetBlock cssInsetBlock;
+    public CssInsetInlineStart cssInsetInlineStart;
 
+    public CssInsetInlineStart getInsetInlineStart() {
+        if (cssInsetInlineStart == null) {
+            cssInsetInlineStart =
+                    (CssInsetInlineStart) style.CascadingOrder(new CssInsetInlineStart(),
+                            style, selector);
+        }
+        return cssInsetInlineStart;
+    }
+    
     public CssInsetBlock getInsetBlock() {
         if (cssInsetBlock == null) {
             cssInsetBlock =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -156,6 +156,7 @@ import org.w3c.css.properties.css.CssOverflowStyle;
 import org.w3c.css.properties.css.CssOverflowWrap;
 import org.w3c.css.properties.css.CssOverflowX;
 import org.w3c.css.properties.css.CssOverflowY;
+import org.w3c.css.properties.css.CssPaddingBlockEnd;
 import org.w3c.css.properties.css.CssPaddingBlockStart;
 import org.w3c.css.properties.css.CssPerspective;
 import org.w3c.css.properties.css.CssPerspectiveOrigin;
@@ -537,8 +538,17 @@ public class Css3Style extends ATSCStyle {
     public CssInsetInline   cssInsetInline;
     public CssInset cssInset;
     public CssPaddingBlockStart cssPaddingBlockStart;
+    public CssPaddingBlockEnd cssPaddingBlockEnd;
 
-
+    public CssPaddingBlockEnd getPaddingBlockEnd() {
+        if (cssPaddingBlockEnd == null) {
+            cssPaddingBlockEnd =
+                    (CssPaddingBlockEnd) style.CascadingOrder(new CssPaddingBlockEnd(),
+                            style, selector);
+        }
+        return cssPaddingBlockEnd;
+    }
+    
     public CssPaddingBlockStart getPaddingBlockStart() {
         if (cssPaddingBlockStart == null) {
             cssPaddingBlockStart =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -33,6 +33,7 @@ import org.w3c.css.properties.css.CssBackgroundPositionX;
 import org.w3c.css.properties.css.CssBackgroundPositionY;
 import org.w3c.css.properties.css.CssBackgroundSize;
 import org.w3c.css.properties.css.CssBaselineShift;
+import org.w3c.css.properties.css.CssBlockSize;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
 import org.w3c.css.properties.css.CssBoxShadow;
@@ -112,6 +113,7 @@ import org.w3c.css.properties.css.CssImeMode;
 import org.w3c.css.properties.css.CssInitialLetter;
 import org.w3c.css.properties.css.CssInitialLetterAlign;
 import org.w3c.css.properties.css.CssInitialLetterWrap;
+import org.w3c.css.properties.css.CssInlineSize;
 import org.w3c.css.properties.css.CssIsolation;
 import org.w3c.css.properties.css.CssJustifyContent;
 import org.w3c.css.properties.css.CssJustifyItems;
@@ -496,6 +498,26 @@ public class Css3Style extends ATSCStyle {
     public CssColorAdjust cssColorAdjust;
     public CssForcedColorAdjust cssForcedColorAdjust;
     public CssColorScheme cssColorScheme;
+
+    public CssBlockSize cssBlockSize;
+    public CssInlineSize cssInlineSize;
+
+    public CssInlineSize getInlineSize() {
+        if (cssInlineSize == null) {
+            cssInlineSize =
+                    (CssInlineSize) style.CascadingOrder(new CssInlineSize(),
+                            style, selector);
+        }
+        return cssInlineSize;
+    }
+    public CssBlockSize getBlockSize() {
+        if (cssBlockSize == null) {
+            cssBlockSize =
+                    (CssBlockSize) style.CascadingOrder(new CssBlockSize(),
+                            style, selector);
+        }
+        return cssBlockSize;
+    }
 
     public CssColorScheme getColorScheme() {
         if (cssColorScheme == null) {

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -59,6 +59,7 @@ import org.w3c.css.properties.css.CssBorderInlineStartStyle;
 import org.w3c.css.properties.css.CssBorderInlineStartWidth;
 import org.w3c.css.properties.css.CssBorderInlineStyle;
 import org.w3c.css.properties.css.CssBorderInlineWidth;
+import org.w3c.css.properties.css.CssBorderStartEndRadius;
 import org.w3c.css.properties.css.CssBorderStartStartRadius;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
 import org.w3c.css.properties.css.CssBoxShadow;
@@ -597,7 +598,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderBlock   cssBorderBlock;
     public CssBorderInline  cssBorderInline;
     public CssBorderStartStartRadius cssBorderStartStartRadius;
+    public CssBorderStartEndRadius cssBorderStartEndRadius;
 
+    public CssBorderStartEndRadius getBorderStartEndRadius() {
+        if (cssBorderStartEndRadius == null) {
+            cssBorderStartEndRadius =
+                    (CssBorderStartEndRadius) style.CascadingOrder(new CssBorderStartEndRadius(),
+                            style, selector);
+        }
+        return cssBorderStartEndRadius;
+    }
+    
     public CssBorderStartStartRadius getBorderStartStartRadius() {
         if (cssBorderStartStartRadius == null) {
             cssBorderStartStartRadius =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -34,6 +34,7 @@ import org.w3c.css.properties.css.CssBackgroundPositionY;
 import org.w3c.css.properties.css.CssBackgroundSize;
 import org.w3c.css.properties.css.CssBaselineShift;
 import org.w3c.css.properties.css.CssBlockSize;
+import org.w3c.css.properties.css.CssBorderBlockStartWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBoxDecorationBreak;
 import org.w3c.css.properties.css.CssBoxShadow;
@@ -547,7 +548,17 @@ public class Css3Style extends ATSCStyle {
     public CssPaddingInlineStart cssPaddingInlineStart;
     public CssPaddingInlineEnd cssPaddingInlineEnd;
     public CssPaddingInline cssPaddingInline;
+    public CssBorderBlockStartWidth cssBorderBlockStartWidth;
 
+    public CssBorderBlockStartWidth getBorderBlockStartWidth() {
+        if (cssBorderBlockStartWidth == null) {
+            cssBorderBlockStartWidth =
+                    (CssBorderBlockStartWidth) style.CascadingOrder(new CssBorderBlockStartWidth(),
+                            style, selector);
+        }
+        return cssBorderBlockStartWidth;
+    }
+    
     public CssPaddingInline getPaddingInline() {
         if (cssPaddingInline == null) {
             cssPaddingInline =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -125,6 +125,8 @@ import org.w3c.css.properties.css.CssMarqueeDirection;
 import org.w3c.css.properties.css.CssMarqueePlayCount;
 import org.w3c.css.properties.css.CssMarqueeSpeed;
 import org.w3c.css.properties.css.CssMarqueeStyle;
+import org.w3c.css.properties.css.CssMaxBlockSize;
+import org.w3c.css.properties.css.CssMaxInlineSize;
 import org.w3c.css.properties.css.CssMinBlockSize;
 import org.w3c.css.properties.css.CssMinInlineSize;
 import org.w3c.css.properties.css.CssMixBlendMode;
@@ -505,7 +507,26 @@ public class Css3Style extends ATSCStyle {
     public CssInlineSize cssInlineSize;
     public CssMinBlockSize cssMinBlockSize;
     public CssMinInlineSize cssMinInlineSize;
-
+    public CssMaxBlockSize cssMaxBlockSize;
+    public CssMaxInlineSize cssMaxInlineSize;
+    
+    public CssMaxInlineSize getMaxInlineSize() {
+        if (cssMaxInlineSize == null) {
+            cssMaxInlineSize =
+                    (CssMaxInlineSize) style.CascadingOrder(new CssMaxInlineSize(),
+                            style, selector);
+        }
+        return cssMaxInlineSize;
+    }
+    public CssMaxBlockSize getMaxBlockSize() {
+        if (cssMaxBlockSize == null) {
+            cssMaxBlockSize =
+                    (CssMaxBlockSize) style.CascadingOrder(new CssMaxBlockSize(),
+                            style, selector);
+        }
+        return cssMaxBlockSize;
+    }
+    
     public CssMinInlineSize getMinInlineSize() {
         if (cssMinInlineSize == null) {
             cssMinInlineSize =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -38,6 +38,7 @@ import org.w3c.css.properties.css.CssBorderBlockEndStyle;
 import org.w3c.css.properties.css.CssBorderBlockEndWidth;
 import org.w3c.css.properties.css.CssBorderBlockStartStyle;
 import org.w3c.css.properties.css.CssBorderBlockStartWidth;
+import org.w3c.css.properties.css.CssBorderBlockStyle;
 import org.w3c.css.properties.css.CssBorderBlockWidth;
 import org.w3c.css.properties.css.CssBorderImageSource;
 import org.w3c.css.properties.css.CssBorderInlineEndWidth;
@@ -563,7 +564,17 @@ public class Css3Style extends ATSCStyle {
     public CssBorderInlineWidth cssBorderInlineWidth;
     public CssBorderBlockStartStyle cssBorderBlockStartStyle;
     public CssBorderBlockEndStyle cssBorderBlockEndStyle;
+    public CssBorderBlockStyle  cssBorderBlockStyle;
 
+    public CssBorderBlockStyle getBorderBlockStyle() {
+        if (cssBorderBlockStyle == null) {
+            cssBorderBlockStyle =
+                    (CssBorderBlockStyle) style.CascadingOrder(new CssBorderBlockStyle(),
+                            style, selector);
+        }
+        return cssBorderBlockStyle;
+    }
+    
     public CssBorderBlockEndStyle getBorderBlockEndStyle() {
         if (cssBorderBlockEndStyle == null) {
             cssBorderBlockEndStyle =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -114,6 +114,7 @@ import org.w3c.css.properties.css.CssInitialLetter;
 import org.w3c.css.properties.css.CssInitialLetterAlign;
 import org.w3c.css.properties.css.CssInitialLetterWrap;
 import org.w3c.css.properties.css.CssInlineSize;
+import org.w3c.css.properties.css.CssInsetBlock;
 import org.w3c.css.properties.css.CssInsetBlockEnd;
 import org.w3c.css.properties.css.CssInsetBlockStart;
 import org.w3c.css.properties.css.CssIsolation;
@@ -525,7 +526,17 @@ public class Css3Style extends ATSCStyle {
     public CssMarginInline cssMarginInline;
     public CssInsetBlockStart cssInsetBlockStart;
     public CssInsetBlockEnd cssInsetBlockEnd;
+    public CssInsetBlock cssInsetBlock;
 
+    public CssInsetBlock getInsetBlock() {
+        if (cssInsetBlock == null) {
+            cssInsetBlock =
+                    (CssInsetBlock) style.CascadingOrder(new CssInsetBlock(),
+                            style, selector);
+        }
+        return cssInsetBlock;
+    }
+    
     public CssInsetBlockEnd getInsetBlockEnd() {
         if (cssInsetBlockEnd == null) {
             cssInsetBlockEnd =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -120,6 +120,7 @@ import org.w3c.css.properties.css.CssJustifyItems;
 import org.w3c.css.properties.css.CssJustifySelf;
 import org.w3c.css.properties.css.CssLightingColor;
 import org.w3c.css.properties.css.CssLineBreak;
+import org.w3c.css.properties.css.CssMarginBlockEnd;
 import org.w3c.css.properties.css.CssMarginBlockStart;
 import org.w3c.css.properties.css.CssMarkerSide;
 import org.w3c.css.properties.css.CssMarqueeDirection;
@@ -511,7 +512,17 @@ public class Css3Style extends ATSCStyle {
     public CssMaxBlockSize cssMaxBlockSize;
     public CssMaxInlineSize cssMaxInlineSize;
     public CssMarginBlockStart cssMarginBlockStart;
-
+    public CssMarginBlockEnd cssMarginBlockEnd;
+    
+    public CssMarginBlockEnd getMarginBlockEnd() {
+        if (cssMarginBlockEnd == null) {
+            cssMarginBlockEnd =
+                    (CssMarginBlockEnd) style.CascadingOrder(new CssMarginBlockEnd(),
+                            style, selector);
+        }
+        return cssMarginBlockEnd;
+    }
+    
     public CssMarginBlockStart getMarginBlockStart() {
         if (cssMarginBlockStart == null) {
             cssMarginBlockStart =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -120,6 +120,7 @@ import org.w3c.css.properties.css.CssJustifyItems;
 import org.w3c.css.properties.css.CssJustifySelf;
 import org.w3c.css.properties.css.CssLightingColor;
 import org.w3c.css.properties.css.CssLineBreak;
+import org.w3c.css.properties.css.CssMarginBlock;
 import org.w3c.css.properties.css.CssMarginBlockEnd;
 import org.w3c.css.properties.css.CssMarginBlockStart;
 import org.w3c.css.properties.css.CssMarginInlineEnd;
@@ -515,6 +516,7 @@ public class Css3Style extends ATSCStyle {
     public CssMaxInlineSize cssMaxInlineSize;
     public CssMarginBlockStart cssMarginBlockStart;
     public CssMarginBlockEnd cssMarginBlockEnd;
+    public CssMarginBlock cssMarginBlock;
     public CssMarginInlineStart cssMarginInlineStart;
     public CssMarginInlineEnd cssMarginInlineEnd;
 
@@ -535,6 +537,15 @@ public class Css3Style extends ATSCStyle {
                             style, selector);
         }
         return cssMarginInlineStart;
+    }
+
+    public CssMarginBlock getMarginBlock() {
+        if (cssMarginBlock == null) {
+            cssMarginBlock =
+                    (CssMarginBlock) style.CascadingOrder(new CssMarginBlock(),
+                            style, selector);
+        }
+        return cssMarginBlock;
     }
     
     public CssMarginBlockEnd getMarginBlockEnd() {

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -114,6 +114,7 @@ import org.w3c.css.properties.css.CssInitialLetter;
 import org.w3c.css.properties.css.CssInitialLetterAlign;
 import org.w3c.css.properties.css.CssInitialLetterWrap;
 import org.w3c.css.properties.css.CssInlineSize;
+import org.w3c.css.properties.css.CssInsetBlockStart;
 import org.w3c.css.properties.css.CssIsolation;
 import org.w3c.css.properties.css.CssJustifyContent;
 import org.w3c.css.properties.css.CssJustifyItems;
@@ -521,7 +522,17 @@ public class Css3Style extends ATSCStyle {
     public CssMarginInlineStart cssMarginInlineStart;
     public CssMarginInlineEnd cssMarginInlineEnd;
     public CssMarginInline cssMarginInline;
+    public CssInsetBlockStart cssInsetBlockStart;
 
+    public CssInsetBlockStart getInsetBlockStart() {
+        if (cssInsetBlockStart == null) {
+            cssInsetBlockStart =
+                    (CssInsetBlockStart) style.CascadingOrder(new CssInsetBlockStart(),
+                            style, selector);
+        }
+        return cssInsetBlockStart;
+    }
+    
     public CssMarginInline getMarginInline() {
         if (cssMarginInline == null) {
             cssMarginInline =

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -159,6 +159,7 @@ import org.w3c.css.properties.css.CssOverflowY;
 import org.w3c.css.properties.css.CssPaddingBlock;
 import org.w3c.css.properties.css.CssPaddingBlockEnd;
 import org.w3c.css.properties.css.CssPaddingBlockStart;
+import org.w3c.css.properties.css.CssPaddingInline;
 import org.w3c.css.properties.css.CssPaddingInlineEnd;
 import org.w3c.css.properties.css.CssPaddingInlineStart;
 import org.w3c.css.properties.css.CssPerspective;
@@ -545,7 +546,17 @@ public class Css3Style extends ATSCStyle {
     public CssPaddingBlock cssPaddingBlock;
     public CssPaddingInlineStart cssPaddingInlineStart;
     public CssPaddingInlineEnd cssPaddingInlineEnd;
+    public CssPaddingInline cssPaddingInline;
 
+    public CssPaddingInline getPaddingInline() {
+        if (cssPaddingInline == null) {
+            cssPaddingInline =
+                    (CssPaddingInline) style.CascadingOrder(new CssPaddingInline(),
+                            style, selector);
+        }
+        return cssPaddingInline;
+    }
+    
     public CssPaddingInlineEnd getPaddingInlineEnd() {
         if (cssPaddingInlineEnd == null) {
             cssPaddingInlineEnd =

--- a/org/w3c/css/properties/css3/CssBlockSize.java
+++ b/org/w3c/css/properties/css3/CssBlockSize.java
@@ -1,0 +1,47 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-block-size
+ */
+public class CssBlockSize extends org.w3c.css.properties.css.CssBlockSize {
+
+    /**
+     * Create a new CssBlockSize
+     */
+    public CssBlockSize() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBlockSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBlockSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+
+        value = CssWidth.parseWidth(ac, expression, this);
+
+    }
+
+    public CssBlockSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+}
+

--- a/org/w3c/css/properties/css3/CssBorder.java
+++ b/org/w3c/css/properties/css3/CssBorder.java
@@ -55,7 +55,7 @@ public class CssBorder extends org.w3c.css.properties.css.CssBorder {
         // great, it's the same thing as one side!
         CssValueList valueList = new CssValueList();
 
-        SideValues values = checkBorderSide(ac, this, expression, check);
+        SideValues values = parseBorderSide(ac, expression, check, this);
         shorthand = true;
         if (values.color != null) {
             valueList.add(values.color);
@@ -100,8 +100,7 @@ public class CssBorder extends org.w3c.css.properties.css.CssBorder {
      * Check the border-* and returns a value.
      * It makes sense to do it only once for all the sides, so by having the code here.
      */
-    protected static SideValues checkBorderSide(ApplContext ac, CssProperty caller, CssExpression expression,
-                                                boolean check) throws InvalidParamException {
+    protected static SideValues parseBorderSide(ApplContext ac, CssExpression expression, boolean check, CssProperty caller) throws InvalidParamException {
         if (check && expression.getCount() > 3) {
             throw new InvalidParamException("unrecognize", ac);
         }

--- a/org/w3c/css/properties/css3/CssBorderBlock.java
+++ b/org/w3c/css/properties/css3/CssBorderBlock.java
@@ -1,0 +1,68 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block
+ */
+public class CssBorderBlock extends org.w3c.css.properties.css.CssBorderBlock {
+
+    /**
+     * Create a new CssBorderBlock
+     */
+    public CssBorderBlock() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlock
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlock(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
+        ArrayList<CssValue> vl = new ArrayList<>();
+
+        if (values.width != null) {
+            vl.add(values.width);
+        }
+        if (values.style != null) {
+            vl.add(values.style);
+        }
+        if (values.color != null) {
+            vl.add(values.color);
+        }
+        setByUser();
+
+        if (vl.size() == 1) {
+            value = vl.get(0);
+        } else {
+            if (vl.contains(inherit)) {
+                // no need to bail out, multiple inherit value is already checked
+                value = inherit;
+            } else {
+                value = new CssValueList(vl);
+            }
+        }
+    }
+
+
+    public CssBorderBlock(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockColor.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockColor.java
@@ -1,0 +1,74 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-color
+ */
+public class CssBorderBlockColor extends org.w3c.css.properties.css.CssBorderBlockColor {
+
+    /**
+     * Create a new CssBorderBlockColor
+     */
+    public CssBorderBlockColor() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssBorderColor.parseBorderSideColor(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssBorderColor.parseBorderSideColor(ac, expression,
+                    false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssBorderBlockColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockEnd.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockEnd.java
@@ -1,0 +1,68 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-end
+ */
+public class CssBorderBlockEnd extends org.w3c.css.properties.css.CssBorderBlockEnd {
+
+    /**
+     * Create a new CssBorderBlockEnd
+     */
+    public CssBorderBlockEnd() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
+        ArrayList<CssValue> vl = new ArrayList<>();
+
+        if (values.width != null) {
+            vl.add(values.width);
+        }
+        if (values.style != null) {
+            vl.add(values.style);
+        }
+        if (values.color != null) {
+            vl.add(values.color);
+        }
+        setByUser();
+
+        if (vl.size() == 1) {
+            value = vl.get(0);
+        } else {
+            if (vl.contains(inherit)) {
+                // no need to bail out, multiple inherit value is already checked
+                value = inherit;
+            } else {
+                value = new CssValueList(vl);
+            }
+        }
+    }
+
+
+    public CssBorderBlockEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockEndColor.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockEndColor.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-end-color
+ */
+public class CssBorderBlockEndColor extends org.w3c.css.properties.css.CssBorderBlockEndColor {
+
+    /**
+     * Create a new CssBorderBlockEndColor
+     */
+    public CssBorderBlockEndColor() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockEndColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderBlockEndColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderColor.parseBorderSideColor(ac, expression, check, this);
+    }
+
+
+    public CssBorderBlockEndColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockEndStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockEndStyle.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-end-style
+ */
+public class CssBorderBlockEndStyle extends org.w3c.css.properties.css.CssBorderBlockEndStyle {
+
+    /**
+     * Create a new CssBorderBlockEndStyle
+     */
+    public CssBorderBlockEndStyle() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockEndStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderBlockEndStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
+    }
+
+
+    public CssBorderBlockEndStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockEndWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockEndWidth.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-end-width
+ */
+public class CssBorderBlockEndWidth extends org.w3c.css.properties.css.CssBorderBlockEndWidth {
+
+    /**
+     * Create a new CssBorderBlockEndWidth
+     */
+    public CssBorderBlockEndWidth() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockEndWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderBlockEndWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
+    }
+
+
+    public CssBorderBlockEndWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockStart.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockStart.java
@@ -1,0 +1,68 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-start
+ */
+public class CssBorderBlockStart extends org.w3c.css.properties.css.CssBorderBlockStart {
+
+    /**
+     * Create a new CssBorderBlockStart
+     */
+    public CssBorderBlockStart() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
+        ArrayList<CssValue> vl = new ArrayList<>();
+
+        if (values.width != null) {
+            vl.add(values.width);
+        }
+        if (values.style != null) {
+            vl.add(values.style);
+        }
+        if (values.color != null) {
+            vl.add(values.color);
+        }
+        setByUser();
+
+        if (vl.size() == 1) {
+            value = vl.get(0);
+        } else {
+            if (vl.contains(inherit)) {
+                // no need to bail out, multiple inherit value is already checked
+                value = inherit;
+            } else {
+                value = new CssValueList(vl);
+            }
+        }
+    }
+
+
+    public CssBorderBlockStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockStartColor.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockStartColor.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-start-color
+ */
+public class CssBorderBlockStartColor extends org.w3c.css.properties.css.CssBorderBlockStartColor {
+
+    /**
+     * Create a new CssBorderBlockStartColor
+     */
+    public CssBorderBlockStartColor() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockStartColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderBlockStartColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderColor.parseBorderSideColor(ac, expression, check, this);
+    }
+
+
+    public CssBorderBlockStartColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockStartStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockStartStyle.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-start-style
+ */
+public class CssBorderBlockStartStyle extends org.w3c.css.properties.css.CssBorderBlockStartStyle {
+
+    /**
+     * Create a new CssBorderBlockStartStyle
+     */
+    public CssBorderBlockStartStyle() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockStartStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderBlockStartStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
+    }
+
+
+    public CssBorderBlockStartStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockStartWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockStartWidth.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-start-width
+ */
+public class CssBorderBlockStartWidth extends org.w3c.css.properties.css.CssBorderBlockStartWidth {
+
+    /**
+     * Create a new CssBorderBlockStartWidth
+     */
+    public CssBorderBlockStartWidth() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockStartWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderBlockStartWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
+    }
+
+
+    public CssBorderBlockStartWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockStyle.java
@@ -1,0 +1,74 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-style
+ */
+public class CssBorderBlockStyle extends org.w3c.css.properties.css.CssBorderBlockStyle {
+
+    /**
+     * Create a new CssBorderBlockStyle
+     */
+    public CssBorderBlockStyle() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssBorderStyle.parseBorderSideStyle(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssBorderStyle.parseBorderSideStyle(ac, expression,
+                    false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssBorderBlockStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBlockWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderBlockWidth.java
@@ -1,0 +1,74 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-block-width
+ */
+public class CssBorderBlockWidth extends org.w3c.css.properties.css.CssBorderBlockWidth {
+
+    /**
+     * Create a new CssBorderBlockWidth
+     */
+    public CssBorderBlockWidth() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderBlockWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderBlockWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssBorderWidth.parseBorderSideWidth(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssBorderWidth.parseBorderSideWidth(ac, expression,
+                    false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssBorderBlockWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderBottom.java
+++ b/org/w3c/css/properties/css3/CssBorderBottom.java
@@ -49,7 +49,7 @@ public class CssBorderBottom extends org.w3c.css.properties.css.CssBorderBottom 
      */
     public CssBorderBottom(ApplContext ac, CssExpression expression,
                            boolean check) throws InvalidParamException {
-        CssBorder.SideValues values = CssBorder.checkBorderSide(ac, this, expression, check);
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
         if (values.width != null) {
             _width = new CssBorderBottomWidth();
             _width.setByUser();

--- a/org/w3c/css/properties/css3/CssBorderBottomColor.java
+++ b/org/w3c/css/properties/css3/CssBorderBottomColor.java
@@ -31,7 +31,7 @@ public class CssBorderBottomColor extends org.w3c.css.properties.css.CssBorderBo
      */
     public CssBorderBottomColor(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
-        value = CssBorderColor.checkBorderSideColor(ac, this, expression, check);
+        value = CssBorderColor.parseBorderSideColor(ac, expression, check, this);
     }
 
     public CssBorderBottomColor(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderBottomLeftRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderBottomLeftRadius.java
@@ -34,7 +34,7 @@ public class CssBorderBottomLeftRadius extends org.w3c.css.properties.css.CssBor
     public CssBorderBottomLeftRadius(ApplContext ac, CssExpression expression,
                                      boolean check) throws InvalidParamException {
         setByUser();
-        value = CssBorderRadius.checkBorderCornerRadius(ac, this, expression, check);
+        value = CssBorderRadius.parseBorderCornerRadius(ac, expression, check, this);
         if (value.getType() == CssTypes.CSS_VALUE_LIST) {
             CssValueList vl = (CssValueList) value;
             h_radius = vl.get(0);

--- a/org/w3c/css/properties/css3/CssBorderBottomRightRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderBottomRightRadius.java
@@ -34,7 +34,7 @@ public class CssBorderBottomRightRadius extends org.w3c.css.properties.css.CssBo
     public CssBorderBottomRightRadius(ApplContext ac, CssExpression expression,
                                       boolean check) throws InvalidParamException {
         setByUser();
-        value = CssBorderRadius.checkBorderCornerRadius(ac, this, expression, check);
+        value = CssBorderRadius.parseBorderCornerRadius(ac, expression, check, this);
         if (value.getType() == CssTypes.CSS_VALUE_LIST) {
             CssValueList vl = (CssValueList) value;
             h_radius = vl.get(0);

--- a/org/w3c/css/properties/css3/CssBorderBottomStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderBottomStyle.java
@@ -33,7 +33,7 @@ public class CssBorderBottomStyle extends org.w3c.css.properties.css.CssBorderBo
             throws InvalidParamException {
         setByUser();
         // here we delegate to BorderWidth implementation
-        value = CssBorderStyle.checkBorderSideStyle(ac, this, expression, check);
+        value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
     }
 
     public CssBorderBottomStyle(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderBottomWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderBottomWidth.java
@@ -33,7 +33,7 @@ public class CssBorderBottomWidth extends org.w3c.css.properties.css.CssBorderBo
             throws InvalidParamException {
         setByUser();
         // here we delegate to BorderWidth implementation
-        value = CssBorderWidth.checkBorderSideWidth(ac, this, expression, check);
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
     }
 
     public CssBorderBottomWidth(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderColor.java
+++ b/org/w3c/css/properties/css3/CssBorderColor.java
@@ -133,8 +133,7 @@ public class CssBorderColor extends org.w3c.css.properties.css.CssBorderColor {
      * Check the border-*-color and returns a value.
      * It makes sense to do it only once for all the sides, so by having the code here.
      */
-    protected static CssValue checkBorderSideColor(ApplContext ac, CssProperty caller, CssExpression expression,
-                                                   boolean check) throws InvalidParamException {
+    protected static CssValue parseBorderSideColor(ApplContext ac, CssExpression expression, boolean check, CssProperty caller) throws InvalidParamException {
 
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);

--- a/org/w3c/css/properties/css3/CssBorderEndEndRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderEndEndRadius.java
@@ -1,0 +1,43 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-end-end-radius
+ */
+public class CssBorderEndEndRadius extends org.w3c.css.properties.css.CssBorderEndEndRadius {
+
+    /**
+     * Create a new CssBorderEndEndRadius
+     */
+    public CssBorderEndEndRadius() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderEndEndRadius
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderEndEndRadius(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        setByUser();
+        value = CssBorderRadius.parseBorderCornerRadius(ac, expression, check, this);
+    }
+
+
+    public CssBorderEndEndRadius(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderEndStartRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderEndStartRadius.java
@@ -1,0 +1,43 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-end-start-radius
+ */
+public class CssBorderEndStartRadius extends org.w3c.css.properties.css.CssBorderEndStartRadius {
+
+    /**
+     * Create a new CssBorderStartStartRadius
+     */
+    public CssBorderEndStartRadius() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderStartStartRadius
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderEndStartRadius(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        setByUser();
+        value = CssBorderRadius.parseBorderCornerRadius(ac, expression, check, this);
+    }
+
+
+    public CssBorderEndStartRadius(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInline.java
+++ b/org/w3c/css/properties/css3/CssBorderInline.java
@@ -1,0 +1,68 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline
+ */
+public class CssBorderInline extends org.w3c.css.properties.css.CssBorderInline {
+
+    /**
+     * Create a new CssBorderInline
+     */
+    public CssBorderInline() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInline
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInline(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
+        ArrayList<CssValue> vl = new ArrayList<>();
+
+        if (values.width != null) {
+            vl.add(values.width);
+        }
+        if (values.style != null) {
+            vl.add(values.style);
+        }
+        if (values.color != null) {
+            vl.add(values.color);
+        }
+        setByUser();
+
+        if (vl.size() == 1) {
+            value = vl.get(0);
+        } else {
+            if (vl.contains(inherit)) {
+                // no need to bail out, multiple inherit value is already checked
+                value = inherit;
+            } else {
+                value = new CssValueList(vl);
+            }
+        }
+    }
+
+
+    public CssBorderInline(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineColor.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineColor.java
@@ -1,0 +1,74 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-color
+ */
+public class CssBorderInlineColor extends org.w3c.css.properties.css.CssBorderInlineColor {
+
+    /**
+     * Create a new CssBorderInlineColor
+     */
+    public CssBorderInlineColor() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssBorderColor.parseBorderSideColor(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssBorderColor.parseBorderSideColor(ac, expression,
+                    false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssBorderInlineColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineEnd.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineEnd.java
@@ -1,0 +1,68 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-end
+ */
+public class CssBorderInlineEnd extends org.w3c.css.properties.css.CssBorderInlineEnd {
+
+    /**
+     * Create a new CssBorderInlineEnd
+     */
+    public CssBorderInlineEnd() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
+        ArrayList<CssValue> vl = new ArrayList<>();
+
+        if (values.width != null) {
+            vl.add(values.width);
+        }
+        if (values.style != null) {
+            vl.add(values.style);
+        }
+        if (values.color != null) {
+            vl.add(values.color);
+        }
+        setByUser();
+
+        if (vl.size() == 1) {
+            value = vl.get(0);
+        } else {
+            if (vl.contains(inherit)) {
+                // no need to bail out, multiple inherit value is already checked
+                value = inherit;
+            } else {
+                value = new CssValueList(vl);
+            }
+        }
+    }
+
+
+    public CssBorderInlineEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineEndColor.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineEndColor.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-end-color
+ */
+public class CssBorderInlineEndColor extends org.w3c.css.properties.css.CssBorderInlineEndColor {
+
+    /**
+     * Create a new CssBorderInlineEndColor
+     */
+    public CssBorderInlineEndColor() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineEndColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderInlineEndColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderColor.parseBorderSideColor(ac, expression, check, this);
+    }
+
+
+    public CssBorderInlineEndColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineEndStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineEndStyle.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-end-style
+ */
+public class CssBorderInlineEndStyle extends org.w3c.css.properties.css.CssBorderInlineEndStyle {
+
+    /**
+     * Create a new CssBorderInlineEndStyle
+     */
+    public CssBorderInlineEndStyle() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineEndStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderInlineEndStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
+    }
+
+
+    public CssBorderInlineEndStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineEndWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineEndWidth.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-end-width
+ */
+public class CssBorderInlineEndWidth extends org.w3c.css.properties.css.CssBorderInlineEndWidth {
+
+    /**
+     * Create a new CssBorderInlineEndWidth
+     */
+    public CssBorderInlineEndWidth() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineEndWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderInlineEndWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
+    }
+
+
+    public CssBorderInlineEndWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineStart.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineStart.java
@@ -1,0 +1,68 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-start
+ */
+public class CssBorderInlineStart extends org.w3c.css.properties.css.CssBorderInlineStart {
+
+    /**
+     * Create a new CssBorderInlineStart
+     */
+    public CssBorderInlineStart() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
+        ArrayList<CssValue> vl = new ArrayList<>();
+
+        if (values.width != null) {
+            vl.add(values.width);
+        }
+        if (values.style != null) {
+            vl.add(values.style);
+        }
+        if (values.color != null) {
+            vl.add(values.color);
+        }
+        setByUser();
+
+        if (vl.size() == 1) {
+            value = vl.get(0);
+        } else {
+            if (vl.contains(inherit)) {
+                // no need to bail out, multiple inherit value is already checked
+                value = inherit;
+            } else {
+                value = new CssValueList(vl);
+            }
+        }
+    }
+
+
+    public CssBorderInlineStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineStartColor.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineStartColor.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-start-color
+ */
+public class CssBorderInlineStartColor extends org.w3c.css.properties.css.CssBorderInlineStartColor {
+
+    /**
+     * Create a new CssBorderInlineStartColor
+     */
+    public CssBorderInlineStartColor() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineStartColor
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderInlineStartColor(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderColor.parseBorderSideColor(ac, expression, check, this);
+    }
+
+
+    public CssBorderInlineStartColor(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineStartStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineStartStyle.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-start-style
+ */
+public class CssBorderInlineStartStyle extends org.w3c.css.properties.css.CssBorderInlineStartStyle {
+
+    /**
+     * Create a new CssBorderInlineStartStyle
+     */
+    public CssBorderInlineStartStyle() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineStartStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderInlineStartStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
+    }
+
+
+    public CssBorderInlineStartStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineStartWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineStartWidth.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-start-width
+ */
+public class CssBorderInlineStartWidth extends org.w3c.css.properties.css.CssBorderInlineStartWidth {
+
+    /**
+     * Create a new CssBorderInlineStartWidth
+     */
+    public CssBorderInlineStartWidth() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineStartWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderInlineStartWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
+    }
+
+
+    public CssBorderInlineStartWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineStyle.java
@@ -1,0 +1,74 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-style
+ */
+public class CssBorderInlineStyle extends org.w3c.css.properties.css.CssBorderInlineStyle {
+
+    /**
+     * Create a new CssBorderInlineStyle
+     */
+    public CssBorderInlineStyle() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineStyle
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineStyle(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssBorderStyle.parseBorderSideStyle(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssBorderStyle.parseBorderSideStyle(ac, expression,
+                    false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssBorderInlineStyle(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderInlineWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderInlineWidth.java
@@ -1,0 +1,74 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-inline-width
+ */
+public class CssBorderInlineWidth extends org.w3c.css.properties.css.CssBorderInlineWidth {
+
+    /**
+     * Create a new CssBorderInlineWidth
+     */
+    public CssBorderInlineWidth() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderInlineWidth
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssBorderInlineWidth(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssBorderWidth.parseBorderSideWidth(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssBorderWidth.parseBorderSideWidth(ac, expression,
+                    false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssBorderInlineWidth(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderLeft.java
+++ b/org/w3c/css/properties/css3/CssBorderLeft.java
@@ -47,7 +47,7 @@ public class CssBorderLeft extends org.w3c.css.properties.css.CssBorderLeft {
      */
     public CssBorderLeft(ApplContext ac, CssExpression expression,
                          boolean check) throws InvalidParamException {
-        CssBorder.SideValues values = CssBorder.checkBorderSide(ac, this, expression, check);
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
         CssValueList vl = new CssValueList();
 
         if (values.width != null) {

--- a/org/w3c/css/properties/css3/CssBorderLeftColor.java
+++ b/org/w3c/css/properties/css3/CssBorderLeftColor.java
@@ -31,7 +31,7 @@ public class CssBorderLeftColor extends org.w3c.css.properties.css.CssBorderLeft
      */
     public CssBorderLeftColor(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
-        value = CssBorderColor.checkBorderSideColor(ac, this, expression, check);
+        value = CssBorderColor.parseBorderSideColor(ac, expression, check, this);
     }
 
     public CssBorderLeftColor(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderLeftStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderLeftStyle.java
@@ -33,7 +33,7 @@ public class CssBorderLeftStyle extends org.w3c.css.properties.css.CssBorderLeft
             throws InvalidParamException {
         setByUser();
         // here we delegate to BorderWidth implementation
-        value = CssBorderStyle.checkBorderSideStyle(ac, this, expression, check);
+        value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
     }
 
     public CssBorderLeftStyle(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderLeftWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderLeftWidth.java
@@ -33,7 +33,7 @@ public class CssBorderLeftWidth extends org.w3c.css.properties.css.CssBorderLeft
             throws InvalidParamException {
         setByUser();
         // here we delegate to BorderWidth implementation
-        value = CssBorderWidth.checkBorderSideWidth(ac, this, expression, check);
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
     }
 
     public CssBorderLeftWidth(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderRadius.java
@@ -177,8 +177,7 @@ public class CssBorderRadius extends org.w3c.css.properties.css.CssBorderRadius 
      * Check the border-*-radius and returns a value.
      * It makes sense to do it only once for all the corners, so by having the code here.
      */
-    public static CssValue checkBorderCornerRadius(ApplContext ac, CssProperty caller,
-                                                   CssExpression expression, boolean check)
+    public static CssValue parseBorderCornerRadius(ApplContext ac, CssExpression expression, boolean check, CssProperty caller)
             throws InvalidParamException {
 
         if (check && expression.getCount() > 2) {
@@ -204,7 +203,7 @@ public class CssBorderRadius extends org.w3c.css.properties.css.CssBorderRadius 
                     res.add(val);
                     break;
                 case CssTypes.CSS_IDENT:
-                    if (inherit.equals((val))) {
+                    if (inherit.equals(val)) {
                         if (res.size() > 0) {
                             throw new InvalidParamException("unrecognize", ac);
                         }

--- a/org/w3c/css/properties/css3/CssBorderRight.java
+++ b/org/w3c/css/properties/css3/CssBorderRight.java
@@ -46,7 +46,7 @@ public class CssBorderRight extends org.w3c.css.properties.css.CssBorderRight {
      */
     public CssBorderRight(ApplContext ac, CssExpression expression,
                           boolean check) throws InvalidParamException {
-        CssBorder.SideValues values = CssBorder.checkBorderSide(ac, this, expression, check);
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
         if (values.width != null) {
             _width = new CssBorderRightWidth();
             _width.setByUser();

--- a/org/w3c/css/properties/css3/CssBorderRightColor.java
+++ b/org/w3c/css/properties/css3/CssBorderRightColor.java
@@ -31,7 +31,7 @@ public class CssBorderRightColor extends org.w3c.css.properties.css.CssBorderRig
      */
     public CssBorderRightColor(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
-        value = CssBorderColor.checkBorderSideColor(ac, this, expression, check);
+        value = CssBorderColor.parseBorderSideColor(ac, expression, check, this);
     }
 
     public CssBorderRightColor(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderRightStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderRightStyle.java
@@ -33,7 +33,7 @@ public class CssBorderRightStyle extends org.w3c.css.properties.css.CssBorderRig
             throws InvalidParamException {
         setByUser();
         // here we delegate to BorderWidth implementation
-        value = CssBorderStyle.checkBorderSideStyle(ac, this, expression, check);
+        value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
     }
 
     public CssBorderRightStyle(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderRightWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderRightWidth.java
@@ -33,7 +33,7 @@ public class CssBorderRightWidth extends org.w3c.css.properties.css.CssBorderRig
             throws InvalidParamException {
         setByUser();
         // here we delegate to BorderWidth implementation
-        value = CssBorderWidth.checkBorderSideWidth(ac, this, expression, check);
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
     }
 
     public CssBorderRightWidth(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderStartEndRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderStartEndRadius.java
@@ -1,0 +1,43 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-start-end-radius
+ */
+public class CssBorderStartEndRadius extends org.w3c.css.properties.css.CssBorderStartEndRadius {
+
+    /**
+     * Create a new CssBorderStartStartRadius
+     */
+    public CssBorderStartEndRadius() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderStartStartRadius
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderStartEndRadius(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        setByUser();
+        value = CssBorderRadius.parseBorderCornerRadius(ac, expression, check, this);
+    }
+
+
+    public CssBorderStartEndRadius(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderStartStartRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderStartStartRadius.java
@@ -1,0 +1,43 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-border-start-start-radius
+ */
+public class CssBorderStartStartRadius extends org.w3c.css.properties.css.CssBorderStartStartRadius {
+
+    /**
+     * Create a new CssBorderStartStartRadius
+     */
+    public CssBorderStartStartRadius() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssBorderStartStartRadius
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssBorderStartStartRadius(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        setByUser();
+        value = CssBorderRadius.parseBorderCornerRadius(ac, expression, check, this);
+    }
+
+
+    public CssBorderStartStartRadius(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssBorderStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderStyle.java
@@ -156,8 +156,7 @@ public class CssBorderStyle extends org.w3c.css.properties.css.CssBorderStyle {
      * Check the border-*-style and returns a value.
      * It makes sense to do it only once for all the sides, so by having the code here.
      */
-    protected static CssValue checkBorderSideStyle(ApplContext ac, CssProperty caller, CssExpression expression,
-                                                   boolean check) throws InvalidParamException {
+    protected static CssValue parseBorderSideStyle(ApplContext ac, CssExpression expression, boolean check, CssProperty caller) throws InvalidParamException {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);
         }

--- a/org/w3c/css/properties/css3/CssBorderTop.java
+++ b/org/w3c/css/properties/css3/CssBorderTop.java
@@ -49,7 +49,7 @@ public class CssBorderTop extends org.w3c.css.properties.css.CssBorderTop {
      */
     public CssBorderTop(ApplContext ac, CssExpression expression,
                         boolean check) throws InvalidParamException {
-        CssBorder.SideValues values = CssBorder.checkBorderSide(ac, this, expression, check);
+        CssBorder.SideValues values = CssBorder.parseBorderSide(ac, expression, check, this);
         if (values.width != null) {
             _width = new CssBorderTopWidth();
             _width.setByUser();

--- a/org/w3c/css/properties/css3/CssBorderTopColor.java
+++ b/org/w3c/css/properties/css3/CssBorderTopColor.java
@@ -31,7 +31,7 @@ public class CssBorderTopColor extends org.w3c.css.properties.css.CssBorderTopCo
      */
     public CssBorderTopColor(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
-        value = CssBorderColor.checkBorderSideColor(ac, this, expression, check);
+        value = CssBorderColor.parseBorderSideColor(ac, expression, check, this);
     }
 
     public CssBorderTopColor(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderTopLeftRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderTopLeftRadius.java
@@ -33,7 +33,7 @@ public class CssBorderTopLeftRadius extends org.w3c.css.properties.css.CssBorder
     public CssBorderTopLeftRadius(ApplContext ac, CssExpression expression,
                                   boolean check) throws InvalidParamException {
         setByUser();
-        value = CssBorderRadius.checkBorderCornerRadius(ac, this, expression, check);
+        value = CssBorderRadius.parseBorderCornerRadius(ac, expression, check, this);
         if (value.getType() == CssTypes.CSS_VALUE_LIST) {
             CssValueList vl = (CssValueList) value;
             h_radius = vl.get(0);

--- a/org/w3c/css/properties/css3/CssBorderTopRightRadius.java
+++ b/org/w3c/css/properties/css3/CssBorderTopRightRadius.java
@@ -33,7 +33,7 @@ public class CssBorderTopRightRadius extends org.w3c.css.properties.css.CssBorde
     public CssBorderTopRightRadius(ApplContext ac, CssExpression expression,
                                    boolean check) throws InvalidParamException {
         setByUser();
-        value = CssBorderRadius.checkBorderCornerRadius(ac, this, expression, check);
+        value = CssBorderRadius.parseBorderCornerRadius(ac, expression, check, this);
         if (value.getType() == CssTypes.CSS_VALUE_LIST) {
             CssValueList vl = (CssValueList) value;
             h_radius = vl.get(0);

--- a/org/w3c/css/properties/css3/CssBorderTopStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderTopStyle.java
@@ -33,7 +33,7 @@ public class CssBorderTopStyle extends org.w3c.css.properties.css.CssBorderTopSt
             throws InvalidParamException {
         setByUser();
         // here we delegate to BorderWidth implementation
-        value = CssBorderStyle.checkBorderSideStyle(ac, this, expression, check);
+        value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
     }
 
     public CssBorderTopStyle(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderTopWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderTopWidth.java
@@ -33,7 +33,7 @@ public class CssBorderTopWidth extends org.w3c.css.properties.css.CssBorderTopWi
             throws InvalidParamException {
         setByUser();
         // here we delegate to BorderWidth implementation
-        value = CssBorderWidth.checkBorderSideWidth(ac, this, expression, check);
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
     }
 
     public CssBorderTopWidth(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssBorderWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderWidth.java
@@ -166,8 +166,9 @@ public class CssBorderWidth extends org.w3c.css.properties.css.CssBorderWidth {
      * Check the border-*-width and returns a value.
      * It makes sense to do it only once for all the sides, so by having the code here.
      */
-    protected static CssValue checkBorderSideWidth(ApplContext ac, CssProperty caller, CssExpression expression,
-                                                   boolean check) throws InvalidParamException {
+    protected static CssValue parseBorderSideWidth(ApplContext ac, CssExpression expression,
+                                                   boolean check, CssProperty caller)
+            throws InvalidParamException {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);
         }

--- a/org/w3c/css/properties/css3/CssBottom.java
+++ b/org/w3c/css/properties/css3/CssBottom.java
@@ -32,7 +32,7 @@ public class CssBottom extends org.w3c.css.properties.css.CssBottom {
      */
     public CssBottom(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
-        value = CssTop.checkValue(ac, expression, check, this);
+        value = CssTop.parseTop(ac, expression, check, this);
 
     }
 

--- a/org/w3c/css/properties/css3/CssBoxSizing.java
+++ b/org/w3c/css/properties/css3/CssBoxSizing.java
@@ -13,7 +13,7 @@ import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2015/CR-css-ui-3-20150707/#propdef-box-sizing
+ * @spec https://www.w3.org/TR/2021/WD-css-sizing-3-20210317/#propdef-box-sizing
  */
 public class CssBoxSizing extends org.w3c.css.properties.css.CssBoxSizing {
 

--- a/org/w3c/css/properties/css3/CssClear.java
+++ b/org/w3c/css/properties/css3/CssClear.java
@@ -14,6 +14,7 @@ import org.w3c.css.values.CssValue;
 
 /**
  * @spec http://www.w3.org/TR/2015/WD-css-page-floats-3-20150915/#propdef-clear
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#float-clear
  */
 public class CssClear extends org.w3c.css.properties.css.CssClear {
 

--- a/org/w3c/css/properties/css3/CssColumnRuleStyle.java
+++ b/org/w3c/css/properties/css3/CssColumnRuleStyle.java
@@ -37,7 +37,7 @@ public class CssColumnRuleStyle extends org.w3c.css.properties.css.CssColumnRule
                               boolean check) throws InvalidParamException {
 
         setByUser();
-        value = CssBorderStyle.checkBorderSideStyle(ac, this, expression, check);
+        value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
     }
 
     public CssColumnRuleStyle(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssColumnRuleWidth.java
+++ b/org/w3c/css/properties/css3/CssColumnRuleWidth.java
@@ -36,7 +36,7 @@ public class CssColumnRuleWidth extends org.w3c.css.properties.css.CssColumnRule
                               boolean check) throws InvalidParamException {
 
         setByUser();
-        value = CssBorderWidth.checkBorderSideWidth(ac, this, expression, check);
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
     }
 
     public CssColumnRuleWidth(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssHeight.java
+++ b/org/w3c/css/properties/css3/CssHeight.java
@@ -7,39 +7,12 @@ package org.w3c.css.properties.css3;
 
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
-import org.w3c.css.values.CssCheckableValue;
 import org.w3c.css.values.CssExpression;
-import org.w3c.css.values.CssIdent;
-import org.w3c.css.values.CssTypes;
-import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2007/WD-css3-box-20070809/#height
- * @spec https://www.w3.org/TR/2016/WD-css-sizing-3-20160512/#width-height-keywords
+ * @spec https://www.w3.org/TR/2021/WD-css-sizing-3-20210317/#propdef-height
  */
 public class CssHeight extends org.w3c.css.properties.css.CssHeight {
-
-    public static final CssIdent[] allowed_values;
-
-    static {
-        // fill to fit-content from css-sizing
-        String[] _allowed_values = {"auto", "fill", "max-content", "min-content", "fit-content"};
-
-        allowed_values = new CssIdent[_allowed_values.length];
-        int i = 0;
-        for (String s : _allowed_values) {
-            allowed_values[i++] = CssIdent.getIdent(s);
-        }
-    }
-
-    public static CssIdent getAllowedIdent(CssIdent ident) {
-        for (CssIdent id : allowed_values) {
-            if (id.equals(ident)) {
-                return id;
-            }
-        }
-        return null;
-    }
 
     /**
      * Create a new CssHeight
@@ -52,8 +25,7 @@ public class CssHeight extends org.w3c.css.properties.css.CssHeight {
      * Create a new CssHeight.
      *
      * @param expression The expression for this property
-     * @throws org.w3c.css.util.InvalidParamException
-     *          Values are incorrect
+     * @throws org.w3c.css.util.InvalidParamException Values are incorrect
      */
     public CssHeight(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
@@ -61,38 +33,8 @@ public class CssHeight extends org.w3c.css.properties.css.CssHeight {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);
         }
-
-        CssValue val = expression.getValue();
-
         setByUser();
-
-        switch (val.getType()) {
-            case CssTypes.CSS_IDENT:
-                if (inherit.equals(val)) {
-                    value = inherit;
-                } else {
-                    CssIdent id = getAllowedIdent((CssIdent) val);
-                    if (id != null) {
-                        value = id;
-                    } else {
-                        throw new InvalidParamException("unrecognize", ac);
-                    }
-                }
-                break;
-            case CssTypes.CSS_NUMBER:
-                val.getCheckableValue().checkEqualsZero(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_LENGTH:
-            case CssTypes.CSS_PERCENTAGE:
-                CssCheckableValue l = val.getCheckableValue();
-                l.checkPositiveness(ac, this);
-                value = val;
-                break;
-            default:
-                throw new InvalidParamException("value", val, getPropertyName(), ac);
-        }
-        expression.next();
+        value = CssWidth.parseWidth(ac, expression, this);
     }
 
     public CssHeight(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssInlineSize.java
+++ b/org/w3c/css/properties/css3/CssInlineSize.java
@@ -1,0 +1,47 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-inline-size
+ */
+public class CssInlineSize extends org.w3c.css.properties.css.CssInlineSize {
+
+    /**
+     * Create a new CssInlineSize
+     */
+    public CssInlineSize() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssInlineSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInlineSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+
+        value = CssWidth.parseWidth(ac, expression, this);
+
+    }
+
+    public CssInlineSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+}
+

--- a/org/w3c/css/properties/css3/CssInset.java
+++ b/org/w3c/css/properties/css3/CssInset.java
@@ -1,0 +1,72 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-inset
+ */
+public class CssInset extends org.w3c.css.properties.css.CssInset {
+
+    /**
+     * Create a new CssInset
+     */
+    public CssInset() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssInset
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInset(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 4) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        while(!expression.end()) {
+            v.add(CssTop.parseTop(ac, expression, false, this));
+            if (op != SPACE) {
+                throw new InvalidParamException("operator",
+                        Character.toString(op), ac);
+            }
+        }
+
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssInset(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssInsetBlock.java
+++ b/org/w3c/css/properties/css3/CssInsetBlock.java
@@ -1,0 +1,73 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-inset-block
+ */
+public class CssInsetBlock extends org.w3c.css.properties.css.CssInsetBlock {
+
+    /**
+     * Create a new CssInsetBlock
+     */
+    public CssInsetBlock() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssInsetBlock
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInsetBlock(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssTop.parseTop(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssTop.parseTop(ac, expression, false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssInsetBlock(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssInsetBlockEnd.java
+++ b/org/w3c/css/properties/css3/CssInsetBlockEnd.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-inset-block-end
+ */
+public class CssInsetBlockEnd extends org.w3c.css.properties.css.CssInsetBlockEnd {
+
+    /**
+     * Create a new CssInsetBlockEnd
+     */
+    public CssInsetBlockEnd() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssInsetBlockEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssInsetBlockEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssTop.parseTop(ac, expression, check, this);
+    }
+
+
+    public CssInsetBlockEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssInsetBlockStart.java
+++ b/org/w3c/css/properties/css3/CssInsetBlockStart.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-inset-block-start
+ */
+public class CssInsetBlockStart extends org.w3c.css.properties.css.CssInsetBlockStart {
+
+    /**
+     * Create a new CssInsetBlockStart
+     */
+    public CssInsetBlockStart() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssInsetBlockStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssInsetBlockStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssTop.parseTop(ac, expression, check, this);
+    }
+
+
+    public CssInsetBlockStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssInsetInline.java
+++ b/org/w3c/css/properties/css3/CssInsetInline.java
@@ -1,0 +1,73 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-inset-inline
+ */
+public class CssInsetInline extends org.w3c.css.properties.css.CssInsetInline {
+
+    /**
+     * Create a new CssInsetInline
+     */
+    public CssInsetInline() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssInsetInline
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssInsetInline(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssTop.parseTop(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssTop.parseTop(ac, expression, false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssInsetInline(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssInsetInlineEnd.java
+++ b/org/w3c/css/properties/css3/CssInsetInlineEnd.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-inset-inline-end
+ */
+public class CssInsetInlineEnd extends org.w3c.css.properties.css.CssInsetInlineEnd {
+
+    /**
+     * Create a new CssInsetInlineEnd
+     */
+    public CssInsetInlineEnd() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssInsetInlineEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssInsetInlineEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssTop.parseTop(ac, expression, check, this);
+    }
+
+
+    public CssInsetInlineEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssInsetInlineStart.java
+++ b/org/w3c/css/properties/css3/CssInsetInlineStart.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-inset-inline-start
+ */
+public class CssInsetInlineStart extends org.w3c.css.properties.css.CssInsetInlineStart {
+
+    /**
+     * Create a new CssInsetInlineStart
+     */
+    public CssInsetInlineStart() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssInsetInlineStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssInsetInlineStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssTop.parseTop(ac, expression, check, this);
+    }
+
+
+    public CssInsetInlineStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssLeft.java
+++ b/org/w3c/css/properties/css3/CssLeft.java
@@ -32,7 +32,7 @@ public class CssLeft extends org.w3c.css.properties.css.CssLeft {
      */
     public CssLeft(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
-        value = CssTop.checkValue(ac, expression, check, this);
+        value = CssTop.parseTop(ac, expression, check, this);
 
     }
 

--- a/org/w3c/css/properties/css3/CssMargin.java
+++ b/org/w3c/css/properties/css3/CssMargin.java
@@ -155,9 +155,9 @@ public class CssMargin extends org.w3c.css.properties.css.CssMargin {
 
     // for use by individual margin-* properties
 
-    protected static CssValue checkValue(ApplContext ac,
-                                         CssExpression expression,
-                                         boolean check, CssProperty caller)
+    protected static CssValue parseMargin(ApplContext ac,
+                                          CssExpression expression,
+                                          boolean check, CssProperty caller)
             throws InvalidParamException {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);

--- a/org/w3c/css/properties/css3/CssMarginBlock.java
+++ b/org/w3c/css/properties/css3/CssMarginBlock.java
@@ -1,0 +1,73 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-margin-block
+ */
+public class CssMarginBlock extends org.w3c.css.properties.css.CssMarginBlock {
+
+    /**
+     * Create a new CssMarginBlock
+     */
+    public CssMarginBlock() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMarginBlock
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMarginBlock(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssMargin.parseMargin(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssMargin.parseMargin(ac, expression, false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (inherit.equals(v.get(0)) && inherit.equals(v.get(1))) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssMarginBlock(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssMarginBlock.java
+++ b/org/w3c/css/properties/css3/CssMarginBlock.java
@@ -56,7 +56,7 @@ public class CssMarginBlock extends org.w3c.css.properties.css.CssMarginBlock {
         if (v.size() == 1) {
             value = v.get(0);
         } else {
-            if (inherit.equals(v.get(0)) && inherit.equals(v.get(1))) {
+            if (v.contains(inherit)) {
                 throw new InvalidParamException("value", inherit.toString(),
                         getPropertyName(), ac);
             }

--- a/org/w3c/css/properties/css3/CssMarginBlockEnd.java
+++ b/org/w3c/css/properties/css3/CssMarginBlockEnd.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-margin-block-end
+ */
+public class CssMarginBlockEnd extends org.w3c.css.properties.css.CssMarginBlockEnd {
+
+    /**
+     * Create a new CssMarginBlockEnd
+     */
+    public CssMarginBlockEnd() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMarginBlockEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssMarginBlockEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssMargin.parseMargin(ac, expression, check, this);
+    }
+
+
+    public CssMarginBlockEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssMarginBlockStart.java
+++ b/org/w3c/css/properties/css3/CssMarginBlockStart.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-margin-block-start
+ */
+public class CssMarginBlockStart extends org.w3c.css.properties.css.CssMarginBlockStart {
+
+    /**
+     * Create a new CssMarginBlockStart
+     */
+    public CssMarginBlockStart() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMarginBlockStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssMarginBlockStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssMargin.parseMargin(ac, expression, check, this);
+    }
+
+
+    public CssMarginBlockStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssMarginBottom.java
+++ b/org/w3c/css/properties/css3/CssMarginBottom.java
@@ -45,7 +45,7 @@ public class CssMarginBottom extends org.w3c.css.properties.css.CssMarginBottom 
     public CssMarginBottom(ApplContext ac, CssExpression expression,
                            boolean check) throws InvalidParamException {
         setByUser();
-        value = CssMargin.checkValue(ac, expression, check, this);
+        value = CssMargin.parseMargin(ac, expression, check, this);
     }
 
 }

--- a/org/w3c/css/properties/css3/CssMarginInline.java
+++ b/org/w3c/css/properties/css3/CssMarginInline.java
@@ -1,0 +1,73 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-margin-inline
+ */
+public class CssMarginInline extends org.w3c.css.properties.css.CssMarginInline {
+
+    /**
+     * Create a new CssMarginInline
+     */
+    public CssMarginInline() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMarginInline
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMarginInline(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssMargin.parseMargin(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssMargin.parseMargin(ac, expression, false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssMarginInline(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssMarginInlineEnd.java
+++ b/org/w3c/css/properties/css3/CssMarginInlineEnd.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-margin-inline-end
+ */
+public class CssMarginInlineEnd extends org.w3c.css.properties.css.CssMarginInlineEnd {
+
+    /**
+     * Create a new CssMarginInlineEnd
+     */
+    public CssMarginInlineEnd() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMarginInlineEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssMarginInlineEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssMargin.parseMargin(ac, expression, check, this);
+    }
+
+
+    public CssMarginInlineEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssMarginInlineStart.java
+++ b/org/w3c/css/properties/css3/CssMarginInlineStart.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-margin-inline-start
+ */
+public class CssMarginInlineStart extends org.w3c.css.properties.css.CssMarginInlineStart {
+
+    /**
+     * Create a new CssMarginInlineStart
+     */
+    public CssMarginInlineStart() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMarginInlineStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssMarginInlineStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssMargin.parseMargin(ac, expression, check, this);
+    }
+
+
+    public CssMarginInlineStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssMarginLeft.java
+++ b/org/w3c/css/properties/css3/CssMarginLeft.java
@@ -45,7 +45,7 @@ public class CssMarginLeft extends org.w3c.css.properties.css.CssMarginLeft {
     public CssMarginLeft(ApplContext ac, CssExpression expression,
                          boolean check) throws InvalidParamException {
         setByUser();
-        value = CssMargin.checkValue(ac, expression, check, this);
+        value = CssMargin.parseMargin(ac, expression, check, this);
     }
 
 }

--- a/org/w3c/css/properties/css3/CssMarginRight.java
+++ b/org/w3c/css/properties/css3/CssMarginRight.java
@@ -45,6 +45,6 @@ public class CssMarginRight extends org.w3c.css.properties.css.CssMarginRight {
     public CssMarginRight(ApplContext ac, CssExpression expression,
                           boolean check) throws InvalidParamException {
         setByUser();
-        value = CssMargin.checkValue(ac, expression, check, this);
+        value = CssMargin.parseMargin(ac, expression, check, this);
     }
 }

--- a/org/w3c/css/properties/css3/CssMarginTop.java
+++ b/org/w3c/css/properties/css3/CssMarginTop.java
@@ -45,6 +45,6 @@ public class CssMarginTop extends org.w3c.css.properties.css.CssMarginTop {
     public CssMarginTop(ApplContext ac, CssExpression expression,
                         boolean check) throws InvalidParamException {
         setByUser();
-        value = CssMargin.checkValue(ac, expression, check, this);
+        value = CssMargin.parseMargin(ac, expression, check, this);
     }
 }

--- a/org/w3c/css/properties/css3/CssMaxBlockSize.java
+++ b/org/w3c/css/properties/css3/CssMaxBlockSize.java
@@ -1,0 +1,47 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec  https://drafts.csswg.org/css-logical-1/#propdef-max-block-size retrieved 20210723 (no comment...)
+ */
+public class CssMaxBlockSize extends org.w3c.css.properties.css.CssMaxBlockSize {
+
+    /**
+     * Create a new CssMaxBlockSize
+     */
+    public CssMaxBlockSize() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMaxBlockSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMaxBlockSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+
+        value = CssMaxWidth.parseMaxWidth(ac, expression, this);
+
+    }
+
+    public CssMaxBlockSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+}
+

--- a/org/w3c/css/properties/css3/CssMaxHeight.java
+++ b/org/w3c/css/properties/css3/CssMaxHeight.java
@@ -7,39 +7,12 @@ package org.w3c.css.properties.css3;
 
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
-import org.w3c.css.values.CssCheckableValue;
 import org.w3c.css.values.CssExpression;
-import org.w3c.css.values.CssIdent;
-import org.w3c.css.values.CssTypes;
-import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2007/WD-css3-box-20070809/#max-height
- * @spec https://www.w3.org/TR/2016/WD-css-sizing-3-20160512/#width-height-keywords
+ * @spec https://www.w3.org/TR/2021/WD-css-sizing-3-20210317/#propdef-max-height
  */
 public class CssMaxHeight extends org.w3c.css.properties.css.CssMaxHeight {
-
-    public static final CssIdent[] allowed_values;
-
-    static {
-        // fill to fit-content from css-sizing
-        String[] _allowed_values = {"none", "fill", "max-content", "min-content", "fit-content"};
-
-        allowed_values = new CssIdent[_allowed_values.length];
-        int i = 0;
-        for (String s : _allowed_values) {
-            allowed_values[i++] = CssIdent.getIdent(s);
-        }
-    }
-
-    public static CssIdent getAllowedIdent(CssIdent ident) {
-        for (CssIdent id : allowed_values) {
-            if (id.equals(ident)) {
-                return id;
-            }
-        }
-        return null;
-    }
 
     /**
      * Create a new CssMaxHeight
@@ -60,39 +33,8 @@ public class CssMaxHeight extends org.w3c.css.properties.css.CssMaxHeight {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);
         }
-
-        CssValue val = expression.getValue();
-
         setByUser();
-
-        switch (val.getType()) {
-            case CssTypes.CSS_NUMBER:
-                val.getCheckableValue().checkEqualsZero(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_LENGTH:
-            case CssTypes.CSS_PERCENTAGE:
-                CssCheckableValue length = val.getCheckableValue();
-                length.checkPositiveness(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_IDENT:
-                if (inherit.equals(val)) {
-                    value = inherit;
-                } else {
-                    CssIdent id = getAllowedIdent((CssIdent) val);
-                    if (id != null) {
-                        value = id;
-                    } else {
-                        throw new InvalidParamException("unrecognize", ac);
-                    }
-                }
-                break;
-            default:
-                throw new InvalidParamException("value", expression.getValue(),
-                        getPropertyName(), ac);
-        }
-        expression.next();
+        value = CssMaxWidth.parseMaxWidth(ac, expression, this);
     }
 
     public CssMaxHeight(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssMaxInlineSize.java
+++ b/org/w3c/css/properties/css3/CssMaxInlineSize.java
@@ -1,0 +1,47 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://drafts.csswg.org/css-logical-1/#propdef-max-inline-size retrieved 20210723 (no comment...)
+ */
+public class CssMaxInlineSize extends org.w3c.css.properties.css.CssMinInlineSize {
+
+    /**
+     * Create a new CssMaxInlineSize
+     */
+    public CssMaxInlineSize() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMaxInlineSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMaxInlineSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+
+        value = CssMaxWidth.parseMaxWidth(ac, expression, this);
+
+    }
+
+    public CssMaxInlineSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+}
+

--- a/org/w3c/css/properties/css3/CssMaxWidth.java
+++ b/org/w3c/css/properties/css3/CssMaxWidth.java
@@ -10,21 +10,20 @@ import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssCheckableValue;
 import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssFunction;
 import org.w3c.css.values.CssIdent;
 import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2007/WD-css3-box-20070809/#max-width
- * @spec https://www.w3.org/TR/2016/WD-css-sizing-3-20160512/#width-height-keywords
+ * @spec https://www.w3.org/TR/2021/WD-css-sizing-3-20210317/#propdef-max-width
  */
 public class CssMaxWidth extends org.w3c.css.properties.css.CssMaxWidth {
 
     public static final CssIdent[] allowed_values;
-
+    public static final String fit_content_func = "fit-content";
     static {
-        // fill to fit-content from css-sizing
-        String[] _allowed_values = {"none", "fill", "max-content", "min-content", "fit-content"};
+        String[] _allowed_values = {"none", "max-content", "min-content"};
 
         allowed_values = new CssIdent[_allowed_values.length];
         int i = 0;
@@ -53,8 +52,7 @@ public class CssMaxWidth extends org.w3c.css.properties.css.CssMaxWidth {
      * Creates a new CssMaxWidth
      *
      * @param expression The expression for this property
-     * @throws org.w3c.css.util.InvalidParamException
-     *          Expressions are incorrect
+     * @throws org.w3c.css.util.InvalidParamException Expressions are incorrect
      */
     public CssMaxWidth(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
@@ -87,6 +85,9 @@ public class CssMaxWidth extends org.w3c.css.properties.css.CssMaxWidth {
                 length.checkPositiveness(ac, caller);
                 v = val;
                 break;
+            case CssTypes.CSS_FUNCTION:
+                v = parseFunctionValue(ac, val, caller);
+                break;
             case CssTypes.CSS_IDENT:
                 if (inherit.equals(val)) {
                     v = inherit;
@@ -105,6 +106,35 @@ public class CssMaxWidth extends org.w3c.css.properties.css.CssMaxWidth {
         }
         expression.next();
         return v;
+    }
+    protected static CssValue parseFunctionValue(ApplContext ac, CssValue value,
+                                                 CssProperty caller)
+            throws InvalidParamException
+    {
+        CssFunction function = (CssFunction) value;
+        if (!fit_content_func.equalsIgnoreCase(function.getName())) {
+            throw new InvalidParamException("value", value.toString(),
+                    caller.getPropertyName(), ac);
+        }
+        CssExpression expression = function.getParameters();
+        if (expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        CssValue val = expression.getValue();
+        switch (val.getType()) {
+            case CssTypes.CSS_NUMBER:
+                val.getCheckableValue().checkEqualsZero(ac, caller);
+                break;
+            case CssTypes.CSS_LENGTH:
+            case CssTypes.CSS_PERCENTAGE:
+                CssCheckableValue l = val.getCheckableValue();
+                l.checkPositiveness(ac, caller);
+                break;
+            default:
+                throw new InvalidParamException("value", expression.getValue(),
+                        caller.getPropertyName(), ac);
+        }
+        return value;
     }
 }
 

--- a/org/w3c/css/properties/css3/CssMaxWidth.java
+++ b/org/w3c/css/properties/css3/CssMaxWidth.java
@@ -17,14 +17,17 @@ import org.w3c.css.values.CssValue;
 
 /**
  * @spec https://www.w3.org/TR/2021/WD-css-sizing-3-20210317/#propdef-max-width
+ * @spec https://www.w3.org/TR/2021/WD-css-sizing-4-20210520/#sizing-values
  */
 public class CssMaxWidth extends org.w3c.css.properties.css.CssMaxWidth {
 
     public static final CssIdent[] allowed_values;
     public static final String fit_content_func = "fit-content";
-    static {
-        String[] _allowed_values = {"none", "max-content", "min-content"};
 
+    static {
+        String[] _allowed_values = {"none", "max-content", "min-content",
+                // following from sizing-4
+                "stretch", "fit-content", "contain"};
         allowed_values = new CssIdent[_allowed_values.length];
         int i = 0;
         for (String s : _allowed_values) {
@@ -107,10 +110,10 @@ public class CssMaxWidth extends org.w3c.css.properties.css.CssMaxWidth {
         expression.next();
         return v;
     }
+
     protected static CssValue parseFunctionValue(ApplContext ac, CssValue value,
                                                  CssProperty caller)
-            throws InvalidParamException
-    {
+            throws InvalidParamException {
         CssFunction function = (CssFunction) value;
         if (!fit_content_func.equalsIgnoreCase(function.getName())) {
             throw new InvalidParamException("value", value.toString(),

--- a/org/w3c/css/properties/css3/CssMaxWidth.java
+++ b/org/w3c/css/properties/css3/CssMaxWidth.java
@@ -5,6 +5,7 @@
 // Please first read the full copyright statement in file COPYRIGHT.html
 package org.w3c.css.properties.css3;
 
+import org.w3c.css.properties.css.CssProperty;
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssCheckableValue;
@@ -60,39 +61,8 @@ public class CssMaxWidth extends org.w3c.css.properties.css.CssMaxWidth {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);
         }
-
-        CssValue val = expression.getValue();
-
         setByUser();
-
-        switch (val.getType()) {
-            case CssTypes.CSS_NUMBER:
-                val.getCheckableValue().checkEqualsZero(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_LENGTH:
-            case CssTypes.CSS_PERCENTAGE:
-                CssCheckableValue length = val.getCheckableValue();
-                length.checkPositiveness(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_IDENT:
-                if (inherit.equals(val)) {
-                    value = inherit;
-                } else {
-                    CssIdent id = getAllowedIdent((CssIdent) val);
-                    if (id != null) {
-                        value = id;
-                    } else {
-                        throw new InvalidParamException("unrecognize", ac);
-                    }
-                }
-                break;
-            default:
-                throw new InvalidParamException("value", expression.getValue(),
-                        getPropertyName(), ac);
-        }
-        expression.next();
+        value = parseMaxWidth(ac, expression, this);
     }
 
     public CssMaxWidth(ApplContext ac, CssExpression expression)
@@ -100,5 +70,41 @@ public class CssMaxWidth extends org.w3c.css.properties.css.CssMaxWidth {
         this(ac, expression, false);
     }
 
+    public static CssValue parseMaxWidth(ApplContext ac, CssExpression expression,
+                                         CssProperty caller)
+            throws InvalidParamException {
+        CssValue val = expression.getValue();
+        CssValue v = null;
+
+        switch (val.getType()) {
+            case CssTypes.CSS_NUMBER:
+                val.getCheckableValue().checkEqualsZero(ac, caller);
+                v = val;
+                break;
+            case CssTypes.CSS_LENGTH:
+            case CssTypes.CSS_PERCENTAGE:
+                CssCheckableValue length = val.getCheckableValue();
+                length.checkPositiveness(ac, caller);
+                v = val;
+                break;
+            case CssTypes.CSS_IDENT:
+                if (inherit.equals(val)) {
+                    v = inherit;
+                } else {
+                    CssIdent id = getAllowedIdent((CssIdent) val);
+                    if (id != null) {
+                        v = id;
+                    } else {
+                        throw new InvalidParamException("unrecognize", ac);
+                    }
+                }
+                break;
+            default:
+                throw new InvalidParamException("value", expression.getValue(),
+                        caller.getPropertyName(), ac);
+        }
+        expression.next();
+        return v;
+    }
 }
 

--- a/org/w3c/css/properties/css3/CssMinBlockSize.java
+++ b/org/w3c/css/properties/css3/CssMinBlockSize.java
@@ -1,0 +1,47 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec  https://drafts.csswg.org/css-logical-1/#propdef-min-block-size retrieved 20210723 (no comment...)
+ */
+public class CssMinBlockSize extends org.w3c.css.properties.css.CssMinBlockSize {
+
+    /**
+     * Create a new CssMinBlockSize
+     */
+    public CssMinBlockSize() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMinBlockSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMinBlockSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+
+        value = CssMinWidth.parseMinWidth(ac, expression, this);
+
+    }
+
+    public CssMinBlockSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+}
+

--- a/org/w3c/css/properties/css3/CssMinHeight.java
+++ b/org/w3c/css/properties/css3/CssMinHeight.java
@@ -7,40 +7,12 @@ package org.w3c.css.properties.css3;
 
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
-import org.w3c.css.values.CssCheckableValue;
 import org.w3c.css.values.CssExpression;
-import org.w3c.css.values.CssIdent;
-import org.w3c.css.values.CssTypes;
-import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2007/WD-css3-box-20070809/#min-height
- * @spec https://www.w3.org/TR/2016/CR-css-flexbox-1-20160526/#min-size-auto
- * @spec https://www.w3.org/TR/2016/WD-css-sizing-3-20160512/#width-height-keywords
+ * @spec https://www.w3.org/TR/2021/WD-css-sizing-3-20210317/#propdef-min-height
  */
 public class CssMinHeight extends org.w3c.css.properties.css.CssMinHeight {
-
-    public static final CssIdent[] allowed_values;
-
-    static {
-        // auto from flexbox, fill to fit-content from css-sizing
-        String[] _allowed_values = {"auto", "fill", "max-content", "min-content", "fit-content"};
-
-        allowed_values = new CssIdent[_allowed_values.length];
-        int i = 0;
-        for (String s : _allowed_values) {
-            allowed_values[i++] = CssIdent.getIdent(s);
-        }
-    }
-
-    public static CssIdent getAllowedIdent(CssIdent ident) {
-        for (CssIdent id : allowed_values) {
-            if (id.equals(ident)) {
-                return id;
-            }
-        }
-        return null;
-    }
 
     /**
      * Create a new CssMinHeight
@@ -61,39 +33,8 @@ public class CssMinHeight extends org.w3c.css.properties.css.CssMinHeight {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);
         }
-
-        CssValue val = expression.getValue();
-
         setByUser();
-
-        switch (val.getType()) {
-            case CssTypes.CSS_NUMBER:
-                val.getCheckableValue().checkEqualsZero(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_LENGTH:
-            case CssTypes.CSS_PERCENTAGE:
-                CssCheckableValue l = val.getCheckableValue();
-                l.checkPositiveness(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_IDENT:
-                if (inherit.equals(val)) {
-                    value = inherit;
-                } else {
-                    CssIdent id = getAllowedIdent((CssIdent) val);
-                    if (id != null) {
-                        value = id;
-                    } else {
-                        throw new InvalidParamException("unrecognize", ac);
-                    }
-                }
-                break;
-            default:
-                throw new InvalidParamException("value", expression.getValue(),
-                        getPropertyName(), ac);
-        }
-        expression.next();
+        value = CssMinWidth.parseMinWidth(ac, expression, this);
     }
 
     public CssMinHeight(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssMinInlineSize.java
+++ b/org/w3c/css/properties/css3/CssMinInlineSize.java
@@ -1,0 +1,47 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://drafts.csswg.org/css-logical-1/#propdef-min-block-size retrieved 20210723 (no comment...)
+ */
+public class CssMinInlineSize extends org.w3c.css.properties.css.CssMinInlineSize {
+
+    /**
+     * Create a new CssMinInlineSize
+     */
+    public CssMinInlineSize() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssMinInlineSize
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssMinInlineSize(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+
+        value = CssMinWidth.parseMinWidth(ac, expression, this);
+
+    }
+
+    public CssMinInlineSize(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+}
+

--- a/org/w3c/css/properties/css3/CssMinWidth.java
+++ b/org/w3c/css/properties/css3/CssMinWidth.java
@@ -10,22 +10,21 @@ import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssCheckableValue;
 import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssFunction;
 import org.w3c.css.values.CssIdent;
 import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
 
 /**
- * @spec http://www.w3.org/TR/2007/WD-css3-box-20070809/#min-width
- * @spec https://www.w3.org/TR/2016/CR-css-flexbox-1-20160526/#min-size-auto
- * @spec https://www.w3.org/TR/2016/WD-css-sizing-3-20160512/#width-height-keywords
+ * @spec https://www.w3.org/TR/2021/WD-css-sizing-3-20210317/#propdef-min-width
  */
 public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
 
     public static final CssIdent[] allowed_values;
+    public static final String fit_content_func = "fit-content";
 
     static {
-        // auto from flexbox, fill to fit-content from css-sizing
-        String[] _allowed_values = {"auto", "fill", "max-content", "min-content", "fit-content"};
+        String[] _allowed_values = {"auto", "max-content", "min-content"};
 
         allowed_values = new CssIdent[_allowed_values.length];
         int i = 0;
@@ -54,8 +53,7 @@ public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
      * Creates a new CssMinWidth
      *
      * @param expression The expression for this property
-     * @throws org.w3c.css.util.InvalidParamException
-     *          Expressions are incorrect
+     * @throws org.w3c.css.util.InvalidParamException Expressions are incorrect
      */
     public CssMinWidth(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
@@ -63,7 +61,7 @@ public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
             throw new InvalidParamException("unrecognize", ac);
         }
         setByUser();
-         value = parseMinWidth(ac, expression, this);
+        value = parseMinWidth(ac, expression, this);
     }
 
     public CssMinWidth(ApplContext ac, CssExpression expression)
@@ -73,7 +71,7 @@ public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
 
     public static CssValue parseMinWidth(ApplContext ac, CssExpression expression,
                                          CssProperty caller)
-        throws InvalidParamException {
+            throws InvalidParamException {
         CssValue val = expression.getValue();
         CssValue v = null;
 
@@ -87,6 +85,9 @@ public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
                 CssCheckableValue l = val.getCheckableValue();
                 l.checkPositiveness(ac, caller);
                 v = val;
+                break;
+            case CssTypes.CSS_FUNCTION:
+                v = parseFunctionValue(ac, val, caller);
                 break;
             case CssTypes.CSS_IDENT:
                 if (inherit.equals(val)) {
@@ -106,6 +107,36 @@ public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
         }
         expression.next();
         return v;
+    }
+
+    protected static CssValue parseFunctionValue(ApplContext ac, CssValue value,
+                                                 CssProperty caller)
+            throws InvalidParamException
+    {
+        CssFunction function = (CssFunction) value;
+        if (!fit_content_func.equalsIgnoreCase(function.getName())) {
+            throw new InvalidParamException("value", value.toString(),
+                    caller.getPropertyName(), ac);
+        }
+        CssExpression expression = function.getParameters();
+        if (expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        CssValue val = expression.getValue();
+        switch (val.getType()) {
+            case CssTypes.CSS_NUMBER:
+                val.getCheckableValue().checkEqualsZero(ac, caller);
+                break;
+            case CssTypes.CSS_LENGTH:
+            case CssTypes.CSS_PERCENTAGE:
+                CssCheckableValue l = val.getCheckableValue();
+                l.checkPositiveness(ac, caller);
+                break;
+            default:
+                throw new InvalidParamException("value", expression.getValue(),
+                        caller.getPropertyName(), ac);
+        }
+        return value;
     }
 }
 

--- a/org/w3c/css/properties/css3/CssMinWidth.java
+++ b/org/w3c/css/properties/css3/CssMinWidth.java
@@ -5,6 +5,7 @@
 // Please first read the full copyright statement in file COPYRIGHT.html
 package org.w3c.css.properties.css3;
 
+import org.w3c.css.properties.css.CssProperty;
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssCheckableValue;
@@ -61,39 +62,8 @@ public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);
         }
-
-        CssValue val = expression.getValue();
-
         setByUser();
-
-        switch (val.getType()) {
-            case CssTypes.CSS_NUMBER:
-                val.getCheckableValue().checkEqualsZero(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_LENGTH:
-            case CssTypes.CSS_PERCENTAGE:
-                CssCheckableValue l = val.getCheckableValue();
-                l.checkPositiveness(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_IDENT:
-                if (inherit.equals(val)) {
-                    value = inherit;
-                } else {
-                    CssIdent id = getAllowedIdent((CssIdent) val);
-                    if (id != null) {
-                        value = id;
-                    } else {
-                        throw new InvalidParamException("unrecognize", ac);
-                    }
-                }
-                break;
-            default:
-                throw new InvalidParamException("value", expression.getValue(),
-                        getPropertyName(), ac);
-        }
-        expression.next();
+         value = parseMinWidth(ac, expression, this);
     }
 
     public CssMinWidth(ApplContext ac, CssExpression expression)
@@ -101,5 +71,41 @@ public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
         this(ac, expression, false);
     }
 
+    public static CssValue parseMinWidth(ApplContext ac, CssExpression expression,
+                                         CssProperty caller)
+        throws InvalidParamException {
+        CssValue val = expression.getValue();
+        CssValue v = null;
+
+        switch (val.getType()) {
+            case CssTypes.CSS_NUMBER:
+                val.getCheckableValue().checkEqualsZero(ac, caller);
+                v = val;
+                break;
+            case CssTypes.CSS_LENGTH:
+            case CssTypes.CSS_PERCENTAGE:
+                CssCheckableValue l = val.getCheckableValue();
+                l.checkPositiveness(ac, caller);
+                v = val;
+                break;
+            case CssTypes.CSS_IDENT:
+                if (inherit.equals(val)) {
+                    v = inherit;
+                } else {
+                    CssIdent id = getAllowedIdent((CssIdent) val);
+                    if (id != null) {
+                        v = id;
+                    } else {
+                        throw new InvalidParamException("unrecognize", ac);
+                    }
+                }
+                break;
+            default:
+                throw new InvalidParamException("value", expression.getValue(),
+                        caller.getPropertyName(), ac);
+        }
+        expression.next();
+        return v;
+    }
 }
 

--- a/org/w3c/css/properties/css3/CssMinWidth.java
+++ b/org/w3c/css/properties/css3/CssMinWidth.java
@@ -17,6 +17,7 @@ import org.w3c.css.values.CssValue;
 
 /**
  * @spec https://www.w3.org/TR/2021/WD-css-sizing-3-20210317/#propdef-min-width
+ * @spec https://www.w3.org/TR/2021/WD-css-sizing-4-20210520/#sizing-values
  */
 public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
 
@@ -24,8 +25,9 @@ public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
     public static final String fit_content_func = "fit-content";
 
     static {
-        String[] _allowed_values = {"auto", "max-content", "min-content"};
-
+        String[] _allowed_values = {"auto", "max-content", "min-content",
+                // following from sizing-4
+                "stretch", "fit-content", "contain"};
         allowed_values = new CssIdent[_allowed_values.length];
         int i = 0;
         for (String s : _allowed_values) {
@@ -111,8 +113,7 @@ public class CssMinWidth extends org.w3c.css.properties.css.CssMinWidth {
 
     protected static CssValue parseFunctionValue(ApplContext ac, CssValue value,
                                                  CssProperty caller)
-            throws InvalidParamException
-    {
+            throws InvalidParamException {
         CssFunction function = (CssFunction) value;
         if (!fit_content_func.equalsIgnoreCase(function.getName())) {
             throw new InvalidParamException("value", value.toString(),

--- a/org/w3c/css/properties/css3/CssOutlineStyle.java
+++ b/org/w3c/css/properties/css3/CssOutlineStyle.java
@@ -69,7 +69,7 @@ public class CssOutlineStyle extends org.w3c.css.properties.css.CssOutlineStyle 
             expression.next();
         } else {
             // here we delegate to BorderStyle implementation
-            value = CssBorderStyle.checkBorderSideStyle(ac, this, expression, check);
+            value = CssBorderStyle.parseBorderSideStyle(ac, expression, check, this);
             // but hidden is not a valid value...
             if (hidden.equals(value)) {
                 throw new InvalidParamException("value", hidden,

--- a/org/w3c/css/properties/css3/CssOutlineWidth.java
+++ b/org/w3c/css/properties/css3/CssOutlineWidth.java
@@ -33,7 +33,7 @@ public class CssOutlineWidth extends org.w3c.css.properties.css.CssOutlineWidth 
             throws InvalidParamException {
         setByUser();
         // here we delegate to BorderWidth implementation
-        value = CssBorderWidth.checkBorderSideWidth(ac, this, expression, check);
+        value = CssBorderWidth.parseBorderSideWidth(ac, expression, check, this);
     }
 
     public CssOutlineWidth(ApplContext ac, CssExpression expression)

--- a/org/w3c/css/properties/css3/CssPadding.java
+++ b/org/w3c/css/properties/css3/CssPadding.java
@@ -153,9 +153,9 @@ public class CssPadding extends org.w3c.css.properties.css.CssPadding {
 
     // for use by individual padding-* properties
 
-    protected static CssValue checkValue(ApplContext ac,
-                                         CssExpression expression,
-                                         boolean check, CssProperty caller)
+    protected static CssValue parsePadding(ApplContext ac,
+                                           CssExpression expression,
+                                           boolean check, CssProperty caller)
             throws InvalidParamException {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);

--- a/org/w3c/css/properties/css3/CssPaddingBlock.java
+++ b/org/w3c/css/properties/css3/CssPaddingBlock.java
@@ -1,0 +1,73 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-padding-block
+ */
+public class CssPaddingBlock extends org.w3c.css.properties.css.CssPaddingBlock {
+
+    /**
+     * Create a new CssPaddingBlock
+     */
+    public CssPaddingBlock() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssPaddingBlock
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssPaddingBlock(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssPadding.parsePadding(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssPadding.parsePadding(ac, expression, false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssPaddingBlock(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssPaddingBlockEnd.java
+++ b/org/w3c/css/properties/css3/CssPaddingBlockEnd.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-padding-block-end
+ */
+public class CssPaddingBlockEnd extends org.w3c.css.properties.css.CssPaddingBlockEnd {
+
+    /**
+     * Create a new CssPaddingBlockEnd
+     */
+    public CssPaddingBlockEnd() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssPaddingBlockEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssPaddingBlockEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssPadding.parsePadding(ac, expression, check, this);
+    }
+
+
+    public CssPaddingBlockEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssPaddingBlockStart.java
+++ b/org/w3c/css/properties/css3/CssPaddingBlockStart.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-padding-block-start
+ */
+public class CssPaddingBlockStart extends org.w3c.css.properties.css.CssPaddingBlockStart {
+
+    /**
+     * Create a new CssPaddingBlockStart
+     */
+    public CssPaddingBlockStart() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssPaddingBlockStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssPaddingBlockStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssPadding.parsePadding(ac, expression, check, this);
+    }
+
+
+    public CssPaddingBlockStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssPaddingBottom.java
+++ b/org/w3c/css/properties/css3/CssPaddingBottom.java
@@ -45,7 +45,7 @@ public class CssPaddingBottom extends org.w3c.css.properties.css.CssPaddingBotto
     public CssPaddingBottom(ApplContext ac, CssExpression expression,
                             boolean check) throws InvalidParamException {
         setByUser();
-        value = CssPadding.checkValue(ac, expression, check, this);
+        value = CssPadding.parsePadding(ac, expression, check, this);
     }
 
 }

--- a/org/w3c/css/properties/css3/CssPaddingInline.java
+++ b/org/w3c/css/properties/css3/CssPaddingInline.java
@@ -1,0 +1,73 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssValue;
+import org.w3c.css.values.CssValueList;
+
+import java.util.ArrayList;
+
+import static org.w3c.css.values.CssOperator.SPACE;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-padding-inline
+ */
+public class CssPaddingInline extends org.w3c.css.properties.css.CssPaddingInline {
+
+    /**
+     * Create a new CssPaddingInline
+     */
+    public CssPaddingInline() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssPaddingInline
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssPaddingInline(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 2) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        CssValue val;
+        char op;
+        ArrayList<CssValue> v = new ArrayList<>();
+
+        op = expression.getOperator();
+        val = CssPadding.parsePadding(ac, expression, false, this);
+        v.add(val);
+        if (op != SPACE) {
+            throw new InvalidParamException("operator",
+                    Character.toString(op), ac);
+        }
+        if (!expression.end()) {
+            v.add(CssPadding.parsePadding(ac, expression, false, this));
+        }
+        if (v.size() == 1) {
+            value = v.get(0);
+        } else {
+            if (v.contains(inherit)) {
+                throw new InvalidParamException("value", inherit.toString(),
+                        getPropertyName(), ac);
+            }
+            value = new CssValueList(v);
+        }
+    }
+
+
+    public CssPaddingInline(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssPaddingInlineEnd.java
+++ b/org/w3c/css/properties/css3/CssPaddingInlineEnd.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-padding-inline-end
+ */
+public class CssPaddingInlineEnd extends org.w3c.css.properties.css.CssPaddingInlineEnd {
+
+    /**
+     * Create a new CssPaddingInlineEnd
+     */
+    public CssPaddingInlineEnd() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssPaddingInlineEnd
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssPaddingInlineEnd(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssPadding.parsePadding(ac, expression, check, this);
+    }
+
+
+    public CssPaddingInlineEnd(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssPaddingInlineStart.java
+++ b/org/w3c/css/properties/css3/CssPaddingInlineStart.java
@@ -1,0 +1,46 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT MIT, ERCIM, Keio, Beihang, 2021.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#propdef-padding-inline-start
+ */
+public class CssPaddingInlineStart extends org.w3c.css.properties.css.CssPaddingInlineStart {
+
+    /**
+     * Create a new CssPaddingInlineStart
+     */
+    public CssPaddingInlineStart() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssPaddingInlineStart
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssPaddingInlineStart(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+        value = CssPadding.parsePadding(ac, expression, check, this);
+    }
+
+
+    public CssPaddingInlineStart(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+}
+

--- a/org/w3c/css/properties/css3/CssPaddingLeft.java
+++ b/org/w3c/css/properties/css3/CssPaddingLeft.java
@@ -45,7 +45,7 @@ public class CssPaddingLeft extends org.w3c.css.properties.css.CssPaddingLeft {
     public CssPaddingLeft(ApplContext ac, CssExpression expression,
                           boolean check) throws InvalidParamException {
         setByUser();
-        value = CssPadding.checkValue(ac, expression, check, this);
+        value = CssPadding.parsePadding(ac, expression, check, this);
     }
 
 }

--- a/org/w3c/css/properties/css3/CssPaddingRight.java
+++ b/org/w3c/css/properties/css3/CssPaddingRight.java
@@ -45,6 +45,6 @@ public class CssPaddingRight extends org.w3c.css.properties.css.CssPaddingRight 
     public CssPaddingRight(ApplContext ac, CssExpression expression,
                            boolean check) throws InvalidParamException {
         setByUser();
-        value = CssPadding.checkValue(ac, expression, check, this);
+        value = CssPadding.parsePadding(ac, expression, check, this);
     }
 }

--- a/org/w3c/css/properties/css3/CssPaddingTop.java
+++ b/org/w3c/css/properties/css3/CssPaddingTop.java
@@ -45,6 +45,6 @@ public class CssPaddingTop extends org.w3c.css.properties.css.CssPaddingTop {
     public CssPaddingTop(ApplContext ac, CssExpression expression,
                          boolean check) throws InvalidParamException {
         setByUser();
-        value = CssPadding.checkValue(ac, expression, check, this);
+        value = CssPadding.parsePadding(ac, expression, check, this);
     }
 }

--- a/org/w3c/css/properties/css3/CssResize.java
+++ b/org/w3c/css/properties/css3/CssResize.java
@@ -13,14 +13,16 @@ import org.w3c.css.values.CssTypes;
 import org.w3c.css.values.CssValue;
 
 /**
- * @spec https://www.w3.org/TR/2020/WD-css-ui-4-20200124/#propdef-resize
+ * @spec https://www.w3.org/TR/2020/WD-css-ui-4-20210316/#propdef-resize
+ * @spec https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#resize
  */
 public class CssResize extends org.w3c.css.properties.css.CssResize {
 
     private static CssIdent[] allowed_values;
 
     static {
-        String id_values[] = {"none", "both", "horizontal", "vertical"};
+        String id_values[] = {"none", "both", "horizontal", "vertical",
+                "block", "inline"};
         allowed_values = new CssIdent[id_values.length];
         int i = 0;
         for (String s : id_values) {
@@ -48,8 +50,7 @@ public class CssResize extends org.w3c.css.properties.css.CssResize {
      * Creates a new CssResize
      *
      * @param expression The expression for this property
-     * @throws org.w3c.css.util.InvalidParamException
-     *          Expressions are incorrect
+     * @throws org.w3c.css.util.InvalidParamException Expressions are incorrect
      */
     public CssResize(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {

--- a/org/w3c/css/properties/css3/CssRight.java
+++ b/org/w3c/css/properties/css3/CssRight.java
@@ -32,7 +32,7 @@ public class CssRight extends org.w3c.css.properties.css.CssRight {
      */
     public CssRight(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
-        value = CssTop.checkValue(ac, expression, check, this);
+        value = CssTop.parseTop(ac, expression, check, this);
 
     }
 

--- a/org/w3c/css/properties/css3/CssTop.java
+++ b/org/w3c/css/properties/css3/CssTop.java
@@ -36,7 +36,7 @@ public class CssTop extends org.w3c.css.properties.css.CssTop {
      */
     public CssTop(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
-        value = checkValue(ac, expression, check, this);
+        value = parseTop(ac, expression, check, this);
     }
 
     public CssTop(ApplContext ac, CssExpression expression)
@@ -51,9 +51,9 @@ public class CssTop extends org.w3c.css.properties.css.CssTop {
      * @see CssLeft
      * @see CssRight
      */
-    protected static CssValue checkValue(ApplContext ac,
-                                         CssExpression expression,
-                                         boolean check, CssProperty caller)
+    protected static CssValue parseTop(ApplContext ac,
+                                       CssExpression expression,
+                                       boolean check, CssProperty caller)
             throws InvalidParamException {
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);

--- a/org/w3c/css/properties/css3/CssWidth.java
+++ b/org/w3c/css/properties/css3/CssWidth.java
@@ -17,6 +17,7 @@ import org.w3c.css.values.CssValue;
 
 /**
  * @spec https://www.w3.org/TR/2021/WD-css-sizing-3-20210317/#propdef-width
+ * @spec https://www.w3.org/TR/2021/WD-css-sizing-4-20210520/#sizing-values
  */
 public class CssWidth extends org.w3c.css.properties.css.CssWidth {
 
@@ -24,7 +25,9 @@ public class CssWidth extends org.w3c.css.properties.css.CssWidth {
     public static final String fit_content_func = "fit-content";
 
     static {
-        String[] _allowed_values = {"auto", "max-content", "min-content"};
+        String[] _allowed_values = {"auto", "max-content", "min-content",
+                // following from sizing-4
+                "stretch", "fit-content", "contain"};
         allowed_values = new CssIdent[_allowed_values.length];
         int i = 0;
         for (String s : _allowed_values) {
@@ -120,8 +123,7 @@ public class CssWidth extends org.w3c.css.properties.css.CssWidth {
 
     protected static CssValue parseFunctionValue(ApplContext ac, CssValue value,
                                                  CssProperty caller)
-            throws InvalidParamException
-    {
+            throws InvalidParamException {
         CssFunction function = (CssFunction) value;
         if (!fit_content_func.equalsIgnoreCase(function.getName())) {
             throw new InvalidParamException("value", value.toString(),

--- a/org/w3c/css/properties/css3/CssWidth.java
+++ b/org/w3c/css/properties/css3/CssWidth.java
@@ -5,6 +5,7 @@
 // Please first read the full copyright statement in file COPYRIGHT.html
 package org.w3c.css.properties.css3;
 
+import org.w3c.css.properties.css.CssProperty;
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssCheckableValue;
@@ -52,49 +53,16 @@ public class CssWidth extends org.w3c.css.properties.css.CssWidth {
      * Create a new CssWidth.
      *
      * @param expression The expression for this property
-     * @throws org.w3c.css.util.InvalidParamException
-     *          Values are incorrect
+     * @throws org.w3c.css.util.InvalidParamException Values are incorrect
      */
     public CssWidth(ApplContext ac, CssExpression expression, boolean check)
             throws InvalidParamException {
-
         if (check && expression.getCount() > 1) {
             throw new InvalidParamException("unrecognize", ac);
         }
 
-        CssValue val = expression.getValue();
-
         setByUser();
-
-        switch (val.getType()) {
-            case CssTypes.CSS_IDENT:
-                if (inherit.equals(val)) {
-                    value = inherit;
-                } else {
-                    CssIdent id = getAllowedIdent((CssIdent) val);
-                    if (id != null) {
-                        value = id;
-                    } else {
-                        throw new InvalidParamException("unrecognize", ac);
-                    }
-                }
-                break;
-            case CssTypes.CSS_NUMBER:
-                // only 0 can be a length...
-                CssCheckableValue p = val.getCheckableValue();
-                p.checkEqualsZero(ac, this);
-                value = val;
-                break;
-            case CssTypes.CSS_LENGTH:
-            case CssTypes.CSS_PERCENTAGE:
-                p = val.getCheckableValue();
-                p.checkPositiveness(ac, this);
-                value = val;
-                break;
-            default:
-                throw new InvalidParamException("value", val, getPropertyName(), ac);
-        }
-        expression.next();
+        value = parseWidth(ac, expression, this);
     }
 
     public CssWidth(ApplContext ac, CssExpression expression)
@@ -110,4 +78,41 @@ public class CssWidth extends org.w3c.css.properties.css.CssWidth {
         return ((value == auto) || (value == initial));
     }
 
+    public static final CssValue parseWidth(ApplContext ac, CssExpression expression,
+                                            CssProperty caller)
+            throws InvalidParamException {
+        CssValue v = null;
+        CssValue val = expression.getValue();
+        switch (val.getType()) {
+            case CssTypes.CSS_IDENT:
+                if (inherit.equals(val)) {
+                    v = inherit;
+                } else {
+                    CssIdent id = getAllowedIdent((CssIdent) val);
+                    if (id != null) {
+                        v = id;
+                    } else {
+                        throw new InvalidParamException("unrecognize", ac);
+                    }
+                }
+                break;
+            case CssTypes.CSS_NUMBER:
+                // only 0 can be a length...
+                CssCheckableValue p = val.getCheckableValue();
+                p.checkEqualsZero(ac, caller);
+                v = val;
+                break;
+            case CssTypes.CSS_LENGTH:
+            case CssTypes.CSS_PERCENTAGE:
+                p = val.getCheckableValue();
+                p.checkPositiveness(ac, caller);
+                v = val;
+                break;
+            default:
+                throw new InvalidParamException("value", val,
+                        caller.getPropertyName(), ac);
+        }
+        expression.next();
+        return v;
+    }
 }

--- a/org/w3c/css/properties/svg/CssClipPath.java
+++ b/org/w3c/css/properties/svg/CssClipPath.java
@@ -210,7 +210,7 @@ public class CssClipPath extends org.w3c.css.properties.css.CssClipPath {
                         if (nex.getCount() == 0) {
                             throw new InvalidParamException("unrecognize", ac);
                         }
-                        CssBorderRadius.checkBorderCornerRadius(ac, caller, nex, true);
+                        CssBorderRadius.parseBorderCornerRadius(ac, nex, true, caller);
                         break;
                     }
                 default:


### PR DESCRIPTION
per https://www.w3.org/TR/2018/WD-css-logical-1-20180827/ amended by the edcopy retrieved 2021-07-23
Only thing not done is the 'logical' keyword for shorthands, https://www.w3.org/TR/2018/WD-css-logical-1-20180827/#logical-shorthand-keyword as it is not settled yet.
This fixes #306 Also some side specifications were updated.
