### PR TITLE
chore: Add Dependabot for Actions and submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+  - package-ecosystem: gitsubmodule
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Will create PRs to update the submodules when they change, and also for GitHub Actions versions