### PR TITLE
Fix non-functional --printCSS/-p option

### DIFF
--- a/org/w3c/css/css/StyleSheetGenerator.java
+++ b/org/w3c/css/css/StyleSheetGenerator.java
@@ -197,7 +197,8 @@ public class StyleSheetGenerator extends StyleReport {
 
         produceError();
         produceWarning();
-        produceStyleSheet();
+        if (CssValidator.showCSS)
+            produceStyleSheet();
 
         try {
             String _template_dir = "org/w3c/css/css/";


### PR DESCRIPTION
This option didn't do anything, because the value it set (showCSS) wasn't considered when generating the output.