### PR TITLE
Allow preprocessing of the input stream to be skipped

### DIFF
--- a/org/w3c/css/css/StyleSheetParser.java
+++ b/org/w3c/css/css/StyleSheetParser.java
@@ -50,6 +50,7 @@ public final class StyleSheetParser
         implements CssValidatorListener, CssParser {
 
     private static Constructor co = null;
+    private static boolean isPreprocessed;
 
     static {
         try {
@@ -64,8 +65,13 @@ public final class StyleSheetParser
     CssFouffa cssFouffa;
     StyleSheet style = new StyleSheet();
 
-    public StyleSheetParser(ApplContext ac) {
+    public StyleSheetParser(ApplContext ac, boolean isPreprocessed) {
+        this.isPreprocessed = isPreprocessed;
         ac.setStyleSheet(getStyleSheet());
+    }
+
+    public StyleSheetParser(ApplContext ac) {
+        new StyleSheetParser(ac, false);
     }
 
     public void reInit() {
@@ -293,7 +299,8 @@ public final class StyleSheetParser
 
 //	    if (cssFouffa == null) {
             String charset = ac.getCharsetForURL(url);
-            if (ac.getCssVersion().compareTo(CssVersion.CSS2) >=0 ) {
+            if (ac.getCssVersion().compareTo(CssVersion.CSS2) >=0
+                    && !isPreprocessed) {
                 cssFouffa = new CssFouffa(ac, new UnescapeFilterReader(new BufferedReader(reader)), url, lineno);
             } else {
                 cssFouffa = new CssFouffa(ac, reader, url, lineno);


### PR DESCRIPTION
This change adds an optional `isPreprocessed` boolean parameter to the `StyleSheetParser()` constructor; if the value of that parameter is true, the steps from https://drafts.csswg.org/css-syntax/#input-preprocessing for preprocessing the input stream are skipped — so `UnescapeFilterReader()` is not called.

This is useful in a context where the input stream has already been preprocessed — for example, if the contents of the stylesheet being parsed are from an HTML document that has already been parsed by a conformant HTML parser (which is the case, for example, when the https://github.com/validator/validator HTML checker calls the code).