### PR TITLE
Relative links to Sequence Diagrams in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The latest development code for the CSS Validator is available through [the GitHub repository](https://github.com/w3c/css-validator).
 
-For a visual representation, see the [CSS Validator Sequence Diagram](https://github.com/w3c/css-validator/raw/master/docs/CSS_Validator_Sequence_Diagram.png), which is available in [png](https://github.com/w3c/css-validator/raw/master/docs/CSS_Validator_Sequence_Diagram.png), [graffle](https://github.com/w3c/css-validator/raw/master/docs/CSS_Validator_Sequence_Diagram.graffle) and [svg](https://github.com/w3c/css-validator/raw/master/docs/CSS_Validator_Sequence_Diagram.svg) formats.
+For a visual representation, see the [CSS Validator Sequence Diagram](./docs/CSS_Validator_Sequence_Diagram.png), which is available in [png](./docs/CSS_Validator_Sequence_Diagram.png), [graffle](./docs/CSS_Validator_Sequence_Diagram.graffle) and [svg](./docs/CSS_Validator_Sequence_Diagram.svg) formats.
 
 If you have any questions or problems with the validator, send us an [email](https://github.com/w3c/css-validator/blob/master/Email.html.en).
 


### PR DESCRIPTION
Since changing the base branch to `main` from `master`, the absolute links to the sequence diagrams have been broken. However, the most robust remedy is to use relative links (truth in aliteration), not absolute URIs.