### PR TITLE
Generate html files at build time (keeps HTML)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -149,7 +149,7 @@
     </jar>
   </target>
 
-  <target name="war" depends="build" description="Creates the webapp module">
+  <target name="war" depends="build, buildhtml" description="Creates the webapp module">
     <delete file="${war.file}"/>
     <war warfile="${war.file}" webxml="web.xml" basedir="." includes="*html*,favicon.ico,images/**,style/**,scripts/**" excludes="html,css-validator.*">
       <classes dir="build"/>
@@ -172,6 +172,20 @@
       includeantruntime="false"/>
     <java classname="autotest.AutoTest" classpath="css-validator.jar">
       <arg value="${testfile}"/>
+    </java>
+  </target>
+
+  <path id="generate.class.path">
+    <path refid="build.class.path"/>
+    <pathelement location="build"/>
+  </path>
+
+  <target name="buildhtml" depends="build">
+    <java classpathref="generate.class.path" classname="org.w3c.css.index.IndexGenerator">
+      <arg value="."/>
+    </java>
+    <java classpathref="generate.class.path" classname="org.w3c.css.index.TranslationTableGenerator">
+      <arg value="."/>
     </java>
   </target>
 

--- a/org/w3c/css/index/IndexGenerator.java
+++ b/org/w3c/css/index/IndexGenerator.java
@@ -22,6 +22,9 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Iterator;
 
@@ -42,6 +45,31 @@ public class IndexGenerator {
      * @param args
      */
     public static void main(String[] args) {
+        // 1st argument: output path of the html files
+        if (args.length != 0 && !args[0].isEmpty())
+        {
+            String currentPathToClass = IndexGenerator.class.getResource("").getPath();
+            try {
+                Path path = Paths.get(currentPathToClass);
+                Path outputPath = Paths.get(new File(args[0]).getAbsolutePath().toString());
+                Path relativeOutputPath = path.relativize(outputPath);
+                // Overwrite html_files_path so that it is relative to the path (ie. currentPathToClass)
+                html_files_path = relativeOutputPath.toString() + "/";
+                if (!outputPath.toFile().exists()) {
+                    System.err.println("Directory doesn't exist:" + outputPath);
+                    System.exit(1);
+                }
+                if (!Files.isWritable(outputPath)) {
+                    System.err.println("Directory is not writable: " + outputPath);
+                    System.exit(1);
+                }
+                System.out.println("Writing files to " + path.toString() + "/" + html_files_path);
+            } catch (Exception e)
+            {
+                e.printStackTrace();
+                System.exit(1);
+            }
+        }
         IndexGenerator.generatesIndex(false);
     }
 

--- a/org/w3c/css/index/TranslationTableGenerator.java
+++ b/org/w3c/css/index/TranslationTableGenerator.java
@@ -22,6 +22,9 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -56,6 +59,31 @@ public class TranslationTableGenerator {
      * @param args
      */
     public static void main(String[] args) {
+        // 1st argument: output path of the html files
+        if (args.length > 0 && !args[0].isEmpty())
+        {
+            String currentPathToClass = IndexGenerator.class.getResource("").getPath();
+            try {
+                Path path = Paths.get(currentPathToClass);
+                Path outputPath = Paths.get(new File(args[0]).getAbsolutePath().toString());
+                Path relativeOutputPath = path.relativize(outputPath);
+                // Overwrite html_files_path so that it is relative to the path (ie. currentPathToClass)
+                html_files_path = relativeOutputPath.toString() + "/";
+                if (!outputPath.toFile().exists()) {
+                    System.err.println("Directory doesn't exist:" + outputPath);
+                    System.exit(1);
+                }
+                if (!Files.isWritable(outputPath)) {
+                    System.err.println("Directory is not writable: " + outputPath);
+                    System.exit(1);
+                }
+                System.out.println("Writing files to " + path.toString() + "/" + html_files_path);
+            } catch (Exception e)
+            {
+                e.printStackTrace();
+                System.exit(1);
+            }
+        }
         TranslationTableGenerator.generateTable();
     }
 


### PR DESCRIPTION
Same as #453 but this one keeps the html files (and doesn't delete them in the `clean` task) although I don't really see why they should be kept since:
- if the generated file doesn't exists it is created anyway by the servlet
- if the file is older than the template it will be regenerated by the servlet
However, in both cases, this requires the servlet to have write permission on their folder.

I can suppose this can be useful for jigsaw, and maybe as deployed war (on tomcat/jetty...), but this reveals bug https://github.com/w3c/css-validator/issues/451

Checking whether regeneration is required using the timestamp doesn't really make sense in a git repo as the timestamps of the commit are not kept&restored from the commit date IIRC. But on a deployed app using the timestamp makes sense.

Also, eg. on tag cssval-20250226, the generated files were not in line with the template. Maintaining template & generated files synchronized is extra work while having them generated ensures that they match the template.

IMHO, the benefit of keeping the HTML files would be that one can see how a change in the template impacts the generated HTML.

You may merge this PR or the previous one #453 , as you prefer, but I think it may be better to remove the generated html and keep them generated at build time + 1st load in the case the deployed app doesn't ship them. That's not much extra work and actually permits to ensure that the generation works before deployment, instead of discovering after deployment that there is a generation issue.