### PR TITLE
BUGFIX for null-byte at nth-child selectors

### DIFF
--- a/org/w3c/css/values/CssANPlusB.java
+++ b/org/w3c/css/values/CssANPlusB.java
@@ -206,7 +206,9 @@ public class CssANPlusB extends CssValue {
                 sb.append('n');
             }
             if (b != null) {
-                sb.append(operator);
+            	if(operator != '\0') {
+            		sb.append(operator);
+            	}
                 sb.append(b.toPlainString());
             }
             representation = sb.toString();


### PR DESCRIPTION
Consider the following example:

```
.foo:nth-child(2){
    margin-top: 2px;
}
```

The validator parses a null-byte before the number (2), because no operand is specified. This caused that the browsers couldn't understand the style.