### PR TITLE
Clip Bug

### DIFF
--- a/org/w3c/css/properties/css3/CssClip.java
+++ b/org/w3c/css/properties/css3/CssClip.java
@@ -75,6 +75,7 @@ public class CssClip extends org.w3c.css.properties.css.CssClip {
                 throw new InvalidParamException("value", val,
                         getPropertyName(), ac);
         }
+        expression.next();
     }
 
     public CssClip(ApplContext ac, CssExpression expression)


### PR DESCRIPTION
Consider the following example:

.foo{
  position : absolute;
  clip : rect(0,0,0,0);
}

Without my change, the validator threw and exception that there were too few arguments for the function.