### PR TITLE
FIX: remove secretly overwriting fields

### DIFF
--- a/org/w3c/css/atrules/css/media/MediaRangeFeature.java
+++ b/org/w3c/css/atrules/css/media/MediaRangeFeature.java
@@ -6,7 +6,6 @@ import org.w3c.css.values.CssComparator;
 import org.w3c.css.values.CssValue;
 
 public abstract class MediaRangeFeature extends MediaFeature {
-    public CssValue value;
     public CssValue otherValue;
     public String comparator;
     public String otherComparator;

--- a/org/w3c/css/properties/css/colorprofile/CssName.java
+++ b/org/w3c/css/properties/css/colorprofile/CssName.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssName extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssName
      */

--- a/org/w3c/css/properties/css/colorprofile/CssRenderingIntent.java
+++ b/org/w3c/css/properties/css/colorprofile/CssRenderingIntent.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssRenderingIntent extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssRenderingIntent
      */

--- a/org/w3c/css/properties/css/colorprofile/CssSrc.java
+++ b/org/w3c/css/properties/css/colorprofile/CssSrc.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSrc extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSrc
      */

--- a/org/w3c/css/properties/css/counterstyle/CssAdditiveSymbols.java
+++ b/org/w3c/css/properties/css/counterstyle/CssAdditiveSymbols.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssAdditiveSymbols extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssAdditiveSymbols
      */

--- a/org/w3c/css/properties/css/counterstyle/CssFallback.java
+++ b/org/w3c/css/properties/css/counterstyle/CssFallback.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssFallback extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssFallback
      */

--- a/org/w3c/css/properties/css/counterstyle/CssNegative.java
+++ b/org/w3c/css/properties/css/counterstyle/CssNegative.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssNegative extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssNegative
      */

--- a/org/w3c/css/properties/css/counterstyle/CssPad.java
+++ b/org/w3c/css/properties/css/counterstyle/CssPad.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssPad extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssPad
      */

--- a/org/w3c/css/properties/css/counterstyle/CssPrefix.java
+++ b/org/w3c/css/properties/css/counterstyle/CssPrefix.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssPrefix extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssPrefix
      */

--- a/org/w3c/css/properties/css/counterstyle/CssRange.java
+++ b/org/w3c/css/properties/css/counterstyle/CssRange.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssRange extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssRange
      */

--- a/org/w3c/css/properties/css/counterstyle/CssSpeakAs.java
+++ b/org/w3c/css/properties/css/counterstyle/CssSpeakAs.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSpeakAs extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSpeakAs
      */

--- a/org/w3c/css/properties/css/counterstyle/CssSuffix.java
+++ b/org/w3c/css/properties/css/counterstyle/CssSuffix.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSuffix extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSuffix
      */

--- a/org/w3c/css/properties/css/counterstyle/CssSymbols.java
+++ b/org/w3c/css/properties/css/counterstyle/CssSymbols.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSymbols extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSymbols
      */

--- a/org/w3c/css/properties/css/counterstyle/CssSystem.java
+++ b/org/w3c/css/properties/css/counterstyle/CssSystem.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSystem extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSystem
      */

--- a/org/w3c/css/properties/css/fontface/CssAscentOverride.java
+++ b/org/w3c/css/properties/css/fontface/CssAscentOverride.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssAscentOverride extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssAscentOverride
      */

--- a/org/w3c/css/properties/css/fontface/CssDescentOverride.java
+++ b/org/w3c/css/properties/css/fontface/CssDescentOverride.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssDescentOverride extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssDescentOverride
      */

--- a/org/w3c/css/properties/css/fontface/CssFontDisplay.java
+++ b/org/w3c/css/properties/css/fontface/CssFontDisplay.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssFontDisplay extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssFontDisplay
      */

--- a/org/w3c/css/properties/css/fontface/CssFontFamily.java
+++ b/org/w3c/css/properties/css/fontface/CssFontFamily.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssFontFamily extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssFontFamily
      */

--- a/org/w3c/css/properties/css/fontface/CssFontFeatureSettings.java
+++ b/org/w3c/css/properties/css/fontface/CssFontFeatureSettings.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssFontFeatureSettings extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssFontFeatureSettings
      */

--- a/org/w3c/css/properties/css/fontface/CssFontLanguageOverride.java
+++ b/org/w3c/css/properties/css/fontface/CssFontLanguageOverride.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssFontLanguageOverride extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssFontLanguageOverride
      */

--- a/org/w3c/css/properties/css/fontface/CssFontNamedInstance.java
+++ b/org/w3c/css/properties/css/fontface/CssFontNamedInstance.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssFontNamedInstance extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssFontNamedInstance
      */

--- a/org/w3c/css/properties/css/fontface/CssFontVariationSettings.java
+++ b/org/w3c/css/properties/css/fontface/CssFontVariationSettings.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssFontVariationSettings extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssFontVariationSettings
      */

--- a/org/w3c/css/properties/css/fontface/CssLineGapOverride.java
+++ b/org/w3c/css/properties/css/fontface/CssLineGapOverride.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssLineGapOverride extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssLineGapOverride
      */

--- a/org/w3c/css/properties/css/fontface/CssSizeAdjust.java
+++ b/org/w3c/css/properties/css/fontface/CssSizeAdjust.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSizeAdjust extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSizeAdjust
      */

--- a/org/w3c/css/properties/css/fontface/CssSrc.java
+++ b/org/w3c/css/properties/css/fontface/CssSrc.java
@@ -11,14 +11,11 @@ import org.w3c.css.properties.css2.Css2Style;
 import org.w3c.css.util.ApplContext;
 import org.w3c.css.util.InvalidParamException;
 import org.w3c.css.values.CssExpression;
-import org.w3c.css.values.CssValue;
 
 /**
  * @since CSS2
  */
 public class CssSrc extends CssProperty {
-
-    public CssValue value;
 
     /**
      * Create a new CssSrc

--- a/org/w3c/css/properties/css/fontface/CssSubscriptPositionOverride.java
+++ b/org/w3c/css/properties/css/fontface/CssSubscriptPositionOverride.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSubscriptPositionOverride extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSubscriptPositionOverride
      */

--- a/org/w3c/css/properties/css/fontface/CssSubscriptSizeOverride.java
+++ b/org/w3c/css/properties/css/fontface/CssSubscriptSizeOverride.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSubscriptSizeOverride extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSubscriptSizeOverride
      */

--- a/org/w3c/css/properties/css/fontface/CssSuperscriptPositionOverride.java
+++ b/org/w3c/css/properties/css/fontface/CssSuperscriptPositionOverride.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSuperscriptPositionOverride extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSuperscriptPositionOverride
      */

--- a/org/w3c/css/properties/css/fontface/CssSuperscriptSizeOverride.java
+++ b/org/w3c/css/properties/css/fontface/CssSuperscriptSizeOverride.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssSuperscriptSizeOverride extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssSuperscriptSizeOverride
      */

--- a/org/w3c/css/properties/css/fontface/CssUnicodeRange.java
+++ b/org/w3c/css/properties/css/fontface/CssUnicodeRange.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssUnicodeRange extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssUnicodeRange
      */

--- a/org/w3c/css/properties/css/fontfeaturevalues/CatchallProperty.java
+++ b/org/w3c/css/properties/css/fontfeaturevalues/CatchallProperty.java
@@ -18,7 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CatchallProperty extends CssProperty {
 
-    public CssValue value;
     public String name;
 
     /**

--- a/org/w3c/css/properties/css/fontfeaturevalues/CssFontDisplay.java
+++ b/org/w3c/css/properties/css/fontfeaturevalues/CssFontDisplay.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssFontDisplay extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssFontDisplay
      */

--- a/org/w3c/css/properties/css/fontpalettevalues/CssBasePalette.java
+++ b/org/w3c/css/properties/css/fontpalettevalues/CssBasePalette.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssBasePalette extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssBasePalette
      */

--- a/org/w3c/css/properties/css/fontpalettevalues/CssFontFamily.java
+++ b/org/w3c/css/properties/css/fontpalettevalues/CssFontFamily.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssFontFamily extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssFontFamily
      */

--- a/org/w3c/css/properties/css/fontpalettevalues/CssOverrideColors.java
+++ b/org/w3c/css/properties/css/fontpalettevalues/CssOverrideColors.java
@@ -19,8 +19,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssOverrideColors extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssOverrideColors
      */

--- a/org/w3c/css/properties/css/page/CssMarks.java
+++ b/org/w3c/css/properties/css/page/CssMarks.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssMarks extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssMarks
      */

--- a/org/w3c/css/properties/css/viewport/CssHeight.java
+++ b/org/w3c/css/properties/css/viewport/CssHeight.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssHeight extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssHeight
      */

--- a/org/w3c/css/properties/css/viewport/CssMaxHeight.java
+++ b/org/w3c/css/properties/css/viewport/CssMaxHeight.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssMaxHeight extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssMaxHeight
      */

--- a/org/w3c/css/properties/css/viewport/CssMaxWidth.java
+++ b/org/w3c/css/properties/css/viewport/CssMaxWidth.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssMaxWidth extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssMaxWidth
      */

--- a/org/w3c/css/properties/css/viewport/CssMaxZoom.java
+++ b/org/w3c/css/properties/css/viewport/CssMaxZoom.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssMaxZoom extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssMaxZoom
      */

--- a/org/w3c/css/properties/css/viewport/CssMinHeight.java
+++ b/org/w3c/css/properties/css/viewport/CssMinHeight.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssMinHeight extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssMinHeight
      */

--- a/org/w3c/css/properties/css/viewport/CssMinWidth.java
+++ b/org/w3c/css/properties/css/viewport/CssMinWidth.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssMinWidth extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssMinWidth
      */

--- a/org/w3c/css/properties/css/viewport/CssMinZoom.java
+++ b/org/w3c/css/properties/css/viewport/CssMinZoom.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssMinZoom extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssMinZoom
      */

--- a/org/w3c/css/properties/css/viewport/CssOrientation.java
+++ b/org/w3c/css/properties/css/viewport/CssOrientation.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssOrientation extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssOrientation
      */

--- a/org/w3c/css/properties/css/viewport/CssUserZoom.java
+++ b/org/w3c/css/properties/css/viewport/CssUserZoom.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssUserZoom extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssUserZoom
      */

--- a/org/w3c/css/properties/css/viewport/CssWidth.java
+++ b/org/w3c/css/properties/css/viewport/CssWidth.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssWidth extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssWidth
      */

--- a/org/w3c/css/properties/css/viewport/CssZoom.java
+++ b/org/w3c/css/properties/css/viewport/CssZoom.java
@@ -18,8 +18,6 @@ import org.w3c.css.values.CssValue;
  */
 public class CssZoom extends CssProperty {
 
-    public CssValue value;
-
     /**
      * Create a new CssZoom
      */


### PR DESCRIPTION
Hello @ylafon,

your fix of https://github.com/w3c/css-validator/issues/508#issuecomment-4791911280 exposed another issue in the code. However it seems to be an easy fix. 

I've prepared a testcase for this aswell.

## Description

So it seems that some CSS Property extending classes have a field `public CssValue value;` property set although the parent class already has these. So the value of the Parent gets set because of casting, however the output template doesn't cast and therefore uses the implementations field which is null.

## Input 


```css
/* display */
.a { display: flex; }
.b { display: grid; }
.c { display: none; }

/* marks */
@page {
    marks: crop cross;
}

/* counter-style: system + suffix */
@counter-style custom {
    system: fixed;
    symbols: A B C;
    suffix: ". ";
}

/* media feature */
@media (min-width: 320px) { .d { display: block; } }

/* media feature range */
@media (400px <= width <= 1000px) { .e { display: inline; } }

/* max-height */
@media (max-height: 800px) { .f { display: flex; } }

/* min-width */
@media (min-width: 1024px) { .g { display: grid; } }

/* max-zoom */
@media (max-zoom: 3) { .h { display: block; } }

/* orientation */
@media (orientation: portrait) { .i { display: flex; } }
@media (orientation: landscape) { .j { display: inline-flex; } }

/* font-face */
@font-face {font-family: 'Roboto'; font-style: normal; font-weight: 400; font-stretch: normal; src: url(r2.ttf) format('truetype'); }
@font-face {font-family: 'Roboto'; font-style: normal; font-weight: 700; font-stretch: normal; src: url(r1.ttf) format('truetype'); }
```

## Result on `main`

Output on main commit https://github.com/w3c/css-validator/commit/1ab7ea8da2f463010f467562d3dc48f9ce421fde

```txt
Warnings (6)

URI : file:_11_font_face_with_stretch.css

Line : 31 -  “max-zoom” is a vendor extension
Line : 39 -  Redefinition of “font-family”
Line : 39 -  Redefinition of “font-style”
Line : 39 -  Redefinition of “font-weight”
Line : 39 -  Redefinition of “font-width”
Line : 39 -  Redefinition of “src”



Valid CSS information
```

```css
    .a
    {
        display : flex ;
    }
    .b
    {
        display : grid ;
    }
    .c
    {
        display : none ;
    }

@page
{
        marks : $property ;

}

@counter-style custom
{
        system : $property ;
        symbols : $property ;
        suffix : $property ;

}

@media  (min-width: 320px)
{
    .d
    {
        display : block ;
    }

}

@media  (400px <= width <= 1000px)
{
    .e
    {
        display : inline ;
    }

}

@media  (max-height: 800px)
{
    .f
    {
        display : flex ;
    }

}

@media  (min-width: 1024px)
{
    .g
    {
        display : grid ;
    }

}

@media 
{
    .h
    {
        display : block ;
    }

}

@media  (orientation: portrait)
{
    .i
    {
        display : flex ;
    }

}

@media  (orientation: landscape)
{
    .j
    {
        display : inline-flex ;
    }

}

@font-face
{
        font-family : $property ;
        font-style : normal ;
        font-weight : 400 ;
        font-width : normal ;
        src : $property ;

}

@font-face
{
        font-family : $property ;
        font-style : normal ;
        font-weight : 700 ;
        font-width : normal ;
        src : $property ;

}

```

## Result on pullrequest

Output with this fix

```txt
Warnings (6)

URI : file:_11_font_face_with_stretch.css

Line : 31 -  “max-zoom” is a vendor extension
Line : 39 -  Redefinition of “font-family”
Line : 39 -  Redefinition of “font-style”
Line : 39 -  Redefinition of “font-weight”
Line : 39 -  Redefinition of “font-width”
Line : 39 -  Redefinition of “src”



Valid CSS information
```
```css
    .a
    {
        display : flex ;
    }
    .b
    {
        display : grid ;
    }
    .c
    {
        display : none ;
    }

@page
{
        marks : crop cross ;

}

@counter-style custom
{
        system : fixed ;
        symbols : A B C ;
        suffix : ". " ;

}

@media  (min-width: 320px)
{
    .d
    {
        display : block ;
    }

}

@media  (400px <= width <= 1000px)
{
    .e
    {
        display : inline ;
    }

}

@media  (max-height: 800px)
{
    .f
    {
        display : flex ;
    }

}

@media  (min-width: 1024px)
{
    .g
    {
        display : grid ;
    }

}

@media 
{
    .h
    {
        display : block ;
    }

}

@media  (orientation: portrait)
{
    .i
    {
        display : flex ;
    }

}

@media  (orientation: landscape)
{
    .j
    {
        display : inline-flex ;
    }

}

@font-face
{
        font-family : 'Roboto' ;
        font-style : normal ;
        font-weight : 400 ;
        font-width : normal ;
        src : url(r2.ttf) format('truetype') ;

}

@font-face
{
        font-family : 'Roboto' ;
        font-style : normal ;
        font-weight : 700 ;
        font-width : normal ;
        src : url(r1.ttf) format('truetype') ;

}
```

