### PR TITLE
Don’t do surrogate replacement when preprocessing input stream

### DIFF
--- a/org/w3c/css/util/UnescapeFilterReader.java
+++ b/org/w3c/css/util/UnescapeFilterReader.java
@@ -31,9 +31,6 @@ public class UnescapeFilterReader extends FilterReader {
         if (c == 0) { // U+0000 NULL
             return 0xfffd; // U+FFFD REPLACEMENT CHARACTER
         }
-        if (c >= 0xd800 && c <= 0xdfff) { // surrogate
-            return 0xfffd;
-        }
 
         // now specific case of CSS unicode escape for ascii values [A-Za-z0-9].
         if (c != '\\') {
@@ -107,8 +104,6 @@ public class UnescapeFilterReader extends FilterReader {
             } else if (chars[i] == 0x000c) {
                 chars[j++] = 0x000a;
             } else if (chars[i] == 0) {
-                chars[j++] = 0xfffd;
-            } else if (chars[i] >= 0xd800 && chars[i] <= 0xdfff) {
                 chars[j++] = 0xfffd;
             }
             // escaping


### PR DESCRIPTION
This PR fixes #383, as an alternative to #385.

This change drops the code for replacing surrogate code points from our implementation of “filter code points” from “Preprocessing the input stream” at https://drafts.csswg.org/css-syntax/#css-filter-code-points

I’ve also opened https://github.com/w3c/csswg-drafts/pull/7997 with a patch for updating that part of the CSS Syntax spec to add a clarifying note.

https://github.com/w3c/csswg-drafts/issues/3307#issuecomment-442198338 notes that the only way to produce a unpaired lone surrogate code point in CSS content is by directly assigning a DOMString with one in it via an OM operation; in other words, by manipulating a document using, e.g., `document.styleSheets` in JavaScript to insert a surrogate code point into the document. See the tests at https://github.com/web-platform-tests/wpt/blob/master/css/css-syntax/input-preprocessing.html#L16

But because the CSS validator doesn’t execute any JavaScript from a document, there’s no way for a document being checked by the CSS validator to contain any surrogate code points. Therefore, it’s unnecessary for our implementation to handle replacement of surrogate code points. In other words, our implementation can still conform to the spec requirements even if we don’t perform surrogate replacement.

Otherwise, if we keep the surrogate-replacement code, we don’t have any way to actually test it — because we can’t use `document.styleSheets` or any other JavaScript in the context of the CSS validator, and therefore have no way to write any test cases that would produce an unpaired lone surrogate in the content we need to test with.