### PR TITLE
added zoom

### DIFF
--- a/org/w3c/css/parser/CssPropertyFactory.java
+++ b/org/w3c/css/parser/CssPropertyFactory.java
@@ -36,7 +36,7 @@ import java.util.StringTokenizer;
 public class CssPropertyFactory implements Cloneable {
 
     private static final String[] NONSTANDARD_PROPERTIES = //
-            {"zoom"};
+            { };
 
     private static boolean isNonstandardProperty(String property) {
         if (property.charAt(0) == '-' || property.charAt(0) == '_') {

--- a/org/w3c/css/properties/CSS3Properties.properties
+++ b/org/w3c/css/properties/CSS3Properties.properties
@@ -533,6 +533,8 @@ flood-color:                            org.w3c.css.properties.css3.CssFloodColo
 flood-opacity:                          org.w3c.css.properties.css3.CssFloodOpacity
 lighting-color:                         org.w3c.css.properties.css3.CssLightingColor
 
+zoom:					org.w3c.css.properties.css3.CssZoom
+
 @font-face.ascent-override:             org.w3c.css.properties.css3.fontface.CssAscentOverride
 @font-face.descent-override:            org.w3c.css.properties.css3.fontface.CssDescentOverride
 @font-face.font-display:                org.w3c.css.properties.css3.fontface.CssFontDisplay

--- a/org/w3c/css/properties/css/CssZoom.java
+++ b/org/w3c/css/properties/css/CssZoom.java
@@ -1,0 +1,111 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT W3C, 2026.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css;
+
+import org.w3c.css.parser.CssStyle;
+import org.w3c.css.properties.css3.Css3Style;
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+
+/**
+ * @since CSS3
+ */
+public class CssZoom extends CssProperty {
+
+
+    /**
+     * Create a new CssZoom
+     */
+    public CssZoom() {
+    }
+
+    /**
+     * Creates a new CssZoom
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException
+     *          Expressions are incorrect
+     */
+    public CssZoom(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        throw new InvalidParamException("value",
+                expression.getValue().toString(),
+                getPropertyName(), ac);
+    }
+
+    public CssZoom(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+    /**
+     * Returns the value of this property
+     */
+    public Object get() {
+        return value;
+    }
+
+
+    /**
+     * Returns the name of this property
+     */
+    public final String getPropertyName() {
+        return "zoom";
+    }
+
+    /**
+     * Returns true if this property is "softly" inherited
+     * e.g. his value is equals to inherit
+     */
+    public boolean isSoftlyInherited() {
+        return inherit.equals(value);
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * Add this property to the CssStyle.
+     *
+     * @param style The CssStyle
+     */
+    public void addToStyle(ApplContext ac, CssStyle style) {
+        if (((Css3Style) style).cssZoom != null)
+            style.addRedefinitionWarning(ac, this);
+        ((Css3Style) style).cssZoom = this;
+    }
+
+    /**
+     * Compares two properties for equality.
+     *
+     * @param property The other property.
+     */
+    public boolean equals(CssProperty property) {
+        return (property instanceof CssZoom &&
+                value.equals(((CssZoom) property).value));
+    }
+
+
+    /**
+     * Get this property in the style.
+     *
+     * @param style   The style where the property is
+     * @param resolve if true, resolve the style to find this property
+     */
+    public CssProperty getPropertyInStyle(CssStyle style, boolean resolve) {
+        if (resolve) {
+            return ((Css3Style) style).getZoom();
+        } else {
+            return ((Css3Style) style).cssZoom;
+        }
+    }
+}
+

--- a/org/w3c/css/properties/css3/Css3Style.java
+++ b/org/w3c/css/properties/css3/Css3Style.java
@@ -747,6 +747,16 @@ public class Css3Style extends ATSCStyle {
     public CssTextSpacing cssTextSpacing;
     public CssTranslate cssTranslate;
     public CssRotate cssRotate;
+    public org.w3c.css.properties.css.CssZoom cssZoom;
+
+    public org.w3c.css.properties.css.CssZoom getZoom() {
+        if (cssZoom == null) {
+            cssZoom =
+                    (org.w3c.css.properties.css.CssZoom) style.CascadingOrder(new CssZoom(),
+                            style, selector);
+        }
+        return cssZoom;
+    }
 
     public CssRotate getRotate() {
         if (cssRotate == null) {
@@ -765,7 +775,7 @@ public class Css3Style extends ATSCStyle {
         }
         return cssTranslate;
     }
-    
+
     public CssScale getScale() {
         if (cssScale == null) {
             cssScale =
@@ -774,7 +784,7 @@ public class Css3Style extends ATSCStyle {
         }
         return cssScale;
     }
-    
+
     public CssTextSpacing getTextSpacing() {
         if (cssTextSpacing == null) {
             cssTextSpacing =
@@ -792,7 +802,7 @@ public class Css3Style extends ATSCStyle {
         }
         return cssTextSpacingTrim;
     }
-    
+
     public CssTextAutospace getTextAutospace() {
         if (cssTextAutospace == null) {
             cssTextAutospace =
@@ -801,7 +811,7 @@ public class Css3Style extends ATSCStyle {
         }
         return cssTextAutospace;
     }
-    
+
     public CssLinePadding getLinePadding() {
         if (cssLinePadding == null) {
             cssLinePadding =
@@ -810,7 +820,7 @@ public class Css3Style extends ATSCStyle {
         }
         return cssLinePadding;
     }
-    
+
     public CssTextGroupAlign getTextGroupAlign() {
         if (cssTextGroupAlign == null) {
             cssTextGroupAlign =

--- a/org/w3c/css/properties/css3/CssZoom.java
+++ b/org/w3c/css/properties/css3/CssZoom.java
@@ -1,0 +1,74 @@
+//
+// Author: Yves Lafon <ylafon@w3.org>
+//
+// (c) COPYRIGHT W3C, 2026.
+// Please first read the full copyright statement in file COPYRIGHT.html
+package org.w3c.css.properties.css3;
+
+import org.w3c.css.util.ApplContext;
+import org.w3c.css.util.InvalidParamException;
+import org.w3c.css.values.CssExpression;
+import org.w3c.css.values.CssIdent;
+import org.w3c.css.values.CssTypes;
+import org.w3c.css.values.CssValue;
+
+/**
+ * @spec https://drafts.csswg.org/css-viewport/#zoom-property dated 2025-12-15
+ */
+public class CssZoom extends org.w3c.css.properties.css.CssZoom {
+
+    /**
+     * Create a new CssZoom
+     */
+    public CssZoom() {
+        value = initial;
+    }
+
+    /**
+     * Creates a new CssZoom
+     *
+     * @param expression The expression for this property
+     * @throws InvalidParamException Expressions are incorrect
+     */
+    public CssZoom(ApplContext ac, CssExpression expression, boolean check)
+            throws InvalidParamException {
+        setByUser();
+        if (check && expression.getCount() > 1) {
+            throw new InvalidParamException("unrecognize", ac);
+        }
+        setByUser();
+
+        CssValue val;
+        char op;
+
+        val = expression.getValue();
+        op = expression.getOperator();
+
+        switch (val.getType()) {
+            case CssTypes.CSS_NUMBER:
+            case CssTypes.CSS_PERCENTAGE:
+                val.getCheckableValue().checkPositiveness(ac, this);
+                value = val;
+                break;
+            case CssTypes.CSS_IDENT:
+                // TODO handle 'normal' and 'reset' per https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/zoom#values
+                // deprecated? warning? error with specific message?
+                if (CssIdent.isCssWide(val.getIdent())) {
+                    value = val;
+                }
+                break;
+            default:
+                throw new InvalidParamException("value", expression.getValue(),
+                        getPropertyName(), ac);
+        }
+        expression.next();
+    }
+
+    public CssZoom(ApplContext ac, CssExpression expression)
+            throws InvalidParamException {
+        this(ac, expression, false);
+    }
+
+
+}
+


### PR DESCRIPTION
editor's copy dated 2025-12-15 of https://drafts.csswg.org/css-viewport/

Not ideal for a property which is in Baseline 2024, but well...

removed 'zoom' from the non-std properties added in 4be52de882b04c79a889a9f730e0e9f08ada6d90