### PR TITLE
Instanceof Check Before Cast

### DIFF
--- a/org/w3c/css/properties/css/CssImageRendering.java
+++ b/org/w3c/css/properties/css/CssImageRendering.java
@@ -78,11 +78,13 @@ public class CssImageRendering extends CssProperty {
      * @param style The CssStyle
      */
     public void addToStyle(ApplContext ac, CssStyle style) {
-        SVGBasicStyle s = (SVGBasicStyle) style;
-        if (s.cssImageRendering != null) {
-            style.addRedefinitionWarning(ac, this);
-        }
-        s.cssImageRendering = this;
+    	if(style instanceof SVGBasicStyle) {
+    		SVGBasicStyle s = (SVGBasicStyle) style;
+    		if (s.cssImageRendering != null) {
+    			style.addRedefinitionWarning(ac, this);
+    		}
+    		s.cssImageRendering = this;
+    	}
     }
 
 


### PR DESCRIPTION
I tested it on the following example:

```
#foo {border-width: 0; image-rendering: auto; vertical-align: bottom; }
```

Without setting the ApplContext to `css3svg`, the `image-rendring: auto;` property is a CSS3Style. That will be tried to be cast to SVGBasicStyle without even checking if that's possible. This caused ClassCastException.

Can be recreated on the online validator too, if you set the options from CSS3 + SVG to only CSS3.