### PR TITLE
add support for documenting charset when creating the inputstream 

### DIFF
--- a/org/w3c/css/css/CssParser.java
+++ b/org/w3c/css/css/CssParser.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
+import java.nio.charset.Charset;
 
 /**
  * This class describes how to implements your cascading
@@ -78,6 +79,25 @@ public interface CssParser {
      * @param lineno The number line in the source document. It is used for error message
      */
     public abstract void parseStyleElement(ApplContext ac, InputStream input,
+                                           String title, String media, URL url,
+                                           int lineno);
+
+    /**
+     * Parse a STYLE element.
+     * The real difference between this method and the precedent
+     * is that this method can take an InputStream. The URL is used
+     * to resolve import statement and URL statement in the style
+     * sheet.
+     *
+     * @param input  the input stream.
+     * @param charset the charset for that input stream.
+     * @param title  the title of the style element
+     * @param media  the media of the style element
+     * @param url    the URL where the input stream comes from.
+     * @param lineno The number line in the source document. It is used for error message
+     */
+    public abstract void parseStyleElement(ApplContext ac, InputStream input,
+                                           Charset charset,
                                            String title, String media, URL url,
                                            int lineno);
 

--- a/org/w3c/css/servlet/CssValidator.java
+++ b/org/w3c/css/servlet/CssValidator.java
@@ -46,6 +46,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.nio.charset.Charset;
 
 /**
  * This class is a servlet to use the validator.
@@ -65,6 +66,7 @@ public final class CssValidator extends HttpServlet {
 
     final static String opt_file = "file";
     final static String opt_text = "text";
+    final static String opt_textcharset = "textcharset";
     final static String opt_lang = "lang";
     final static String opt_output = "output";
     final static String opt_warning = "warning";
@@ -517,6 +519,7 @@ public final class CssValidator extends HttpServlet {
         CssParser parser = null;
         FakeFile file = null;
         String text = null;
+        Charset textcharset = null;
         String output = null;
         //boolean XMLinput = false;
         String warning = null;
@@ -583,6 +586,9 @@ public final class CssValidator extends HttpServlet {
                         break;
                     case opt_text:
                         text = (String) pair.getValue();
+                        break;
+                    case opt_textcharset:
+                        textcharset = (Charset) pair.getValue();
                         break;
                     case opt_lang:
                         lang = (String) pair.getValue();
@@ -688,7 +694,7 @@ public final class CssValidator extends HttpServlet {
                 handleScam(ac, text, res, output, warningLevel, errorReport);
                 return;
             }
-            ac.setFakeText(text);
+            ac.setFakeText(text, textcharset);
             fileName = "TextArea";
             Util.verbose("- " + fileName + " Data -");
             Util.verbose(text);
@@ -717,7 +723,7 @@ public final class CssValidator extends HttpServlet {
             if (isCSS) {
                 //if CSS:
                 parser = new StyleSheetParser(ac);
-                parser.parseStyleElement(ac, is, null, ac.getMedium(),
+                parser.parseStyleElement(ac, is, textcharset, null, ac.getMedium(),
                         new URL(fileName), 0);
 
                 handleRequest(ac, res, fileName, parser.getStyleSheet(),

--- a/org/w3c/css/util/ApplContext.java
+++ b/org/w3c/css/util/ApplContext.java
@@ -103,6 +103,7 @@ public class ApplContext {
 
     FakeFile fakefile = null;
     String faketext = null;
+    Charset faketextcharset = null;
     URL fakeurl = null;
 
     URL referrer = null;
@@ -508,23 +509,29 @@ public class ApplContext {
     /**
      * store content of entered text
      */
-    public void setFakeText(String faketext) {
+    public void setFakeText(String faketext, Charset faketextcharset) {
         this.faketext = faketext;
+        this.faketextcharset = faketextcharset;
+
     }
 
     public InputStream getFakeInputStream(URL source)
             throws IOException {
         InputStream is = null;
+        Charset c = null;
         if (fakefile != null) {
             is = fakefile.getInputStream();
         }
         if (faketext != null) {
-            is = new ByteArrayInputStream(faketext.getBytes());
+            is = new ByteArrayInputStream(faketext.getBytes(faketextcharset));
+            c = faketextcharset;
         }
         if (is == null) {
             return null;
         }
-        Charset c = getCharsetObjForURL(source);
+        if (c == null) {
+            c = getCharsetObjForURL(source);
+        }
         if (c == null) {
             UnicodeInputStream uis = new UnicodeInputStream(is);
             String guessedCharset = uis.getEncodingFromStream();


### PR DESCRIPTION
Usable in POST handling, but can be used in parsing fragment out of an HTML document where the encoding is known.