### PR TITLE
fix: Handle calc() with number type in CSS position checking

### DIFF
--- a/org/w3c/css/values/CssCalc.java
+++ b/org/w3c/css/values/CssCalc.java
@@ -410,6 +410,14 @@ public class CssCalc extends CssCheckableValue {
                 return val2.getLength();
             }
         }
+        if (computed_type == CssTypes.CSS_NUMBER) {
+            if (val1.getType() == CssTypes.CSS_NUMBER) {
+                return val1.getLength();
+            }
+            if (val2.getType() == CssTypes.CSS_NUMBER) {
+                return val2.getLength();
+            }
+        }
         throw new ClassCastException("unknown");
     }
 


### PR DESCRIPTION
**Bug:** A `conic-gradient()` position containing a `calc()` that resolves to a number causes a `ClassCastException` to be thrown.

**Cause:** `CssCalc.getLength()` only handled `computed_type == CSS_LENGTH`. When `CssBackgroundPosition.checkSyntax()` calls `getLength()` on a calc with `computed_type == CSS_NUMBER`, it falls through to the throw.

**Fix:** Delegate to the inner value's `getLength()` when `computed_type` is `CSS_NUMBER`, matching how `CssNumber.getLength()` handles the zero-check.

The exception is reproducible by checking http://loconto.net